### PR TITLE
修复 goal_manager 初始化链路并移除 guardrails 运行时依赖

### DIFF
--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -84,6 +84,16 @@ class PluginLifecycle:
             # ------ 社交上下文注入器（必须在 intelligent_responder 之前）------
             p.social_context_injector = component_factory.create_social_context_injector()
 
+            # create_social_context_injector() currently reads goal_manager from the
+            # factory cache, which may not contain the instance we just created above.
+            # Wire it explicitly so social context injection can use conversation goals.
+            if (
+                getattr(p, "social_context_injector", None)
+                and getattr(p, "conversation_goal_manager", None)
+            ):
+                p.social_context_injector.goal_manager = p.conversation_goal_manager
+                logger.info("已将conversation_goal_manager注入social_context_injector")
+
             # ------ 黑话服务 ------
             from ..services.jargon import (
                 JargonQueryService,

--- a/services/quality/conversation_goal_manager.py
+++ b/services/quality/conversation_goal_manager.py
@@ -282,11 +282,27 @@ class ConversationGoalManager:
         from ..response import PromptProtectionService
         self.prompt_protection = PromptProtectionService(wrapper_template_index=0)
 
-        # 初始化Guardrails管理器用于JSON验证
-        from ...utils.guardrails_manager import get_guardrails_manager, GoalAnalysisResult, ConversationIntentAnalysis
-        self.guardrails = get_guardrails_manager()
-        self.GoalAnalysisResult = GoalAnalysisResult
-        self.ConversationIntentAnalysis = ConversationIntentAnalysis
+        # 初始化Guardrails管理器用于JSON验证。
+        # 某些 guardrails 版本依赖旧版 openai.error 接口；在当前环境中
+        # 导入失败时降级为基础 JSON 解析，避免整个 goal manager 无法启动。
+        try:
+            from ...utils.guardrails_manager import (
+                get_guardrails_manager,
+                GoalAnalysisResult,
+                ConversationIntentAnalysis,
+            )
+
+            self.guardrails = get_guardrails_manager()
+            self.GoalAnalysisResult = GoalAnalysisResult
+            self.ConversationIntentAnalysis = ConversationIntentAnalysis
+        except Exception as e:
+            logger.warning(
+                f"Guardrails 初始化失败，将降级为基础 JSON 解析: {e}",
+                exc_info=True,
+            )
+            self.guardrails = None
+            self.GoalAnalysisResult = None
+            self.ConversationIntentAnalysis = None
 
     def _generate_session_id(self, group_id: str, user_id: str) -> str:
         """生成会话ID (24小时内保持不变)"""
@@ -505,29 +521,42 @@ class ConversationGoalManager:
                 logger.error(f"消毒响应失败: {sanitize_error}", exc_info=True)
                 sanitized_response = response # 使用原始响应
 
-            # 使用Guardrails Pydantic模型验证和解析JSON
-            try:
-                # 直接解析已有的响应文本
-                parsed_result = self.guardrails.parse_json_direct(
-                    sanitized_response,
-                    model_class=self.GoalAnalysisResult # 使用正确的模型引用
-                )
+            result = None
+            if self.guardrails and self.GoalAnalysisResult:
+                try:
+                    parsed_result = self.guardrails.parse_json_direct(
+                        sanitized_response,
+                        model_class=self.GoalAnalysisResult,
+                    )
 
-                if parsed_result:
-                    # 转换为字典格式
+                    if parsed_result:
+                        result = {
+                            "goal_type": parsed_result.goal_type,
+                            "topic": parsed_result.topic,
+                            "confidence": parsed_result.confidence,
+                            "reasoning": parsed_result.reasoning,
+                        }
+                        logger.debug(f" [对话目标] Pydantic验证成功: goal_type={result['goal_type']}")
+                except Exception as validation_error:
+                    logger.error(f"Pydantic验证失败: {validation_error}", exc_info=True)
+
+            if result is None:
+                try:
+                    import json
+                    import re
+
+                    match = re.search(r"\{.*\}", sanitized_response, re.S)
+                    candidate = match.group(0) if match else sanitized_response
+                    parsed = json.loads(candidate)
                     result = {
-                        "goal_type": parsed_result.goal_type,
-                        "topic": parsed_result.topic,
-                        "confidence": parsed_result.confidence,
-                        "reasoning": parsed_result.reasoning
+                        "goal_type": str(parsed.get("goal_type", "casual_chat")).strip() or "casual_chat",
+                        "topic": str(parsed.get("topic", "闲聊")).strip() or "闲聊",
+                        "confidence": float(parsed.get("confidence", 0.5) or 0.5),
+                        "reasoning": str(parsed.get("reasoning", "")).strip(),
                     }
-                    logger.debug(f" [对话目标] Pydantic验证成功: goal_type={result['goal_type']}")
-                else:
-                    result = None
-
-            except Exception as validation_error:
-                logger.error(f"Pydantic验证失败: {validation_error}", exc_info=True)
-                result = None
+                    logger.debug(f" [对话目标] 基础JSON解析成功: goal_type={result['goal_type']}")
+                except Exception as json_error:
+                    logger.error(f"基础JSON解析失败: {json_error}", exc_info=True)
 
             # 如果验证失败,使用回退值
             if result is None:
@@ -614,15 +643,28 @@ class ConversationGoalManager:
                 logger.error(f"消毒响应失败: {sanitize_error}", exc_info=True)
                 sanitized_response = response # 使用原始响应
 
-            # 使用guardrails验证和清理JSON
-            try:
-                stages = self.guardrails.validate_and_clean_json(
-                    sanitized_response,
-                    expected_type="array"
-                )
-            except Exception as validation_error:
-                logger.error(f"JSON验证失败: {validation_error}", exc_info=True)
-                stages = None
+            stages = None
+            if self.guardrails:
+                try:
+                    stages = self.guardrails.validate_and_clean_json(
+                        sanitized_response,
+                        expected_type="array"
+                    )
+                except Exception as validation_error:
+                    logger.error(f"JSON验证失败: {validation_error}", exc_info=True)
+
+            if stages is None:
+                try:
+                    import json
+                    import re
+
+                    match = re.search(r"\[.*\]", sanitized_response, re.S)
+                    candidate = match.group(0) if match else sanitized_response
+                    parsed = json.loads(candidate)
+                    if isinstance(parsed, list):
+                        stages = [str(stage).strip() for stage in parsed if str(stage).strip()]
+                except Exception as json_error:
+                    logger.error(f"阶段规划基础JSON解析失败: {json_error}", exc_info=True)
 
             # 如果验证成功且是有效列表,返回
             if isinstance(stages, list) and len(stages) >= 2:
@@ -817,35 +859,53 @@ Bot: {bot_response}
                 logger.error(f"消毒响应失败: {sanitize_error}", exc_info=True)
                 sanitized_response = response # 使用原始响应
 
-            # 使用Guardrails Pydantic模型验证和解析JSON
-            try:
-                # 直接解析已有的响应文本
-                parsed_result = self.guardrails.parse_json_direct(
-                    sanitized_response,
-                    model_class=self.ConversationIntentAnalysis # 使用正确的模型引用
-                )
+            analysis = None
+            if self.guardrails and self.ConversationIntentAnalysis:
+                try:
+                    parsed_result = self.guardrails.parse_json_direct(
+                        sanitized_response,
+                        model_class=self.ConversationIntentAnalysis,
+                    )
 
-                if parsed_result:
-                    # 转换为字典格式
+                    if parsed_result:
+                        analysis = {
+                            "goal_switch_needed": parsed_result.goal_switch_needed,
+                            "new_goal_type": parsed_result.new_goal_type,
+                            "new_topic": parsed_result.new_topic,
+                            "topic_completed": parsed_result.topic_completed,
+                            "stage_completed": parsed_result.stage_completed,
+                            "stage_adjustment_needed": parsed_result.stage_adjustment_needed,
+                            "suggested_stage": parsed_result.suggested_stage,
+                            "completion_signals": parsed_result.completion_signals,
+                            "user_engagement": parsed_result.user_engagement,
+                            "reasoning": parsed_result.reasoning,
+                        }
+                        logger.debug(f" [对话目标] 意图分析Pydantic验证成功")
+                except Exception as validation_error:
+                    logger.error(f"意图分析Pydantic验证失败: {validation_error}", exc_info=True)
+
+            if analysis is None:
+                try:
+                    import json
+                    import re
+
+                    match = re.search(r"\{.*\}", sanitized_response, re.S)
+                    candidate = match.group(0) if match else sanitized_response
+                    parsed = json.loads(candidate)
                     analysis = {
-                        "goal_switch_needed": parsed_result.goal_switch_needed,
-                        "new_goal_type": parsed_result.new_goal_type,
-                        "new_topic": parsed_result.new_topic,
-                        "topic_completed": parsed_result.topic_completed,
-                        "stage_completed": parsed_result.stage_completed,
-                        "stage_adjustment_needed": parsed_result.stage_adjustment_needed,
-                        "suggested_stage": parsed_result.suggested_stage,
-                        "completion_signals": parsed_result.completion_signals,
-                        "user_engagement": parsed_result.user_engagement,
-                        "reasoning": parsed_result.reasoning
+                        "goal_switch_needed": bool(parsed.get("goal_switch_needed", False)),
+                        "new_goal_type": str(parsed.get("new_goal_type", "")).strip(),
+                        "new_topic": str(parsed.get("new_topic", "")).strip(),
+                        "topic_completed": bool(parsed.get("topic_completed", False)),
+                        "stage_completed": bool(parsed.get("stage_completed", False)),
+                        "stage_adjustment_needed": bool(parsed.get("stage_adjustment_needed", False)),
+                        "suggested_stage": str(parsed.get("suggested_stage", "")).strip(),
+                        "completion_signals": parsed.get("completion_signals", []) if isinstance(parsed.get("completion_signals", []), list) else [],
+                        "user_engagement": float(parsed.get("user_engagement", 0.5) or 0.5),
+                        "reasoning": str(parsed.get("reasoning", "")).strip(),
                     }
-                    logger.debug(f" [对话目标] 意图分析Pydantic验证成功")
-                else:
-                    analysis = None
-
-            except Exception as validation_error:
-                logger.error(f"意图分析Pydantic验证失败: {validation_error}", exc_info=True)
-                analysis = None
+                except Exception as json_error:
+                    logger.error(f"意图分析基础JSON解析失败: {json_error}", exc_info=True)
 
             # 如果验证失败,使用回退值
             if analysis is None:

--- a/services/quality/conversation_goal_manager.py
+++ b/services/quality/conversation_goal_manager.py
@@ -3,8 +3,11 @@
 集成到现有的心理状态管理体系
 """
 from typing import Optional, Dict, List
+from typing import Any
 from datetime import datetime
 import hashlib
+import json
+import re
 from astrbot.api import logger
 
 from ...repositories.conversation_goal_repository import ConversationGoalRepository
@@ -295,7 +298,7 @@ class ConversationGoalManager:
             self.guardrails = get_guardrails_manager()
             self.GoalAnalysisResult = GoalAnalysisResult
             self.ConversationIntentAnalysis = ConversationIntentAnalysis
-        except Exception as e:
+        except ImportError as e:
             logger.warning(
                 f"Guardrails 初始化失败，将降级为基础 JSON 解析: {e}",
                 exc_info=True,
@@ -309,6 +312,86 @@ class ConversationGoalManager:
         date_key = datetime.now().strftime("%Y%m%d")
         base = f"{group_id}_{user_id}_{date_key}"
         return f"sess_{hashlib.md5(base.encode()).hexdigest()[:12]}"
+
+    def _extract_json_candidate(self, text: str, expected_type: str = "object") -> Optional[str]:
+        """提取最可能的 JSON 片段，避免使用贪婪正则。"""
+        if not text:
+            return None
+
+        # 优先使用现有的通用清洗逻辑，保持行为一致。
+        if self.guardrails:
+            parsed = self.guardrails.validate_and_clean_json(text, expected_type=expected_type)
+            if parsed is not None:
+                try:
+                    return json.dumps(parsed, ensure_ascii=False)
+                except Exception:
+                    pass
+
+        decoder = json.JSONDecoder()
+        open_char = "{" if expected_type == "object" else "["
+
+        for index, char in enumerate(text):
+            if char != open_char:
+                continue
+            try:
+                parsed, end = decoder.raw_decode(text[index:])
+                if expected_type == "object" and isinstance(parsed, dict):
+                    return text[index:index + end]
+                if expected_type == "array" and isinstance(parsed, list):
+                    return text[index:index + end]
+            except Exception:
+                continue
+
+        return None
+
+    def _to_bool(self, value: Any, default: bool = False) -> bool:
+        """安全地将 LLM 输出归一化为布尔值。"""
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "y", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "n", "off", "", "null", "none"}:
+                return False
+        return default
+
+    def _to_float(self, value: Any, default: float = 0.5) -> float:
+        """安全地将 LLM 输出归一化为浮点数。"""
+        if value is None:
+            return default
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            try:
+                return float(value.strip())
+            except Exception:
+                return default
+        return default
+
+    def _parse_object_fallback(self, text: str) -> Optional[Dict[str, Any]]:
+        candidate = self._extract_json_candidate(text, expected_type="object")
+        if not candidate:
+            return None
+        try:
+            parsed = json.loads(candidate)
+            return parsed if isinstance(parsed, dict) else None
+        except Exception:
+            return None
+
+    def _parse_array_fallback(self, text: str) -> Optional[List[Any]]:
+        candidate = self._extract_json_candidate(text, expected_type="array")
+        if not candidate:
+            return None
+        try:
+            parsed = json.loads(candidate)
+            return parsed if isinstance(parsed, list) else None
+        except Exception:
+            return None
 
     async def get_or_create_conversation_goal(
         self,
@@ -542,19 +625,15 @@ class ConversationGoalManager:
 
             if result is None:
                 try:
-                    import json
-                    import re
-
-                    match = re.search(r"\{.*\}", sanitized_response, re.S)
-                    candidate = match.group(0) if match else sanitized_response
-                    parsed = json.loads(candidate)
-                    result = {
-                        "goal_type": str(parsed.get("goal_type", "casual_chat")).strip() or "casual_chat",
-                        "topic": str(parsed.get("topic", "闲聊")).strip() or "闲聊",
-                        "confidence": float(parsed.get("confidence", 0.5) or 0.5),
-                        "reasoning": str(parsed.get("reasoning", "")).strip(),
-                    }
-                    logger.debug(f" [对话目标] 基础JSON解析成功: goal_type={result['goal_type']}")
+                    parsed = self._parse_object_fallback(sanitized_response)
+                    if parsed is not None:
+                        result = {
+                            "goal_type": str(parsed.get("goal_type", "casual_chat")).strip() or "casual_chat",
+                            "topic": str(parsed.get("topic", "闲聊")).strip() or "闲聊",
+                            "confidence": self._to_float(parsed.get("confidence", 0.5), 0.5),
+                            "reasoning": str(parsed.get("reasoning", "")).strip(),
+                        }
+                        logger.debug(f" [对话目标] 基础JSON解析成功: goal_type={result['goal_type']}")
                 except Exception as json_error:
                     logger.error(f"基础JSON解析失败: {json_error}", exc_info=True)
 
@@ -655,12 +734,7 @@ class ConversationGoalManager:
 
             if stages is None:
                 try:
-                    import json
-                    import re
-
-                    match = re.search(r"\[.*\]", sanitized_response, re.S)
-                    candidate = match.group(0) if match else sanitized_response
-                    parsed = json.loads(candidate)
+                    parsed = self._parse_array_fallback(sanitized_response)
                     if isinstance(parsed, list):
                         stages = [str(stage).strip() for stage in parsed if str(stage).strip()]
                 except Exception as json_error:
@@ -886,24 +960,28 @@ Bot: {bot_response}
 
             if analysis is None:
                 try:
-                    import json
-                    import re
+                    parsed = self._parse_object_fallback(sanitized_response)
+                    if parsed is not None:
+                        completion_signals = parsed.get("completion_signals", 0)
+                        if isinstance(completion_signals, list):
+                            completion_signals = len(completion_signals)
+                        try:
+                            completion_signals = int(completion_signals)
+                        except Exception:
+                            completion_signals = 0
 
-                    match = re.search(r"\{.*\}", sanitized_response, re.S)
-                    candidate = match.group(0) if match else sanitized_response
-                    parsed = json.loads(candidate)
-                    analysis = {
-                        "goal_switch_needed": bool(parsed.get("goal_switch_needed", False)),
-                        "new_goal_type": str(parsed.get("new_goal_type", "")).strip(),
-                        "new_topic": str(parsed.get("new_topic", "")).strip(),
-                        "topic_completed": bool(parsed.get("topic_completed", False)),
-                        "stage_completed": bool(parsed.get("stage_completed", False)),
-                        "stage_adjustment_needed": bool(parsed.get("stage_adjustment_needed", False)),
-                        "suggested_stage": str(parsed.get("suggested_stage", "")).strip(),
-                        "completion_signals": parsed.get("completion_signals", []) if isinstance(parsed.get("completion_signals", []), list) else [],
-                        "user_engagement": float(parsed.get("user_engagement", 0.5) or 0.5),
-                        "reasoning": str(parsed.get("reasoning", "")).strip(),
-                    }
+                        analysis = {
+                            "goal_switch_needed": self._to_bool(parsed.get("goal_switch_needed", False), False),
+                            "new_goal_type": str(parsed.get("new_goal_type", "")).strip(),
+                            "new_topic": str(parsed.get("new_topic", "")).strip(),
+                            "topic_completed": self._to_bool(parsed.get("topic_completed", False), False),
+                            "stage_completed": self._to_bool(parsed.get("stage_completed", False), False),
+                            "stage_adjustment_needed": self._to_bool(parsed.get("stage_adjustment_needed", False), False),
+                            "suggested_stage": str(parsed.get("suggested_stage", "")).strip(),
+                            "completion_signals": max(0, completion_signals),
+                            "user_engagement": self._to_float(parsed.get("user_engagement", 0.5), 0.5),
+                            "reasoning": str(parsed.get("reasoning", "")).strip(),
+                        }
                 except Exception as json_error:
                     logger.error(f"意图分析基础JSON解析失败: {json_error}", exc_info=True)
 

--- a/utils/guardrails_manager.py
+++ b/utils/guardrails_manager.py
@@ -3,8 +3,9 @@ Guardrails AI 管理器
 用于管理 LLM 的结构化输出,确保数据格式正确且符合约束
 """
 from typing import Dict, List, Optional, Any, Type
+import json
+import re
 from pydantic import BaseModel, Field, field_validator
-from guardrails import Guard
 from astrbot.api import logger
 
 
@@ -200,44 +201,26 @@ class GuardrailsManager:
         """
         self.max_reasks = max_reasks
 
-        # 创建不同用途的 Guard 实例
-        self._state_guard: Optional[Guard] = None
-        self._relation_guard: Optional[Guard] = None
-        self._goal_analysis_guard: Optional[Guard] = None
-        self._intent_analysis_guard: Optional[Guard] = None
-
         logger.info(f"[Guardrails] 管理器初始化完成 (max_reasks={max_reasks})")
 
-    def get_state_transition_guard(self) -> Guard:
-        """
-        获取心理状态转换的 Guard 实例
+    def _parse_model_from_text(
+        self,
+        response_text: str,
+        model_class: Type[BaseModel],
+        expected_type: str = "object",
+    ) -> Optional[BaseModel]:
+        """从文本中提取 JSON 并用 Pydantic 校验。"""
+        parsed = self.validate_and_clean_json(response_text, expected_type=expected_type)
+        if parsed is None:
+            return None
 
-        Returns:
-            Guard 实例
-        """
-        if self._state_guard is None:
-            self._state_guard = Guard.for_pydantic(
-                output_class=PsychologicalStateTransition,
-                # 不使用额外的验证器,保持高性能
-            )
-            logger.debug("[Guardrails] 心理状态转换 Guard 已创建")
-
-        return self._state_guard
-
-    def get_relation_analysis_guard(self) -> Guard:
-        """
-        获取社交关系分析的 Guard 实例
-
-        Returns:
-            Guard 实例
-        """
-        if self._relation_guard is None:
-            self._relation_guard = Guard.for_pydantic(
-                output_class=SocialRelationAnalysis,
-            )
-            logger.debug("[Guardrails] 社交关系分析 Guard 已创建")
-
-        return self._relation_guard
+        try:
+            if isinstance(parsed, model_class):
+                return parsed
+            return model_class.model_validate(parsed)
+        except Exception as e:
+            logger.error(f" [Guardrails] Pydantic 校验失败: {e}", exc_info=True)
+            return None
 
     async def parse_state_transition(
         self,
@@ -259,8 +242,6 @@ class GuardrailsManager:
             PsychologicalStateTransition 对象,失败返回 None
         """
         try:
-            guard = self.get_state_transition_guard()
-
             # 使用 JSON 模式获取结构化输出
             # 为提示词添加 JSON 输出要求
             enhanced_prompt = f"""{prompt}
@@ -276,15 +257,14 @@ class GuardrailsManager:
             # 调用 LLM(通过用户提供的 callable)
             response_text = await llm_callable(enhanced_prompt, model=model, **kwargs)
 
-            # 使用 Guard 验证
-            result = guard.parse(response_text)
-
-            if result.validation_passed:
-                logger.debug(f" [Guardrails] 心理状态解析成功: {result.validated_output.new_state}")
-                return result.validated_output
-            else:
-                logger.warning(f" [Guardrails] 心理状态验证失败: {result.validation_summaries}")
-                return None
+            result = self._parse_model_from_text(
+                response_text,
+                PsychologicalStateTransition,
+                expected_type="object",
+            )
+            if result:
+                logger.debug(f" [Guardrails] 心理状态解析成功: {result.new_state}")
+            return result
 
         except Exception as e:
             logger.error(f" [Guardrails] 心理状态解析失败: {e}", exc_info=True)
@@ -310,8 +290,6 @@ class GuardrailsManager:
             SocialRelationAnalysis 对象,失败返回 None
         """
         try:
-            guard = self.get_relation_analysis_guard()
-
             # 增强提示词
             enhanced_prompt = f"""{prompt}
 
@@ -333,50 +311,19 @@ class GuardrailsManager:
             # 调用 LLM
             response_text = await llm_callable(enhanced_prompt, model=model, **kwargs)
 
-            # 使用 Guard 验证
-            result = guard.parse(response_text)
-
-            if result.validation_passed:
-                relation_count = len(result.validated_output.relations)
+            result = self._parse_model_from_text(
+                response_text,
+                SocialRelationAnalysis,
+                expected_type="object",
+            )
+            if result:
+                relation_count = len(result.relations)
                 logger.debug(f" [Guardrails] 社交关系解析成功: {relation_count}个关系")
-                return result.validated_output
-            else:
-                logger.warning(f" [Guardrails] 社交关系验证失败: {result.validation_summaries}")
-                return None
+            return result
 
         except Exception as e:
             logger.error(f" [Guardrails] 社交关系解析失败: {e}", exc_info=True)
             return None
-
-    def get_goal_analysis_guard(self) -> Guard:
-        """
-        获取对话目标分析的 Guard 实例
-
-        Returns:
-            Guard 实例
-        """
-        if self._goal_analysis_guard is None:
-            self._goal_analysis_guard = Guard.for_pydantic(
-                output_class=GoalAnalysisResult,
-            )
-            logger.debug("[Guardrails] 对话目标分析 Guard 已创建")
-
-        return self._goal_analysis_guard
-
-    def get_intent_analysis_guard(self) -> Guard:
-        """
-        获取对话意图分析的 Guard 实例
-
-        Returns:
-            Guard 实例
-        """
-        if self._intent_analysis_guard is None:
-            self._intent_analysis_guard = Guard.for_pydantic(
-                output_class=ConversationIntentAnalysis,
-            )
-            logger.debug("[Guardrails] 对话意图分析 Guard 已创建")
-
-        return self._intent_analysis_guard
 
     async def parse_goal_analysis(
         self,
@@ -398,8 +345,6 @@ class GuardrailsManager:
             GoalAnalysisResult 对象,失败返回 None
         """
         try:
-            guard = self.get_goal_analysis_guard()
-
             # 增强提示词
             enhanced_prompt = f"""{prompt}
 
@@ -420,25 +365,14 @@ class GuardrailsManager:
             # 调用 LLM
             response_text = await llm_callable(enhanced_prompt, model=model, **kwargs)
 
-            # 使用 Guard 验证
-            result = guard.parse(response_text)
-
-            if result.validation_passed:
-                # 修复：validated_output 可能是 dict，需要转换为 Pydantic 模型
-                validated_data = result.validated_output
-                if isinstance(validated_data, dict):
-                    goal_result = GoalAnalysisResult(**validated_data)
-                    logger.debug(f" [Guardrails] 对话目标解析成功: {goal_result.goal_type}")
-                    return goal_result
-                elif isinstance(validated_data, GoalAnalysisResult):
-                    logger.debug(f" [Guardrails] 对话目标解析成功: {validated_data.goal_type}")
-                    return validated_data
-                else:
-                    logger.warning(f" [Guardrails] 意外的输出类型: {type(validated_data)}")
-                    return None
-            else:
-                logger.warning(f" [Guardrails] 对话目标验证失败: {result.validation_summaries}")
-                return None
+            result = self._parse_model_from_text(
+                response_text,
+                GoalAnalysisResult,
+                expected_type="object",
+            )
+            if result:
+                logger.debug(f" [Guardrails] 对话目标解析成功: {result.goal_type}")
+            return result
 
         except Exception as e:
             logger.error(f" [Guardrails] 对话目标解析失败: {e}", exc_info=True)
@@ -464,8 +398,6 @@ class GuardrailsManager:
             ConversationIntentAnalysis 对象,失败返回 None
         """
         try:
-            guard = self.get_intent_analysis_guard()
-
             # 增强提示词
             enhanced_prompt = f"""{prompt}
 
@@ -493,25 +425,14 @@ class GuardrailsManager:
             # 调用 LLM
             response_text = await llm_callable(enhanced_prompt, model=model, **kwargs)
 
-            # 使用 Guard 验证
-            result = guard.parse(response_text)
-
-            if result.validation_passed:
-                # 修复：validated_output 可能是 dict，需要转换为 Pydantic 模型
-                validated_data = result.validated_output
-                if isinstance(validated_data, dict):
-                    intent_result = ConversationIntentAnalysis(**validated_data)
-                    logger.debug(f" [Guardrails] 对话意图解析成功")
-                    return intent_result
-                elif isinstance(validated_data, ConversationIntentAnalysis):
-                    logger.debug(f" [Guardrails] 对话意图解析成功")
-                    return validated_data
-                else:
-                    logger.warning(f" [Guardrails] 意外的输出类型: {type(validated_data)}")
-                    return None
-            else:
-                logger.warning(f" [Guardrails] 对话意图验证失败: {result.validation_summaries}")
-                return None
+            result = self._parse_model_from_text(
+                response_text,
+                ConversationIntentAnalysis,
+                expected_type="object",
+            )
+            if result:
+                logger.debug(" [Guardrails] 对话意图解析成功")
+            return result
 
         except Exception as e:
             logger.error(f" [Guardrails] 对话意图解析失败: {e}", exc_info=True)
@@ -533,24 +454,11 @@ class GuardrailsManager:
             模型实例,失败返回 None
         """
         try:
-            guard = Guard.for_pydantic(output_class=model_class)
-            result = guard.parse(response_text)
-
-            if result.validation_passed:
-                # 修复：validated_output 可能是 dict，需要转换为 Pydantic 模型
-                validated_data = result.validated_output
-                if isinstance(validated_data, dict):
-                    # 将 dict 转换为 Pydantic 模型实例
-                    return model_class(**validated_data)
-                elif isinstance(validated_data, model_class):
-                    # 已经是模型实例，直接返回
-                    return validated_data
-                else:
-                    logger.warning(f" [Guardrails] 意外的输出类型: {type(validated_data)}")
-                    return None
-            else:
-                logger.warning(f" [Guardrails] JSON 验证失败: {result.validation_summaries}")
-                return None
+            return self._parse_model_from_text(
+                response_text,
+                model_class,
+                expected_type="object",
+            )
 
         except Exception as e:
             logger.error(f" [Guardrails] JSON 解析失败: {e}", exc_info=True)
@@ -571,9 +479,6 @@ class GuardrailsManager:
         Returns:
             清洗后的 JSON 对象/数组，失败返回 None
         """
-        import json
-        import re
-
         try:
             # 检查输入是否为空
             if not response_text:


### PR DESCRIPTION
概述
本次修改主要解决了目标驱动对话功能在启用后仍无法正常注入社交上下文的问题，同时移除了对第三方 guardrails 的运行时硬依赖，改为使用本地 JSON + Pydantic 实现结构化输出校验。

问题背景
在同时开启以下功能时：

启用目标驱动对话
启用社交上下文注入
插件仍然会出现类似日志：

[社交上下文] 对话目标功能已启用但goal_manager未初始化
进一步排查后发现，实际有两个独立问题：

1. conversation_goal_manager 没有稳定注入到 social_context_injector
虽然目标管理器在生命周期中已经创建，但社交上下文注入器在创建时并不总能拿到这个实例，导致后续上下文注入阶段仍然认为 goal_manager 未初始化。

2. guardrails 与当前环境中的 openai SDK 不兼容
原实现依赖第三方 guardrails 包，而该依赖内部使用了旧版 openai.error 接口。在较新的 openai SDK 环境下，会直接导致初始化失败，例如：

AttributeError: module 'openai' has no attribute 'error'
这会进一步导致 ConversationGoalManager 创建失败，从而放大上面的注入问题。

修改内容
1. 修复 conversation_goal_manager 注入链路
修改 core/plugin_lifecycle.py：

在创建 social_context_injector 后
显式将已创建的 conversation_goal_manager 注入给它
这样可以避免注入器仅依赖工厂缓存读取，导致取不到目标管理器实例的问题。

2. 移除第三方 guardrails 运行时依赖
修改 utils/guardrails_manager.py：

不再运行时导入 guardrails
保留原有对外接口和方法名
内部改为使用：
本地 JSON 提取/清洗
json.loads
Pydantic.model_validate
这使得插件不再受 guardrails 与 openai SDK 兼容性问题影响，同时仍然保留结构化输出校验能力。

3. 提升 ConversationGoalManager 的容错性
修改 services/quality/conversation_goal_manager.py：

在结构化解析失败时不再直接导致整个管理器初始化失败
让目标驱动对话功能可以在解析异常时平稳降级
修改后的效果
修改完成后，以下功能可以同时正常使用：

启用目标驱动对话
启用社交上下文注入
并且：

conversation_goal_manager 可以正常初始化
social_context_injector 可以正确获取并使用 goal_manager
不再因为 guardrails/openai 兼容问题导致整条链路失效
兼容性说明
本次修改没有改变插件对外暴露的主要接口，重点是把原先对第三方 guardrails 的依赖替换成更轻量、更稳定的本地实现。

从实际用途看，插件当前主要需要的是：

从 LLM 输出中提取 JSON
对结构进行基础清洗
使用 Pydantic 做类型与字段校验
并没有明显依赖 guardrails 的高级特性，因此改为本地实现后，稳定性更高，资源开销也更可控。

复现时可见的典型日志
修复前常见日志：

[社交上下文] 对话目标功能已启用但goal_manager未初始化
AttributeError: module 'openai' has no attribute 'error'
修复后应表现为：

对话目标管理器正常初始化
社交上下文注入器成功整合对话目标管理器
不再出现上述兼容性错误

## Summary by Sourcery

Fix goal-driven conversation initialization and replace runtime Guardrails dependency with local JSON + Pydantic validation.

Bug Fixes:
- Ensure the social context injector reliably receives the initialized conversation_goal_manager so social context can access conversation goals.
- Prevent ConversationGoalManager startup failures when Guardrails or its OpenAI SDK dependencies are unavailable by falling back to basic JSON parsing.

Enhancements:
- Replace Guardrails-based parsing and validation with an internal JSON extraction plus Pydantic model validation helper while preserving existing public interfaces.
- Add graceful degradation paths in goal and intent analysis to use basic JSON parsing and sensible defaults when structured validation fails.