### PR TITLE
fix(memory): resolve AttributeError in graph and updater

### DIFF
--- a/services/memory_graph_manager.py
+++ b/services/memory_graph_manager.py
@@ -487,7 +487,7 @@ class MemoryGraphManager:
                 # 添加记忆节点
                 await memory_graph.add_memory_node(
                     concept=concept,
-                    memory=message.content,
+                    memory=message.message,
                     llm_adapter=self.llm_adapter
                 )
                 
@@ -516,7 +516,7 @@ class MemoryGraphManager:
         try:
             from ..statics.prompts import ENTITY_EXTRACTION_PROMPT
             
-            prompt = ENTITY_EXTRACTION_PROMPT.format(text=message.content)
+            prompt = ENTITY_EXTRACTION_PROMPT.format(text=message.message)
             
             response = await self.llm_adapter.generate_response(
                 prompt,


### PR DESCRIPTION
## Summary
- Fix `message.content` → `message.message` in `MemoryGraphManager` (MessageData uses `message` attribute)
- Replace non-existent `add_memory_node()` call with correct `add_memory_from_message()` in `PersonaUpdater`
- Add `exc_info=True` to persona error logs for full traceback visibility

## Test plan
- [ ] Verify memory graph learning no longer throws AttributeError
- [ ] Verify persona update style flow completes without crash
- [ ] Check logs show full traceback on ProviderOpenAIOfficial errors