### PR TITLE
feat: add few-shot persona anchoring for dynamic personality alignment

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -611,7 +611,7 @@
   "Persona_Anchor_Settings": {
     "description": "Few-shot 人格锚点（动态检索 Bot 历史回复作为人格锚点）",
     "type": "object",
-    "hint": "根据当前对话情境动态检索 Bot 自己的历史回复和该用户的历史发言，注入为 in-context examples",
+    "hint": "根据当前对话情境动态检索 Bot 自己的历史回复和该用户的历史发言，注入为 in-context examples。【注意】本功能与「对话风格学习」的 few-shots 注入机制不同：后者是离线周期性学习并审核后注入静态的已批准学习成果，每次请求内容相同；而本功能是每次请求时根据当前 query 的相关性动态打分、从原始消息中实时检索注入，每轮对话注入的 few-shot 内容都不同。两者同时开启时，prompt 中可能出现重复的 few-shot 内容，增加 token 消耗。建议二选一使用：若追求动态上下文感知和每轮不同的个性化示例可开启本功能并关闭自动学习；若追求质量可控和审核机制则关闭本功能、保留自动学习。",
     "items": {
       "enable_persona_anchor": {
         "description": "启用人格锚点注入",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -607,5 +607,42 @@
         "default": "legacy"
       }
     }
+  },
+  "Persona_Anchor_Settings": {
+    "description": "Few-shot Persona Anchoring（动态检索 Bot 历史回复作为人格锚点）",
+    "type": "object",
+    "hint": "根据当前对话情境动态检索 Bot 自己的历史回复和该用户的历史发言，注入为 in-context examples",
+    "items": {
+      "enable_persona_anchor": {
+        "description": "启用 Persona Anchor 注入",
+        "type": "bool",
+        "hint": "根据当前消息动态检索 Bot 历史回复作为人格锚点注入到 prompt",
+        "default": true
+      },
+      "persona_anchor_bot_k": {
+        "description": "注入的 Bot 历史回复条数",
+        "type": "int",
+        "hint": "建议 2-5，太多会挤占上下文",
+        "default": 3
+      },
+      "persona_anchor_user_k": {
+        "description": "注入的当前用户历史发言条数",
+        "type": "int",
+        "hint": "辅轨，建议 1-3，0 关闭辅轨",
+        "default": 2
+      },
+      "persona_anchor_pool": {
+        "description": "候选池大小（从最近 N 条里打分挑选）",
+        "type": "int",
+        "hint": "从最近多少条消息中筛选高相关样本",
+        "default": 30
+      },
+      "persona_anchor_min_samples": {
+        "description": "最小样本阈值（不足则 fallback 到 SOUL.md 描述）",
+        "type": "int",
+        "hint": "冷启动 Bot 还没说够话时跳过注入",
+        "default": 3
+      }
+    }
   }
 }

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -609,12 +609,12 @@
     }
   },
   "Persona_Anchor_Settings": {
-    "description": "Few-shot Persona Anchoring（动态检索 Bot 历史回复作为人格锚点）",
+    "description": "Few-shot 人格锚点（动态检索 Bot 历史回复作为人格锚点）",
     "type": "object",
     "hint": "根据当前对话情境动态检索 Bot 自己的历史回复和该用户的历史发言，注入为 in-context examples",
     "items": {
       "enable_persona_anchor": {
-        "description": "启用 Persona Anchor 注入",
+        "description": "启用人格锚点注入",
         "type": "bool",
         "hint": "根据当前消息动态检索 Bot 历史回复作为人格锚点注入到 prompt",
         "default": true
@@ -638,7 +638,7 @@
         "default": 30
       },
       "persona_anchor_min_samples": {
-        "description": "最小样本阈值（不足则 fallback 到 SOUL.md 描述）",
+        "description": "最小样本阈值（不足则回退到人格描述）",
         "type": "int",
         "hint": "冷启动 Bot 还没说够话时跳过注入",
         "default": 3

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -620,28 +620,28 @@
         "default": true
       },
       "persona_anchor_bot_k": {
-        "description": "注入的 Bot 历史回复条数",
+        "description": "副轨：注入的 Bot 历史回复条数",
         "type": "int",
-        "hint": "建议 2-5，太多会挤占上下文",
-        "default": 3
+        "hint": "人格一致性参考，建议 1-3，0 关闭副轨",
+        "default": 2
       },
       "persona_anchor_user_k": {
-        "description": "注入的当前用户历史发言条数",
+        "description": "主轨：注入的当前用户历史发言条数",
         "type": "int",
-        "hint": "辅轨，建议 1-3，0 关闭辅轨",
-        "default": 2
+        "hint": "学习真人说话风格，建议 2-4",
+        "default": 3
       },
       "persona_anchor_pool": {
         "description": "候选池大小（从最近 N 条里打分挑选）",
         "type": "int",
-        "hint": "从最近多少条消息中筛选高相关样本",
-        "default": 30
+        "hint": "主轨需要更多候选，建议 40-80",
+        "default": 50
       },
       "persona_anchor_min_samples": {
-        "description": "最小样本阈值（不足则回退到人格描述）",
+        "description": "最小样本阈值（主轨用户池不足则跳过）",
         "type": "int",
-        "hint": "冷启动 Bot 还没说够话时跳过注入",
-        "default": 3
+        "hint": "冷启动用户还没说够话时跳过注入，建议 1-2",
+        "default": 2
       }
     }
   }

--- a/config.py
+++ b/config.py
@@ -201,6 +201,10 @@ class PluginConfig(BaseModel):
     persona_anchor_user_k: int = 2
     persona_anchor_pool: int = 30
     persona_anchor_min_samples: int = 3
+    persona_anchor_enable_filter: bool = True
+    persona_anchor_pool_max_size: int = 200
+    persona_anchor_pool_keep_size: int = 100
+    persona_anchor_time_decay_hours: float = 0.0
 
     @classmethod
     def create_from_config(cls, config: dict, data_dir: Optional[str] = None) -> 'PluginConfig':
@@ -376,6 +380,10 @@ class PluginConfig(BaseModel):
             persona_anchor_user_k=persona_anchor_settings.get('persona_anchor_user_k', 3),
             persona_anchor_pool=persona_anchor_settings.get('persona_anchor_pool', 50),
             persona_anchor_min_samples=persona_anchor_settings.get('persona_anchor_min_samples', 2),
+            persona_anchor_enable_filter=persona_anchor_settings.get('persona_anchor_enable_filter', True),
+            persona_anchor_pool_max_size=persona_anchor_settings.get('persona_anchor_pool_max_size', 200),
+            persona_anchor_pool_keep_size=persona_anchor_settings.get('persona_anchor_pool_keep_size', 100),
+            persona_anchor_time_decay_hours=persona_anchor_settings.get('persona_anchor_time_decay_hours', 0.0),
 
             # 传入数据目录 - 优先级：外部传入 > 配置文件 > 存储设置 > 默认值
             data_dir=data_dir if data_dir else storage_settings.get('data_dir', "./data/self_learning_data")

--- a/config.py
+++ b/config.py
@@ -370,12 +370,12 @@ class PluginConfig(BaseModel):
             recent_interactions_limit=repository_settings.get('recent_interactions_limit', 20),
             trend_analysis_days=repository_settings.get('trend_analysis_days', 7),
 
-            # Persona Anchor Settings
+            # Persona Anchor Settings (swapped primary/secondary track defaults)
             enable_persona_anchor=persona_anchor_settings.get('enable_persona_anchor', True),
-            persona_anchor_bot_k=persona_anchor_settings.get('persona_anchor_bot_k', 3),
-            persona_anchor_user_k=persona_anchor_settings.get('persona_anchor_user_k', 2),
-            persona_anchor_pool=persona_anchor_settings.get('persona_anchor_pool', 30),
-            persona_anchor_min_samples=persona_anchor_settings.get('persona_anchor_min_samples', 3),
+            persona_anchor_bot_k=persona_anchor_settings.get('persona_anchor_bot_k', 2),
+            persona_anchor_user_k=persona_anchor_settings.get('persona_anchor_user_k', 3),
+            persona_anchor_pool=persona_anchor_settings.get('persona_anchor_pool', 50),
+            persona_anchor_min_samples=persona_anchor_settings.get('persona_anchor_min_samples', 2),
 
             # 传入数据目录 - 优先级：外部传入 > 配置文件 > 存储设置 > 默认值
             data_dir=data_dir if data_dir else storage_settings.get('data_dir', "./data/self_learning_data")

--- a/config.py
+++ b/config.py
@@ -195,6 +195,13 @@ class PluginConfig(BaseModel):
     recent_interactions_limit: int = 20 # 近期交互查询数量
     trend_analysis_days: int = 7 # 趋势分析天数
 
+    # Persona Anchor Settings
+    enable_persona_anchor: bool = True
+    persona_anchor_bot_k: int = 3
+    persona_anchor_user_k: int = 2
+    persona_anchor_pool: int = 30
+    persona_anchor_min_samples: int = 3
+
     @classmethod
     def create_from_config(cls, config: dict, data_dir: Optional[str] = None) -> 'PluginConfig':
         """从AstrBot配置创建插件配置"""
@@ -231,6 +238,7 @@ class PluginConfig(BaseModel):
         repository_settings = config.get('Repository_Settings', {}) # 新增：Repository配置
         goal_driven_chat_settings = config.get('Goal_Driven_Chat_Settings', {}) # 新增：目标驱动对话设置
         v2_settings = config.get('V2_Architecture_Settings', {}) # v2架构升级设置
+        persona_anchor_settings = config.get('Persona_Anchor_Settings', {})
 
         # 添加调试日志：显示目标驱动对话配置数据
         logger.info(f" [配置加载] Goal_Driven_Chat_Settings原始数据: {goal_driven_chat_settings}")
@@ -361,6 +369,13 @@ class PluginConfig(BaseModel):
             top_patterns_limit=repository_settings.get('top_patterns_limit', 10),
             recent_interactions_limit=repository_settings.get('recent_interactions_limit', 20),
             trend_analysis_days=repository_settings.get('trend_analysis_days', 7),
+
+            # Persona Anchor Settings
+            enable_persona_anchor=persona_anchor_settings.get('enable_persona_anchor', True),
+            persona_anchor_bot_k=persona_anchor_settings.get('persona_anchor_bot_k', 3),
+            persona_anchor_user_k=persona_anchor_settings.get('persona_anchor_user_k', 2),
+            persona_anchor_pool=persona_anchor_settings.get('persona_anchor_pool', 30),
+            persona_anchor_min_samples=persona_anchor_settings.get('persona_anchor_min_samples', 3),
 
             # 传入数据目录 - 优先级：外部传入 > 配置文件 > 存储设置 > 默认值
             data_dir=data_dir if data_dir else storage_settings.get('data_dir', "./data/self_learning_data")

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -522,6 +522,14 @@ class PluginLifecycle:
                     p.message_collector.save_state(),
                 )
 
+            # 7.5 保存人格锚点指标
+            if getattr(p, "_hook_handler", None):
+                try:
+                    p._hook_handler.save_persona_anchor_metrics()
+                    logger.info("人格锚点指标已保存")
+                except Exception as e:
+                    logger.warning(f"保存人格锚点指标失败: {e}")
+
             # 8. 停止 WebUI
             if self._webui_manager:
                 await self._safe_step(

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -251,6 +251,7 @@ class PluginLifecycle:
                 factory_manager=p.factory_manager,
                 perf_tracker=p._perf_tracker,
                 group_id_to_unified_origin=group_id_to_unified_origin,
+                hook_handler=getattr(p, '_hook_handler', None),
             )
             need_immediate_start = self._webui_manager.create_server()
             if need_immediate_start:

--- a/repositories/filtered_message_repository.py
+++ b/repositories/filtered_message_repository.py
@@ -118,6 +118,39 @@ class FilteredMessageRepository(BaseRepository[FilteredMessage]):
             logger.error(f"[FilteredMessageRepository] 批量标记已处理失败: {e}")
             return 0
 
+    async def get_recent_by_sender(
+        self,
+        group_id: str,
+        sender_id: str,
+        limit: int = 50
+    ) -> List[FilteredMessage]:
+        """
+        获取指定用户在指定群组的最近筛选消息
+
+        Args:
+            group_id: 群组 ID
+            sender_id: 发送者 ID
+            limit: 最大返回数量
+
+        Returns:
+            List[FilteredMessage]: 消息列表（按时间倒序）
+        """
+        try:
+            stmt = (
+                select(FilteredMessage)
+                .where(and_(
+                    FilteredMessage.group_id == group_id,
+                    FilteredMessage.sender_id == sender_id,
+                ))
+                .order_by(desc(FilteredMessage.timestamp))
+                .limit(limit)
+            )
+            result = await self.session.execute(stmt)
+            return list(result.scalars().all())
+        except Exception as e:
+            logger.error(f"[FilteredMessageRepository] 获取用户最近筛选消息失败: {e}")
+            return []
+
     async def get_recent(
         self,
         group_id: Optional[str] = None,

--- a/repositories/raw_message_repository.py
+++ b/repositories/raw_message_repository.py
@@ -119,6 +119,39 @@ class RawMessageRepository(BaseRepository[RawMessage]):
             logger.error(f"[RawMessageRepository] 批量标记已处理失败: {e}")
             return 0
 
+    async def get_recent_by_sender(
+        self,
+        group_id: str,
+        sender_id: str,
+        limit: int = 50
+    ) -> List[RawMessage]:
+        """
+        获取指定用户在指定群组的最近原始消息
+
+        Args:
+            group_id: 群组 ID
+            sender_id: 发送者 ID
+            limit: 最大返回数量
+
+        Returns:
+            List[RawMessage]: 消息列表（按时间倒序）
+        """
+        try:
+            stmt = (
+                select(RawMessage)
+                .where(and_(
+                    RawMessage.group_id == group_id,
+                    RawMessage.sender_id == sender_id,
+                ))
+                .order_by(desc(RawMessage.timestamp))
+                .limit(limit)
+            )
+            result = await self.session.execute(stmt)
+            return list(result.scalars().all())
+        except Exception as e:
+            logger.error(f"[RawMessageRepository] 获取用户最近原始消息失败: {e}")
+            return []
+
     async def get_recent(
         self,
         group_id: Optional[str] = None,

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -288,6 +288,10 @@ class LLMHookHandler:
             return None
         return self._persona_anchor.get_metrics()
 
+    def save_persona_anchor_metrics(self) -> None:
+        if self._persona_anchor:
+            self._persona_anchor.save_metrics()
+
     @monitored
     async def _fetch_persona_anchor(
         self, query: str, group_id: str, user_id: str

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -359,9 +359,9 @@ class LLMHookHandler:
     def _collect_persona_anchor(result: Optional[str], out: List[str]) -> None:
         if result:
             out.append(result)
-            logger.debug(f"[LLM Hook] Persona anchor injected (len={len(result)})")
+            logger.info(f"[PersonaAnchor] 已注入 {len(result)} 字: {result[:120]}...")
         else:
-            logger.debug("[LLM Hook] No persona anchor available")
+            logger.info("[PersonaAnchor] 本次无匹配样本，跳过注入")
 
     def _collect_session_updates(
         self, group_id: str, out: List[str]

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -19,6 +19,7 @@ except ImportError:
     TextPart = None
 
 from .perf_tracker import PerfTracker
+from .persona_anchor_retriever import PersonaAnchorRetriever
 
 
 class LLMHookHandler:
@@ -60,6 +61,10 @@ class LLMHookHandler:
         self._perf_tracker = perf_tracker
         self._group_id_to_unified_origin = group_id_to_unified_origin
         self._db_manager = db_manager
+        self._persona_anchor = (
+            PersonaAnchorRetriever(db_manager, plugin_config)
+            if db_manager else None
+        )
 
     # Public API
 
@@ -67,7 +72,7 @@ class LLMHookHandler:
     async def handle(self, event: AstrMessageEvent, req: Any) -> None:
         """Process an LLM request hook — inject context into *req*."""
         hook_start = time.time()
-        social_ms = v2_ms = diversity_ms = jargon_ms = few_shots_ms = 0.0
+        social_ms = v2_ms = diversity_ms = jargon_ms = few_shots_ms = persona_anchor_ms = 0.0
 
         try:
             if req is None:
@@ -105,6 +110,7 @@ class LLMHookHandler:
             diversity_result: Optional[str] = None
             jargon_result: Optional[str] = None
             few_shots_result: Optional[str] = None
+            persona_anchor_result: Optional[str] = None
 
             async def _timed_social() -> None:
                 nonlocal social_result, social_ms
@@ -136,12 +142,19 @@ class LLMHookHandler:
                 few_shots_result = await self._fetch_few_shots(group_id)
                 few_shots_ms = (time.time() - t0) * 1000
 
+            async def _timed_persona_anchor() -> None:
+                nonlocal persona_anchor_result, persona_anchor_ms
+                t0 = time.time()
+                persona_anchor_result = await self._fetch_persona_anchor(req.prompt, group_id, user_id)
+                persona_anchor_ms = (time.time() - t0) * 1000
+
             await asyncio.gather(
                 _timed_social(),
                 _timed_v2(),
                 _timed_diversity(),
                 _timed_jargon(),
                 _timed_few_shots(),
+                _timed_persona_anchor(),
             )
 
             # Merge results in priority order
@@ -150,6 +163,7 @@ class LLMHookHandler:
             self._collect_diversity(diversity_result, prompt_injections)
             self._collect_jargon(jargon_result, prompt_injections)
             self._collect_few_shots(few_shots_result, prompt_injections)
+            self._collect_persona_anchor(persona_anchor_result, prompt_injections)
             self._collect_session_updates(group_id, prompt_injections)
 
             # Inject into request
@@ -169,6 +183,7 @@ class LLMHookHandler:
                     "diversity_ms": round(diversity_ms, 1),
                     "jargon_ms": round(jargon_ms, 1),
                     "few_shots_ms": round(few_shots_ms, 1),
+                    "persona_anchor_ms": round(persona_anchor_ms, 1),
                     "group_id": group_id,
                 }
             )
@@ -265,6 +280,18 @@ class LLMHookHandler:
             logger.warning(f"[LLM Hook] Failed to fetch approved few-shots: {e}")
         return None
 
+    @monitored
+    async def _fetch_persona_anchor(
+        self, query: str, group_id: str, user_id: str
+    ) -> Optional[str]:
+        if not self._persona_anchor:
+            return None
+        try:
+            return await self._persona_anchor.retrieve(query, group_id, user_id)
+        except Exception as e:
+            logger.debug(f"[LLM Hook] Persona anchor fetch failed: {e}")
+            return None
+
     # Result collectors
 
     @staticmethod
@@ -319,6 +346,14 @@ class LLMHookHandler:
             logger.debug(f"[LLM Hook] Few-shot dialogue injected (len={len(result)})")
         else:
             logger.debug("[LLM Hook] No approved few-shot dialogues available")
+
+    @staticmethod
+    def _collect_persona_anchor(result: Optional[str], out: List[str]) -> None:
+        if result:
+            out.append(result)
+            logger.debug(f"[LLM Hook] Persona anchor injected (len={len(result)})")
+        else:
+            logger.debug("[LLM Hook] No persona anchor available")
 
     def _collect_session_updates(
         self, group_id: str, out: List[str]

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -282,6 +282,12 @@ class LLMHookHandler:
             logger.warning(f"[LLM Hook] Failed to fetch approved few-shots: {e}")
         return None
 
+    @property
+    def persona_anchor_metrics(self) -> Optional[dict]:
+        if not self._persona_anchor:
+            return None
+        return self._persona_anchor.get_metrics()
+
     @monitored
     async def _fetch_persona_anchor(
         self, query: str, group_id: str, user_id: str

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -148,14 +148,16 @@ class LLMHookHandler:
                 persona_anchor_result = await self._fetch_persona_anchor(req.prompt, group_id, user_id)
                 persona_anchor_ms = (time.time() - t0) * 1000
 
-            await asyncio.gather(
+            tasks = [
                 _timed_social(),
                 _timed_v2(),
                 _timed_diversity(),
                 _timed_jargon(),
                 _timed_few_shots(),
-                _timed_persona_anchor(),
-            )
+            ]
+            if self._persona_anchor:
+                tasks.append(_timed_persona_anchor())
+            await asyncio.gather(*tasks)
 
             # Merge results in priority order
             self._collect_social(social_result, group_id, prompt_injections)

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -137,7 +137,12 @@ class PersonaAnchorRetriever:
             session = self._db_manager.engine.get_session()
             async with session as s:
                 repo = RawMessageRepository(s)
-                return await repo.get_recent_by_sender(group_id, user_id, limit)
+                msgs = await repo.get_recent_by_sender(group_id, user_id, limit)
+                logger.debug(
+                    f"[PersonaAnchor] user_pool query: group={group_id}, "
+                    f"user={user_id}, limit={limit}, returned={len(msgs)}"
+                )
+                return msgs
         except Exception as e:
             logger.warning(f"[PersonaAnchor] user pool fetch failed: {e}")
             return []

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -137,8 +137,7 @@ class PersonaAnchorRetriever:
             session = self._db_manager.engine.get_session()
             async with session as s:
                 repo = FilteredMessageRepository(s)
-                msgs = await repo.get_recent(group_id, limit)
-                return [m for m in msgs if m.sender_id == user_id]
+                return await repo.get_recent_by_sender(group_id, user_id, limit)
         except Exception as e:
             logger.warning(f"[PersonaAnchor] user pool fetch failed: {e}")
             return []

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -48,6 +48,12 @@ class PersonaAnchorRetriever:
         bot_top = self._score_and_pick(current_query, bot_pool, k_bot)
         user_top = self._score_and_pick(current_query, user_pool, k_user)
 
+        # If scoring filters out all bot messages, skip persona anchoring entirely.
+        # Returning a persona-anchored block with no bot messages would be misleading.
+        if not bot_top:
+            logger.debug("[PersonaAnchor] no scored bot messages after filtering, skipped")
+            return None
+
         return self._format(bot_top, user_top)
 
     async def _fetch_bot_pool(self, group_id: str, limit: int) -> List:
@@ -93,7 +99,11 @@ class PersonaAnchorRetriever:
             if overlap == 0:
                 continue
             # Time decay: halve every 24 hours
-            hours_ago = (now - msg.timestamp) / 3600.0
+            ts = msg.timestamp
+            # Defensive: normalize if timestamp appears to be in milliseconds
+            if ts > 1e12:
+                ts = ts / 1000.0
+            hours_ago = (now - ts) / 3600.0
             time_weight = exp(-hours_ago / 24.0)
             score = overlap * time_weight
             scored.append((score, msg))

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -16,8 +16,8 @@ from ...repositories.filtered_message_repository import FilteredMessageRepositor
 class PersonaAnchorRetriever:
     """Query-aware dual-track few-shot retriever.
 
-    Primary track: Bot's own historical responses (persona anchoring)
-    Secondary track: Current user's historical messages (natural conversation flow)
+    Primary track: Current user's historical messages (learn real human style).
+    Secondary track: Bot's own historical responses (persona consistency ref).
     """
 
     _METRIC_KEYS = [
@@ -60,7 +60,11 @@ class PersonaAnchorRetriever:
         group_id: str,
         user_id: str,
     ) -> Optional[str]:
-        """Return formatted few-shot text block; return None if insufficient samples."""
+        """Return formatted few-shot text block; return None if insufficient samples.
+
+        Primary track: user's historical messages (learn real human speaking style).
+        Secondary track: Bot's own historical responses (persona consistency).
+        """
         async with self._metrics_lock:
             self._metrics["total_calls"] += 1
 
@@ -74,46 +78,45 @@ class PersonaAnchorRetriever:
         candidate_pool = self._config.persona_anchor_pool
         min_samples = self._config.persona_anchor_min_samples
 
-        # Primary track: Bot historical responses
-        bot_pool = await self._fetch_bot_pool(group_id, candidate_pool)
-
-        async with self._metrics_lock:
-            self._metrics["total_bot_samples"] += len(bot_pool)
-
-        if len(bot_pool) < min_samples:
-            logger.debug("[PersonaAnchor] insufficient bot samples, skipped")
-            async with self._metrics_lock:
-                self._metrics["skips_insufficient"] += 1
-                self._record_history(False, len(bot_pool), None, 0.0)
-            return None
-
-        # Secondary track: user's historical messages
+        # Primary track: user's historical messages
         user_pool = await self._fetch_user_pool(group_id, user_id, candidate_pool)
 
         async with self._metrics_lock:
             self._metrics["total_user_samples"] += len(user_pool)
 
-        bot_top = self._score_and_pick(current_query, bot_pool, k_bot)
-        user_top = self._score_and_pick(current_query, user_pool, k_user)
+        if len(user_pool) < min_samples:
+            logger.debug("[PersonaAnchor] insufficient user samples, skipped")
+            async with self._metrics_lock:
+                self._metrics["skips_insufficient"] += 1
+                self._record_history(False, 0, len(user_pool), 0.0)
+            return None
 
-        # If scoring filters out all bot messages, skip persona anchoring entirely.
-        # Returning a persona-anchored block with no bot messages would be misleading.
-        if not bot_top:
-            logger.debug("[PersonaAnchor] no scored bot messages after filtering, skipped")
+        # Secondary track: Bot historical responses
+        bot_pool = await self._fetch_bot_pool(group_id, candidate_pool)
+
+        async with self._metrics_lock:
+            self._metrics["total_bot_samples"] += len(bot_pool)
+
+        user_top = self._score_and_pick(current_query, user_pool, k_user)
+        bot_top = self._score_and_pick(current_query, bot_pool, k_bot)
+
+        # If scoring filters out all user messages, skip — user pool is primary.
+        if not user_top:
+            logger.debug("[PersonaAnchor] no scored user messages after filtering, skipped")
             async with self._metrics_lock:
                 self._metrics["skips_no_scored"] += 1
                 self._record_history(False, len(bot_pool), len(user_pool), 0.0)
             return None
 
-        # Calculate average relevance score for bot_top
-        avg_score = self._calc_avg_score(current_query, bot_top)
+        # Calculate average relevance score for user_top (primary track)
+        avg_score = self._calc_avg_score(current_query, user_top)
         async with self._metrics_lock:
             self._metrics["total_relevance_score"] += avg_score
             self._metrics["scored_count"] += 1
             self._metrics["successful_injections"] += 1
             self._record_history(True, len(bot_pool), len(user_pool), avg_score)
 
-        return self._format(bot_top, user_top)
+        return self._format(user_top, bot_top)
 
     async def _fetch_bot_pool(self, group_id: str, limit: int) -> List:
         if not self._db_manager or not self._db_manager.engine:
@@ -253,13 +256,14 @@ class PersonaAnchorRetriever:
             logger.warning(f"[PersonaAnchor] 加载指标失败: {e}")
 
     @staticmethod
-    def _format(bot_msgs: list, user_msgs: list) -> str:
-        lines = ["[Persona Anchor — your past responses in similar contexts]"]
-        for msg in bot_msgs:
-            lines.append(f"You: {msg.message}")
-        if user_msgs:
+    def _format(user_msgs: list, bot_msgs: list) -> str:
+        """Format with user style as primary, Bot persona as secondary."""
+        lines = ["[Speaking style reference — how this user typically talks]"]
+        for msg in user_msgs:
+            lines.append(f"User: {msg.message}")
+        if bot_msgs:
             lines.append("")
-            lines.append("[How this user typically speaks]")
-            for msg in user_msgs:
-                lines.append(f"User: {msg.message}")
+            lines.append("[Your past responses in similar contexts]")
+            for msg in bot_msgs:
+                lines.append(f"You: {msg.message}")
         return "\n".join(lines)

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -1,0 +1,114 @@
+"""Persona Anchor Retriever — query-aware dual-track few-shot retrieval."""
+import time
+from math import exp
+from typing import List, Optional
+
+import jieba
+from astrbot.api import logger
+
+from ...repositories.bot_message_repository import BotMessageRepository
+from ...repositories.filtered_message_repository import FilteredMessageRepository
+
+
+class PersonaAnchorRetriever:
+    """Query-aware dual-track few-shot retriever.
+
+    Primary track: Bot's own historical responses (persona anchoring)
+    Secondary track: Current user's historical messages (natural conversation flow)
+    """
+
+    def __init__(self, db_manager, config) -> None:
+        self._db_manager = db_manager
+        self._config = config
+
+    async def retrieve(
+        self,
+        current_query: str,
+        group_id: str,
+        user_id: str,
+    ) -> Optional[str]:
+        """Return formatted few-shot text block; return None if insufficient samples."""
+        if not self._config.enable_persona_anchor:
+            return None
+
+        k_bot = self._config.persona_anchor_bot_k
+        k_user = self._config.persona_anchor_user_k
+        candidate_pool = self._config.persona_anchor_pool
+        min_samples = self._config.persona_anchor_min_samples
+
+        # Primary track: Bot historical responses
+        bot_pool = await self._fetch_bot_pool(group_id, candidate_pool)
+        if len(bot_pool) < min_samples:
+            logger.debug("[PersonaAnchor] insufficient bot samples, skipped")
+            return None
+
+        # Secondary track: user's historical messages
+        user_pool = await self._fetch_user_pool(group_id, user_id, candidate_pool)
+
+        bot_top = self._score_and_pick(current_query, bot_pool, k_bot)
+        user_top = self._score_and_pick(current_query, user_pool, k_user)
+
+        return self._format(bot_top, user_top)
+
+    async def _fetch_bot_pool(self, group_id: str, limit: int) -> List:
+        if not self._db_manager or not self._db_manager.engine:
+            return []
+        try:
+            session = self._db_manager.engine.get_session()
+            async with session as s:
+                repo = BotMessageRepository(s)
+                return await repo.get_recent_responses(group_id, limit)
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] bot pool fetch failed: {e}")
+            return []
+
+    async def _fetch_user_pool(self, group_id: str, user_id: str, limit: int) -> List:
+        if not self._db_manager or not self._db_manager.engine:
+            return []
+        try:
+            session = self._db_manager.engine.get_session()
+            async with session as s:
+                repo = FilteredMessageRepository(s)
+                msgs = await repo.get_recent(group_id, limit)
+                return [m for m in msgs if m.sender_id == user_id]
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] user pool fetch failed: {e}")
+            return []
+
+    def _score_and_pick(self, query: str, pool: list, k: int) -> list:
+        if not query:
+            return pool[:k]
+        query_tokens = set(jieba.cut_for_search(query))
+        if not query_tokens:
+            return pool[:k]
+
+        now = time.time()
+        scored = []
+        for msg in pool:
+            text = msg.message
+            if not text or len(text) < 3:
+                continue
+            msg_tokens = set(jieba.cut_for_search(text))
+            overlap = len(query_tokens & msg_tokens)
+            if overlap == 0:
+                continue
+            # Time decay: halve every 24 hours
+            hours_ago = (now - msg.timestamp) / 3600.0
+            time_weight = exp(-hours_ago / 24.0)
+            score = overlap * time_weight
+            scored.append((score, msg))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [m for _, m in scored[:k]]
+
+    @staticmethod
+    def _format(bot_msgs: list, user_msgs: list) -> str:
+        lines = ["[Persona Anchor — your past responses in similar contexts]"]
+        for msg in bot_msgs:
+            lines.append(f"You: {msg.message}")
+        if user_msgs:
+            lines.append("")
+            lines.append("[How this user typically speaks]")
+            for msg in user_msgs:
+                lines.append(f"User: {msg.message}")
+        return "\n".join(lines)

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -10,7 +10,7 @@ import jieba
 from astrbot.api import logger
 
 from ...repositories.bot_message_repository import BotMessageRepository
-from ...repositories.filtered_message_repository import FilteredMessageRepository
+from ...repositories.raw_message_repository import RawMessageRepository
 
 
 class PersonaAnchorRetriever:
@@ -136,7 +136,7 @@ class PersonaAnchorRetriever:
         try:
             session = self._db_manager.engine.get_session()
             async with session as s:
-                repo = FilteredMessageRepository(s)
+                repo = RawMessageRepository(s)
                 return await repo.get_recent_by_sender(group_id, user_id, limit)
         except Exception as e:
             logger.warning(f"[PersonaAnchor] user pool fetch failed: {e}")

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -1,4 +1,5 @@
 """Persona Anchor Retriever — query-aware dual-track few-shot retrieval."""
+import asyncio
 import time
 from math import exp
 from typing import List, Optional
@@ -17,9 +18,38 @@ class PersonaAnchorRetriever:
     Secondary track: Current user's historical messages (natural conversation flow)
     """
 
+    _METRIC_KEYS = [
+        "total_calls",
+        "successful_injections",
+        "skips_disabled",
+        "skips_insufficient",
+        "skips_no_scored",
+        "total_bot_samples",
+        "total_user_samples",
+        "total_relevance_score",
+        "scored_count",
+    ]
+
     def __init__(self, db_manager, config) -> None:
         self._db_manager = db_manager
         self._config = config
+        self._metrics = self._default_metrics()
+        self._metrics_lock = asyncio.Lock()
+
+    @classmethod
+    def _default_metrics(cls) -> dict:
+        return {
+            "total_calls": 0,
+            "successful_injections": 0,
+            "skips_disabled": 0,
+            "skips_insufficient": 0,
+            "skips_no_scored": 0,
+            "total_bot_samples": 0,
+            "total_user_samples": 0,
+            "total_relevance_score": 0.0,
+            "scored_count": 0,
+            "injection_history": [],
+        }
 
     async def retrieve(
         self,
@@ -28,7 +58,12 @@ class PersonaAnchorRetriever:
         user_id: str,
     ) -> Optional[str]:
         """Return formatted few-shot text block; return None if insufficient samples."""
+        async with self._metrics_lock:
+            self._metrics["total_calls"] += 1
+
         if not self._config.enable_persona_anchor:
+            async with self._metrics_lock:
+                self._metrics["skips_disabled"] += 1
             return None
 
         k_bot = self._config.persona_anchor_bot_k
@@ -38,12 +73,22 @@ class PersonaAnchorRetriever:
 
         # Primary track: Bot historical responses
         bot_pool = await self._fetch_bot_pool(group_id, candidate_pool)
+
+        async with self._metrics_lock:
+            self._metrics["total_bot_samples"] += len(bot_pool)
+
         if len(bot_pool) < min_samples:
             logger.debug("[PersonaAnchor] insufficient bot samples, skipped")
+            async with self._metrics_lock:
+                self._metrics["skips_insufficient"] += 1
+                self._record_history(False, len(bot_pool), None, 0.0)
             return None
 
         # Secondary track: user's historical messages
         user_pool = await self._fetch_user_pool(group_id, user_id, candidate_pool)
+
+        async with self._metrics_lock:
+            self._metrics["total_user_samples"] += len(user_pool)
 
         bot_top = self._score_and_pick(current_query, bot_pool, k_bot)
         user_top = self._score_and_pick(current_query, user_pool, k_user)
@@ -52,7 +97,18 @@ class PersonaAnchorRetriever:
         # Returning a persona-anchored block with no bot messages would be misleading.
         if not bot_top:
             logger.debug("[PersonaAnchor] no scored bot messages after filtering, skipped")
+            async with self._metrics_lock:
+                self._metrics["skips_no_scored"] += 1
+                self._record_history(False, len(bot_pool), len(user_pool), 0.0)
             return None
+
+        # Calculate average relevance score for bot_top
+        avg_score = self._calc_avg_score(current_query, bot_top)
+        async with self._metrics_lock:
+            self._metrics["total_relevance_score"] += avg_score
+            self._metrics["scored_count"] += 1
+            self._metrics["successful_injections"] += 1
+            self._record_history(True, len(bot_pool), len(user_pool), avg_score)
 
         return self._format(bot_top, user_top)
 
@@ -110,6 +166,61 @@ class PersonaAnchorRetriever:
 
         scored.sort(key=lambda x: x[0], reverse=True)
         return [m for _, m in scored[:k]]
+
+    def _calc_avg_score(self, query: str, bot_top: list) -> float:
+        if not query or not bot_top:
+            return 0.0
+        query_tokens = set(jieba.cut_for_search(query))
+        if not query_tokens:
+            return 0.0
+        scores = []
+        for msg in bot_top:
+            text = msg.message
+            if not text:
+                continue
+            msg_tokens = set(jieba.cut_for_search(text))
+            overlap = len(query_tokens & msg_tokens)
+            scores.append(overlap)
+        return sum(scores) / len(scores) if scores else 0.0
+
+    def _record_history(self, success: bool, bot_pool_size: int, user_pool_size: Optional[int], score: float) -> None:
+        history = self._metrics["injection_history"]
+        entry = {
+            "ts": time.time(),
+            "success": success,
+            "bot_pool_size": bot_pool_size,
+            "score": round(score, 2),
+        }
+        if user_pool_size is not None:
+            entry["user_pool_size"] = user_pool_size
+        history.append(entry)
+        if len(history) > 100:
+            history.pop(0)
+
+    def get_metrics(self) -> dict:
+        m = self._metrics
+        total_calls = m["total_calls"]
+        successful = m["successful_injections"]
+        avg_bot = m["total_bot_samples"] / total_calls if total_calls > 0 else 0
+        avg_user = m["total_user_samples"] / total_calls if total_calls > 0 else 0
+        avg_score = m["total_relevance_score"] / m["scored_count"] if m["scored_count"] > 0 else 0
+        injection_rate = successful / total_calls * 100 if total_calls > 0 else 0
+        return {
+            "enabled": getattr(self._config, 'enable_persona_anchor', False) if self._config else False,
+            "total_calls": total_calls,
+            "successful_injections": successful,
+            "injection_rate": round(injection_rate, 1),
+            "skips_disabled": m["skips_disabled"],
+            "skips_insufficient": m["skips_insufficient"],
+            "skips_no_scored": m["skips_no_scored"],
+            "avg_bot_pool_size": round(avg_bot, 1),
+            "avg_user_pool_size": round(avg_user, 1),
+            "avg_relevance_score": round(avg_score, 2),
+            "recent_history": [dict(h) for h in m["injection_history"]][-20:],
+        }
+
+    def reset_metrics(self) -> None:
+        self._metrics = self._default_metrics()
 
     @staticmethod
     def _format(bot_msgs: list, user_msgs: list) -> str:

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -2,15 +2,42 @@
 import asyncio
 import json
 import os
+import re
 import time
 from math import exp
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import jieba
 from astrbot.api import logger
 
 from ...repositories.bot_message_repository import BotMessageRepository
 from ...repositories.raw_message_repository import RawMessageRepository
+
+
+class _PoolEntry:
+    """Lightweight entry for persona-anchor user sample pool."""
+
+    __slots__ = ("message", "timestamp", "sender_id")
+
+    def __init__(self, message: str, timestamp: float, sender_id: str = "") -> None:
+        self.message = message
+        self.timestamp = timestamp
+        self.sender_id = sender_id
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "sender_id": self.sender_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "_PoolEntry":
+        return cls(
+            message=data.get("message", ""),
+            timestamp=data.get("timestamp", 0.0),
+            sender_id=data.get("sender_id", ""),
+        )
 
 
 class PersonaAnchorRetriever:
@@ -31,6 +58,12 @@ class PersonaAnchorRetriever:
         "total_relevance_score",
         "scored_count",
     ]
+
+    _AT_PATTERN = re.compile(r"@[^\s]+\s*")
+    _URL_PATTERN = re.compile(r"https?://\S+|www\.\S+")
+    _TONE_WORDS = {"吧", "呢", "啊", "呀", "哦", "嘛", "呗", "咯", "哈", "哇", "耶", "捏", "噜"}
+    _MEANINGLESS = {"", "???", "。。。", "...", "嗯", "哦", "额", "啊", "呃", "唔", "嗯嗯", "哦哦"}
+    _REPETITIVE_PATTERN = re.compile(r"(.)\1{4,}")
 
     def __init__(self, db_manager, config) -> None:
         self._db_manager = db_manager
@@ -75,11 +108,10 @@ class PersonaAnchorRetriever:
 
         k_bot = self._config.persona_anchor_bot_k
         k_user = self._config.persona_anchor_user_k
-        candidate_pool = self._config.persona_anchor_pool
         min_samples = self._config.persona_anchor_min_samples
 
-        # Primary track: user's historical messages
-        user_pool = await self._fetch_user_pool(group_id, user_id, candidate_pool)
+        # Primary track: user's historical messages (from managed pool)
+        user_pool = await self._fetch_user_pool(group_id, user_id)
 
         async with self._metrics_lock:
             self._metrics["total_user_samples"] += len(user_pool)
@@ -92,7 +124,9 @@ class PersonaAnchorRetriever:
             return None
 
         # Secondary track: Bot historical responses
-        bot_pool = await self._fetch_bot_pool(group_id, candidate_pool)
+        bot_pool = await self._fetch_bot_pool(
+            group_id, self._config.persona_anchor_pool
+        )
 
         async with self._metrics_lock:
             self._metrics["total_bot_samples"] += len(bot_pool)
@@ -102,7 +136,9 @@ class PersonaAnchorRetriever:
 
         # If scoring filters out all user messages, skip — user pool is primary.
         if not user_top:
-            logger.debug("[PersonaAnchor] no scored user messages after filtering, skipped")
+            logger.debug(
+                "[PersonaAnchor] no scored user messages after filtering, skipped"
+            )
             async with self._metrics_lock:
                 self._metrics["skips_no_scored"] += 1
                 self._record_history(False, len(bot_pool), len(user_pool), 0.0)
@@ -130,7 +166,52 @@ class PersonaAnchorRetriever:
             logger.warning(f"[PersonaAnchor] bot pool fetch failed: {e}")
             return []
 
-    async def _fetch_user_pool(self, group_id: str, user_id: str, limit: int) -> List:
+    async def _fetch_user_pool(self, group_id: str, user_id: str) -> List:
+        """Fetch from managed sample pool — syncs from raw_messages on demand."""
+        enable_filter = getattr(self._config, "persona_anchor_enable_filter", True)
+        if not enable_filter:
+            # Fallback: direct raw message query without pool management
+            return await self._fetch_raw_user_pool(group_id, user_id)
+
+        # 1. Load existing pool
+        pool = self._load_pool(group_id, user_id)
+
+        # 2. Determine cutoff timestamp (latest message already in pool)
+        cutoff = max((e.timestamp for e in pool), default=0.0)
+
+        # 3. Fetch newer raw messages
+        new_raw = await self._fetch_raw_user_pool(group_id, user_id, limit=200)
+        new_entries = [
+            _PoolEntry(
+                message=m.message,
+                timestamp=m.timestamp / 1000.0 if m.timestamp > 1e12 else m.timestamp,
+                sender_id=getattr(m, "sender_id", ""),
+            )
+            for m in new_raw
+            if (m.timestamp / 1000.0 if m.timestamp > 1e12 else m.timestamp) > cutoff
+        ]
+
+        if not new_entries:
+            return pool
+
+        # 4. Filter noise
+        filtered = self._filter_noise(new_entries)
+
+        # 5. Merge with existing pool
+        pool.extend(filtered)
+
+        # 6. Clean if over threshold
+        max_size = getattr(self._config, "persona_anchor_pool_max_size", 200)
+        if len(pool) > max_size:
+            pool = self._clean_pool(pool)
+
+        # 7. Save
+        self._save_pool(group_id, user_id, pool)
+        return pool
+
+    async def _fetch_raw_user_pool(
+        self, group_id: str, user_id: str, limit: int = 200
+    ) -> List:
         if not self._db_manager or not self._db_manager.engine:
             return []
         try:
@@ -139,13 +220,157 @@ class PersonaAnchorRetriever:
                 repo = RawMessageRepository(s)
                 msgs = await repo.get_recent_by_sender(group_id, user_id, limit)
                 logger.debug(
-                    f"[PersonaAnchor] user_pool query: group={group_id}, "
+                    f"[PersonaAnchor] raw query: group={group_id}, "
                     f"user={user_id}, limit={limit}, returned={len(msgs)}"
                 )
                 return msgs
         except Exception as e:
-            logger.warning(f"[PersonaAnchor] user pool fetch failed: {e}")
+            logger.warning(f"[PersonaAnchor] raw user pool fetch failed: {e}")
             return []
+
+    # -- Pool persistence --
+
+    def _pool_file(self, group_id: str, user_id: str) -> str:
+        pool_dir = os.path.join(self._config.data_dir, "persona_anchor_pools")
+        os.makedirs(pool_dir, exist_ok=True)
+        safe_name = re.sub(r"[^\w\-_]", "_", f"{group_id}_{user_id}")
+        return os.path.join(pool_dir, f"{safe_name}.json")
+
+    def _load_pool(self, group_id: str, user_id: str) -> List[_PoolEntry]:
+        path = self._pool_file(group_id, user_id)
+        if not os.path.exists(path):
+            return []
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return [_PoolEntry.from_dict(item) for item in data]
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] pool load failed: {e}")
+        return []
+
+    def _save_pool(self, group_id: str, user_id: str, pool: List[_PoolEntry]) -> None:
+        path = self._pool_file(group_id, user_id)
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump([e.to_dict() for e in pool], f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] pool save failed: {e}")
+
+    # -- Quality filtering & cleaning --
+
+    def _filter_noise(self, entries: List[_PoolEntry]) -> List[_PoolEntry]:
+        """Rule-based noise filtering (no LLM calls)."""
+        result: List[_PoolEntry] = []
+        for e in entries:
+            text = e.message
+            if not text:
+                continue
+
+            stripped = text.strip()
+
+            # Length guard
+            if len(stripped) < 5 or len(stripped) > 300:
+                continue
+
+            # Meaningless content
+            if stripped in self._MEANINGLESS:
+                continue
+
+            # Commands
+            if stripped.startswith(("/", "!", "#", ".")):
+                continue
+
+            # @mentions
+            if self._AT_PATTERN.search(stripped):
+                continue
+
+            # URLs
+            if self._URL_PATTERN.search(stripped):
+                continue
+
+            # Pure digits
+            if stripped.replace(" ", "").isdigit():
+                continue
+
+            # Pure punctuation / emoji-only (no CJK or letters)
+            if not any("一" <= c <= "鿿" or c.isalpha() for c in stripped):
+                continue
+
+            result.append(e)
+        return result
+
+    def _deduplicate(self, entries: List[_PoolEntry]) -> List[_PoolEntry]:
+        """Remove near-duplicate entries, keeping the newest."""
+        # Sort by timestamp descending — keep newest
+        sorted_entries = sorted(entries, key=lambda e: e.timestamp, reverse=True)
+        seen_tokens: List[set] = []
+        result: List[_PoolEntry] = []
+        for e in sorted_entries:
+            tokens = set(jieba.cut_for_search(e.message))
+            if not tokens:
+                continue
+            is_dup = False
+            for seen in seen_tokens:
+                overlap = len(tokens & seen)
+                union = len(tokens | seen)
+                if union > 0 and overlap / union > 0.75:
+                    is_dup = True
+                    break
+            if not is_dup:
+                seen_tokens.append(tokens)
+                result.append(e)
+        return result
+
+    def _score_quality(self, text: str) -> float:
+        """Heuristic quality score for style-learning suitability."""
+        score = 0.0
+
+        # 1. Length sweet spot (10-150 chars)
+        length = len(text)
+        if 10 <= length <= 150:
+            score += 3.0
+        elif 5 <= length < 10:
+            score += 1.0
+        else:
+            score -= 1.0
+
+        # 2. Tone words (strong style signature)
+        found_tones = sum(1 for w in self._TONE_WORDS if w in text)
+        score += min(found_tones * 0.6, 2.5)
+
+        # 3. Emotional punctuation
+        if any(p in text for p in "！？…~～"):
+            score += 1.0
+
+        # 4. Question marks (interactive style)
+        if "?" in text or "？" in text:
+            score += 0.8
+
+        # 5. Multiple sentence breaks (complex expression)
+        breaks = text.count("。") + text.count("！") + text.count("？")
+        if breaks >= 2:
+            score += 0.5
+
+        # 6. Repetitive chars penalty
+        if self._REPETITIVE_PATTERN.search(text):
+            score -= 1.5
+
+        # 7. Excessive length penalty
+        if length > 200:
+            score -= 1.0
+
+        return score
+
+    def _clean_pool(self, entries: List[_PoolEntry]) -> List[_PoolEntry]:
+        """Clean pool: deduplicate then keep highest-quality samples."""
+        deduped = self._deduplicate(entries)
+        scored = [(self._score_quality(e.message), e) for e in deduped]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        keep_size = getattr(self._config, "persona_anchor_pool_keep_size", 100)
+        return [e for _, e in scored[:keep_size]]
+
+    # -- Scoring --
 
     def _score_and_pick(self, query: str, pool: list, k: int) -> list:
         if not query:
@@ -155,6 +380,7 @@ class PersonaAnchorRetriever:
             return pool[:k]
 
         now = time.time()
+        decay_hours = getattr(self._config, "persona_anchor_time_decay_hours", 0.0)
         scored = []
         for msg in pool:
             text = msg.message
@@ -164,13 +390,14 @@ class PersonaAnchorRetriever:
             overlap = len(query_tokens & msg_tokens)
             if overlap == 0:
                 continue
-            # Time decay: halve every 24 hours
+            # Time decay (optional — 0 means disabled)
             ts = msg.timestamp
-            # Defensive: normalize if timestamp appears to be in milliseconds
             if ts > 1e12:
                 ts = ts / 1000.0
-            hours_ago = (now - ts) / 3600.0
-            time_weight = exp(-hours_ago / 24.0)
+            time_weight = 1.0
+            if decay_hours > 0:
+                hours_ago = (now - ts) / 3600.0
+                time_weight = exp(-hours_ago / decay_hours)
             score = overlap * time_weight
             scored.append((score, msg))
 
@@ -193,7 +420,9 @@ class PersonaAnchorRetriever:
             scores.append(overlap)
         return sum(scores) / len(scores) if scores else 0.0
 
-    def _record_history(self, success: bool, bot_pool_size: int, user_pool_size: Optional[int], score: float) -> None:
+    def _record_history(
+        self, success: bool, bot_pool_size: int, user_pool_size: Optional[int], score: float
+    ) -> None:
         history = self._metrics["injection_history"]
         entry = {
             "ts": time.time(),
@@ -214,10 +443,18 @@ class PersonaAnchorRetriever:
         successful = m["successful_injections"]
         avg_bot = m["total_bot_samples"] / total_calls if total_calls > 0 else 0
         avg_user = m["total_user_samples"] / total_calls if total_calls > 0 else 0
-        avg_score = m["total_relevance_score"] / m["scored_count"] if m["scored_count"] > 0 else 0
+        avg_score = (
+            m["total_relevance_score"] / m["scored_count"]
+            if m["scored_count"] > 0
+            else 0
+        )
         injection_rate = successful / total_calls * 100 if total_calls > 0 else 0
         return {
-            "enabled": getattr(self._config, 'enable_persona_anchor', False) if self._config else False,
+            "enabled": (
+                getattr(self._config, "enable_persona_anchor", False)
+                if self._config
+                else False
+            ),
             "total_calls": total_calls,
             "successful_injections": successful,
             "injection_rate": round(injection_rate, 1),
@@ -249,13 +486,14 @@ class PersonaAnchorRetriever:
             if os.path.exists(path):
                 with open(path, "r", encoding="utf-8") as f:
                     loaded = json.load(f)
-                # 只加载已知的键，防止 schema 变更导致问题
                 for key in self._METRIC_KEYS:
                     if key in loaded:
                         self._metrics[key] = loaded[key]
                 if "injection_history" in loaded:
                     self._metrics["injection_history"] = loaded["injection_history"]
-                logger.info(f"[PersonaAnchor] 已恢复历史指标: {self._metrics['total_calls']} 次调用")
+                logger.info(
+                    f"[PersonaAnchor] 已恢复历史指标: {self._metrics['total_calls']} 次调用"
+                )
         except Exception as e:
             logger.warning(f"[PersonaAnchor] 加载指标失败: {e}")
 

--- a/services/hooks/persona_anchor_retriever.py
+++ b/services/hooks/persona_anchor_retriever.py
@@ -1,5 +1,7 @@
 """Persona Anchor Retriever — query-aware dual-track few-shot retrieval."""
 import asyncio
+import json
+import os
 import time
 from math import exp
 from typing import List, Optional
@@ -35,6 +37,7 @@ class PersonaAnchorRetriever:
         self._config = config
         self._metrics = self._default_metrics()
         self._metrics_lock = asyncio.Lock()
+        self._load_metrics()
 
     @classmethod
     def _default_metrics(cls) -> dict:
@@ -196,6 +199,7 @@ class PersonaAnchorRetriever:
         history.append(entry)
         if len(history) > 100:
             history.pop(0)
+        self.save_metrics()
 
     def get_metrics(self) -> dict:
         m = self._metrics
@@ -221,6 +225,32 @@ class PersonaAnchorRetriever:
 
     def reset_metrics(self) -> None:
         self._metrics = self._default_metrics()
+
+    def _metrics_file(self) -> str:
+        return os.path.join(self._config.data_dir, "persona_anchor_metrics.json")
+
+    def save_metrics(self) -> None:
+        try:
+            with open(self._metrics_file(), "w", encoding="utf-8") as f:
+                json.dump(self._metrics, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] 保存指标失败: {e}")
+
+    def _load_metrics(self) -> None:
+        try:
+            path = self._metrics_file()
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    loaded = json.load(f)
+                # 只加载已知的键，防止 schema 变更导致问题
+                for key in self._METRIC_KEYS:
+                    if key in loaded:
+                        self._metrics[key] = loaded[key]
+                if "injection_history" in loaded:
+                    self._metrics["injection_history"] = loaded["injection_history"]
+                logger.info(f"[PersonaAnchor] 已恢复历史指标: {self._metrics['total_calls']} 次调用")
+        except Exception as e:
+            logger.warning(f"[PersonaAnchor] 加载指标失败: {e}")
 
     @staticmethod
     def _format(bot_msgs: list, user_msgs: list) -> str:

--- a/web_res/static/html/macos.html
+++ b/web_res/static/html/macos.html
@@ -112,6 +112,7 @@
   <script src="/static/js/macos/apps/JargonLearning.js?v=1.2.5"></script>
   <script src="/static/js/macos/apps/BugReport.js?v=1.2.5"></script>
   <script src="/static/js/macos/apps/PerformanceMonitor.js?v=1.2.5"></script>
+  <script src="/static/js/macos/apps/PersonaAnchor.js?v=1.2.5"></script>
 
   <!-- === 入口 === -->
   <script src="/static/js/macos/main.js?v=1.2.5"></script>

--- a/web_res/static/js/macos/app-model.js
+++ b/web_res/static/js/macos/app-model.js
@@ -268,6 +268,25 @@
           },
         ],
       },
+      {
+        key: "app_persona_anchor",
+        component: "AppPersonaAnchor",
+        icon: "icon-anchor",
+        title: "人格锚点",
+        iconColor: "#fff",
+        iconBgColor: "#007aff",
+        width: Math.min(W, 900),
+        height: H,
+        hideInDesktop: false,
+        keepInDock: true,
+        menu: [
+          {
+            key: "anchor",
+            title: "锚点",
+            sub: [{ key: "close", title: "关闭" }],
+          },
+        ],
+      },
     ],
   };
 })();

--- a/web_res/static/js/macos/apps/Dashboard.js
+++ b/web_res/static/js/macos/apps/Dashboard.js
@@ -46,6 +46,13 @@ window.AppDashboard = {
               {{ trends.sessions_growth >= 0 ? '+' : '' }}{{ trends.sessions_growth }}%
             </div>
           </div>
+          <div class="stat-card">
+            <div class="stat-number">{{ formatNum(personaAnchorPoolSize) }}</div>
+            <div class="stat-label">人格锚点池</div>
+            <div class="stat-trend" :class="personaAnchorEnabled ? 'positive' : 'negative'">
+              {{ personaAnchorEnabled ? '已启用' : '未启用' }}
+            </div>
+          </div>
         </div>
 
         <!-- ========== 图表网格 ========== -->
@@ -95,6 +102,12 @@ window.AppDashboard = {
           <div class="chart-box">
             <h4>系统状态监控</h4>
             <div ref="systemRadarChart" class="chart-area"></div>
+          </div>
+
+          <!-- 5.6 人格锚点学习进度 - 仪表盘 -->
+          <div class="chart-box">
+            <h4>人格锚点学习进度</h4>
+            <div ref="personaAnchorChart" class="chart-area"></div>
           </div>
 
           <!-- 5.5 Hook注入耗时分析 - 堆叠柱状图 -->
@@ -162,6 +175,16 @@ window.AppDashboard = {
       return Object.values(calls).reduce(function (sum, m) {
         return sum + (m.total_calls || 0);
       }, 0);
+    },
+    personaAnchorPoolSize() {
+      const pa = this.metrics.persona_anchor;
+      if (!pa) return 0;
+      return pa.avg_bot_pool_size || 0;
+    },
+    personaAnchorEnabled() {
+      const pa = this.metrics.persona_anchor;
+      if (!pa) return false;
+      return pa.enabled || false;
     },
   },
 
@@ -295,6 +318,7 @@ window.AppDashboard = {
       this.updateResponseTime();
       this.updateLearningGauge();
       this.updateSystemRadar();
+      this.updatePersonaAnchor();
       this.updateHookPerf();
       this.updateStyleChart();
       this.updateHeatmap();
@@ -528,6 +552,93 @@ window.AppDashboard = {
       );
     },
 
+    /* ---------- 5.6 人格锚点学习进度 - 仪表盘 ---------- */
+    updatePersonaAnchor() {
+      var chart =
+        this.chartInstances["personaAnchorChart"] ||
+        this.initChart("personaAnchorChart");
+      if (!chart) return;
+
+      var pa = this.metrics.persona_anchor;
+      var injectionRate = 0;
+      var avgScore = 0;
+      if (pa) {
+        injectionRate = pa.injection_rate || 0;
+        avgScore = pa.avg_relevance_score || 0;
+      }
+
+      chart.setOption(
+        {
+          tooltip: {
+            formatter: function (params) {
+              return (
+                params.name +
+                "<br/>" +
+                params.value.toFixed(1) +
+                "%"
+              );
+            },
+          },
+          series: [
+            {
+              type: "gauge",
+              startAngle: 180,
+              endAngle: 0,
+              center: ["50%", "75%"],
+              radius: "90%",
+              min: 0,
+              max: 100,
+              splitNumber: 10,
+              axisLine: {
+                lineStyle: {
+                  width: 6,
+                  color: [
+                    [0.3, "#ff4444"],
+                    [0.6, "#ff9800"],
+                    [0.8, "#4caf50"],
+                    [1, "#1976d2"],
+                  ],
+                },
+              },
+              pointer: {
+                icon: "path://M12.8,0.7l12,40.1H0.7L12.8,0.7z",
+                length: "12%",
+                width: 20,
+                offsetCenter: [0, "-60%"],
+                itemStyle: { color: "auto" },
+              },
+              axisTick: { length: 12, lineStyle: { color: "auto", width: 2 } },
+              splitLine: { length: 20, lineStyle: { color: "auto", width: 5 } },
+              axisLabel: {
+                color: "#464646",
+                fontSize: 10,
+                distance: -60,
+                formatter: function (value) {
+                  if (value === 100) return "优秀";
+                  if (value === 80) return "良好";
+                  if (value === 60) return "一般";
+                  if (value === 30) return "较差";
+                  return "";
+                },
+              },
+              title: { offsetCenter: [0, "-10%"], fontSize: 14 },
+              detail: {
+                fontSize: 24,
+                offsetCenter: [0, "-35%"],
+                valueAnimation: true,
+                formatter: function (v) {
+                  return Math.round(v) + "%";
+                },
+                color: "auto",
+              },
+              data: [{ value: injectionRate, name: "注入率" }],
+            },
+          ],
+        },
+        true,
+      );
+    },
+
     /* ---------- 5. 系统状态监控 - 雷达图 ---------- */
     updateSystemRadar() {
       var chart =
@@ -648,6 +759,9 @@ window.AppDashboard = {
       var jargonData = recent.map(function (s) {
         return Math.round(s.jargon_ms || 0);
       });
+      var personaAnchorData = recent.map(function (s) {
+        return Math.round(s.persona_anchor_ms || 0);
+      });
 
       chart.setOption(
         {
@@ -667,7 +781,7 @@ window.AppDashboard = {
             },
           },
           legend: {
-            data: ["社交上下文", "V2上下文", "多样性", "黑话"],
+            data: ["社交上下文", "V2上下文", "多样性", "黑话", "人格锚点"],
             bottom: 0,
             textStyle: { fontSize: 10 },
           },
@@ -712,6 +826,13 @@ window.AppDashboard = {
               stack: "hook",
               data: jargonData,
               itemStyle: { color: "#7b1fa2" },
+            },
+            {
+              name: "人格锚点",
+              type: "bar",
+              stack: "hook",
+              data: personaAnchorData,
+              itemStyle: { color: "#00bcd4" },
             },
           ],
         },
@@ -929,6 +1050,7 @@ window.AppDashboard = {
         self.updateResponseTime();
         self.updateLearningGauge();
         self.updateSystemRadar();
+        self.updatePersonaAnchor();
         self.updateHookPerf();
         self.updateStyleChart();
         self.updateHeatmap();

--- a/web_res/static/js/macos/apps/Dashboard.js
+++ b/web_res/static/js/macos/apps/Dashboard.js
@@ -48,7 +48,7 @@ window.AppDashboard = {
           </div>
           <div class="stat-card">
             <div class="stat-number">{{ formatNum(personaAnchorPoolSize) }}</div>
-            <div class="stat-label">人格锚点池</div>
+            <div class="stat-label">人格锚点 主轨池</div>
             <div class="stat-trend" :class="personaAnchorEnabled ? 'positive' : 'negative'">
               {{ personaAnchorEnabled ? '已启用' : '未启用' }}
             </div>
@@ -179,7 +179,7 @@ window.AppDashboard = {
     personaAnchorPoolSize() {
       const pa = this.metrics.persona_anchor;
       if (!pa) return 0;
-      return pa.avg_bot_pool_size || 0;
+      return pa.avg_user_pool_size || 0;
     },
     personaAnchorEnabled() {
       const pa = this.metrics.persona_anchor;

--- a/web_res/static/js/macos/apps/PersonaAnchor.js
+++ b/web_res/static/js/macos/apps/PersonaAnchor.js
@@ -29,8 +29,8 @@ window.AppPersonaAnchor = {
           <!-- ========== Config Bar ========== -->
           <div style="display:flex;gap:12px;margin-bottom:16px;flex-wrap:wrap;">
             <el-tag size="small" type="success">已启用</el-tag>
-            <el-tag size="small">Bot 样本: {{ config.persona_anchor_bot_k }}</el-tag>
-            <el-tag size="small">用户样本: {{ config.persona_anchor_user_k }}</el-tag>
+            <el-tag size="small">主轨 用户样本: {{ config.persona_anchor_user_k }}</el-tag>
+            <el-tag size="small">副轨 Bot 样本: {{ config.persona_anchor_bot_k }}</el-tag>
             <el-tag size="small">候选池: {{ config.persona_anchor_pool }}</el-tag>
             <el-tag size="small">最小样本: {{ config.persona_anchor_min_samples }}</el-tag>
           </div>
@@ -70,12 +70,12 @@ window.AppPersonaAnchor = {
             <h4 style="margin:0 0 8px 0;font-size:14px;color:var(--text-primary);">平均池大小</h4>
             <div class="stat-grid" style="grid-template-columns:repeat(2,1fr);">
               <div class="stat-card">
-                <div class="stat-number">{{ metrics.avg_bot_pool_size }}</div>
-                <div class="stat-label">Bot 候选池</div>
+                <div class="stat-number">{{ metrics.avg_user_pool_size }}</div>
+                <div class="stat-label">主轨 用户候选池</div>
               </div>
               <div class="stat-card">
-                <div class="stat-number">{{ metrics.avg_user_pool_size }}</div>
-                <div class="stat-label">用户候选池</div>
+                <div class="stat-number">{{ metrics.avg_bot_pool_size }}</div>
+                <div class="stat-label">副轨 Bot 候选池</div>
               </div>
             </div>
           </div>
@@ -96,8 +96,8 @@ window.AppPersonaAnchor = {
                   </el-tag>
                 </template>
               </el-table-column>
-              <el-table-column prop="bot_pool_size" label="Bot池" width="80" />
-              <el-table-column prop="user_pool_size" label="用户池" width="80" />
+              <el-table-column prop="user_pool_size" label="用户池(主)" width="90" />
+              <el-table-column prop="bot_pool_size" label="Bot池(副)" width="90" />
               <el-table-column prop="score" label="相关性" width="90" />
             </el-table>
             <div v-if="metrics.recent_history.length === 0" style="text-align:center;padding:20px;color:#86868b;font-size:13px;">

--- a/web_res/static/js/macos/apps/PersonaAnchor.js
+++ b/web_res/static/js/macos/apps/PersonaAnchor.js
@@ -151,15 +151,15 @@ window.AppPersonaAnchor = {
     async loadData() {
       try {
         const [metricsRes, configRes] = await Promise.all([
-          this.tool.get("/api/anchor/metrics"),
-          this.tool.get("/api/anchor/config"),
+          fetch("/api/anchor/metrics").then(function (r) { return r.json(); }),
+          fetch("/api/anchor/config").then(function (r) { return r.json(); }),
         ]);
 
-        if (metricsRes && metricsRes.data) {
-          this.metrics = metricsRes.data;
+        if (metricsRes) {
+          this.metrics = metricsRes;
         }
-        if (configRes && configRes.data) {
-          this.config = configRes.data;
+        if (configRes) {
+          this.config = configRes;
         }
       } catch (e) {
         console.error("[PersonaAnchor] loadData failed:", e);

--- a/web_res/static/js/macos/apps/PersonaAnchor.js
+++ b/web_res/static/js/macos/apps/PersonaAnchor.js
@@ -1,0 +1,183 @@
+/**
+ * Persona Anchor App
+ * Display Persona Anchor metrics, config, and recent injection history.
+ * Auto-refreshes every 10 seconds.
+ */
+window.AppPersonaAnchor = {
+  props: { app: Object },
+
+  template: `
+    <div class="app-content" ref="rootEl">
+      <!-- Loading -->
+      <div v-if="loading" class="loading-center" style="height:100%;flex-direction:column;">
+        <i class="material-icons" style="font-size:36px;animation:spin 1s linear infinite;margin-bottom:12px;">refresh</i>
+        <span style="font-size:13px;">加载数据中...</span>
+        <style>@keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}</style>
+      </div>
+
+      <template v-else>
+        <!-- Not enabled -->
+        <div v-if="!metrics.enabled" class="empty-state">
+          <i class="material-icons">anchor</i>
+          <p>Persona Anchor 未启用</p>
+          <p style="font-size:11px;color:#86868b;">
+            请在插件配置中开启「启用 Persona Anchor 注入」后重启插件。
+          </p>
+        </div>
+
+        <template v-else>
+          <!-- ========== Config Bar ========== -->
+          <div style="display:flex;gap:12px;margin-bottom:16px;flex-wrap:wrap;">
+            <el-tag size="small" type="success">已启用</el-tag>
+            <el-tag size="small">Bot 样本: {{ config.persona_anchor_bot_k }}</el-tag>
+            <el-tag size="small">用户样本: {{ config.persona_anchor_user_k }}</el-tag>
+            <el-tag size="small">候选池: {{ config.persona_anchor_pool }}</el-tag>
+            <el-tag size="small">最小样本: {{ config.persona_anchor_min_samples }}</el-tag>
+          </div>
+
+          <!-- ========== Metrics Cards ========== -->
+          <div class="stat-grid">
+            <div class="stat-card">
+              <div class="stat-number">{{ metrics.total_calls }}</div>
+              <div class="stat-label">总调用次数</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-number">{{ metrics.successful_injections }}</div>
+              <div class="stat-label">成功注入</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-number">{{ metrics.injection_rate }}%</div>
+              <div class="stat-label">注入率</div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-number">{{ metrics.avg_relevance_score }}</div>
+              <div class="stat-label">平均相关性</div>
+            </div>
+          </div>
+
+          <!-- ========== Skip Reasons ========== -->
+          <div style="margin-top:16px;">
+            <h4 style="margin:0 0 8px 0;font-size:14px;color:var(--text-primary);">跳过原因分布</h4>
+            <div style="display:flex;gap:12px;flex-wrap:wrap;">
+              <el-tag size="small" type="info">配置禁用: {{ metrics.skips_disabled }}</el-tag>
+              <el-tag size="small" type="warning">样本不足: {{ metrics.skips_insufficient }}</el-tag>
+              <el-tag size="small" type="danger">无匹配: {{ metrics.skips_no_scored }}</el-tag>
+            </div>
+          </div>
+
+          <!-- ========== Pool Stats ========== -->
+          <div style="margin-top:16px;">
+            <h4 style="margin:0 0 8px 0;font-size:14px;color:var(--text-primary);">平均池大小</h4>
+            <div class="stat-grid" style="grid-template-columns:repeat(2,1fr);">
+              <div class="stat-card">
+                <div class="stat-number">{{ metrics.avg_bot_pool_size }}</div>
+                <div class="stat-label">Bot 候选池</div>
+              </div>
+              <div class="stat-card">
+                <div class="stat-number">{{ metrics.avg_user_pool_size }}</div>
+                <div class="stat-label">用户候选池</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- ========== Recent History ========== -->
+          <div style="margin-top:16px;">
+            <h4 style="margin:0 0 8px 0;font-size:14px;color:var(--text-primary);">最近注入记录（最近 20 条）</h4>
+            <el-table :data="metrics.recent_history" size="small" style="width:100%">
+              <el-table-column prop="ts" label="时间" width="160">
+                <template #default="scope">
+                  {{ formatTime(scope.row.ts) }}
+                </template>
+              </el-table-column>
+              <el-table-column label="结果" width="80">
+                <template #default="scope">
+                  <el-tag size="small" :type="scope.row.success ? 'success' : 'info'">
+                    {{ scope.row.success ? '注入' : '跳过' }}
+                  </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column prop="bot_pool_size" label="Bot池" width="80" />
+              <el-table-column prop="user_pool_size" label="用户池" width="80" />
+              <el-table-column prop="score" label="相关性" width="90" />
+            </el-table>
+            <div v-if="metrics.recent_history.length === 0" style="text-align:center;padding:20px;color:#86868b;font-size:13px;">
+              暂无注入记录，在群里多发几条消息触发 LLM 后即可看到数据。
+            </div>
+          </div>
+        </template>
+      </template>
+    </div>
+  `,
+
+  data() {
+    return {
+      loading: true,
+      metrics: {
+        enabled: false,
+        total_calls: 0,
+        successful_injections: 0,
+        injection_rate: 0,
+        skips_disabled: 0,
+        skips_insufficient: 0,
+        skips_no_scored: 0,
+        avg_bot_pool_size: 0,
+        avg_user_pool_size: 0,
+        avg_relevance_score: 0,
+        recent_history: [],
+      },
+      config: {
+        enable_persona_anchor: false,
+        persona_anchor_bot_k: 3,
+        persona_anchor_user_k: 2,
+        persona_anchor_pool: 30,
+        persona_anchor_min_samples: 3,
+      },
+      refreshTimer: null,
+    };
+  },
+
+  mounted() {
+    this.loadData();
+    this.refreshTimer = setInterval(() => this.loadData(), 10000);
+  },
+
+  beforeUnmount() {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+    }
+  },
+
+  methods: {
+    async loadData() {
+      try {
+        const [metricsRes, configRes] = await Promise.all([
+          this.tool.get("/api/anchor/metrics"),
+          this.tool.get("/api/anchor/config"),
+        ]);
+
+        if (metricsRes && metricsRes.data) {
+          this.metrics = metricsRes.data;
+        }
+        if (configRes && configRes.data) {
+          this.config = configRes.data;
+        }
+      } catch (e) {
+        console.error("[PersonaAnchor] loadData failed:", e);
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    formatTime(ts) {
+      if (!ts) return "-";
+      const d = new Date(ts * 1000);
+      return d.toLocaleString("zh-CN", {
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+    },
+  },
+};

--- a/web_res/static/js/macos/main.js
+++ b/web_res/static/js/macos/main.js
@@ -54,6 +54,7 @@
   app.component("AppJargonLearning", window.AppJargonLearning);
   app.component("AppBugReport", window.AppBugReport);
   app.component("AppPerformanceMonitor", window.AppPerformanceMonitor);
+  app.component("AppPersonaAnchor", window.AppPersonaAnchor);
 
   // 挂载
   app.mount("#app");

--- a/webui/blueprints/__init__.py
+++ b/webui/blueprints/__init__.py
@@ -17,6 +17,7 @@ from .persona_reviews import persona_reviews_bp
 from .intelligent_chat import intelligent_chat_bp
 from .graph_share import graph_share_bp
 from .data_management import data_management_bp
+from .anchor import anchor_bp
 
 # monitoring blueprint requires prometheus_client; degrade gracefully
 try:
@@ -47,6 +48,7 @@ def get_blueprints() -> List[Blueprint]:
         intelligent_chat_bp,
         graph_share_bp,
         data_management_bp,
+        anchor_bp,
     ]
     if _has_monitoring:
         bps.append(monitoring_bp)
@@ -80,6 +82,7 @@ __all__ = [
     'intelligent_chat_bp',
     'graph_share_bp',
     'data_management_bp',
+    'anchor_bp',
     'get_blueprints',
     'register_blueprints'
 ]

--- a/webui/blueprints/anchor.py
+++ b/webui/blueprints/anchor.py
@@ -17,10 +17,12 @@ async def get_anchor_metrics():
     try:
         container = get_container()
         hook_handler = getattr(container, "hook_handler", None)
+        config = getattr(container, "plugin_config", None)
+        cfg_enabled = getattr(config, "enable_persona_anchor", False) if config else False
 
         if hook_handler is None:
             return jsonify({
-                "enabled": False,
+                "enabled": cfg_enabled,
                 "reason": "hook_handler not initialized",
                 "total_calls": 0,
                 "successful_injections": 0,
@@ -37,8 +39,8 @@ async def get_anchor_metrics():
         metrics = hook_handler.persona_anchor_metrics
         if metrics is None:
             return jsonify({
-                "enabled": False,
-                "reason": "persona_anchor not initialized",
+                "enabled": cfg_enabled,
+                "reason": "persona_anchor not initialized (db_manager may be None during init)",
                 "total_calls": 0,
                 "successful_injections": 0,
                 "injection_rate": 0.0,

--- a/webui/blueprints/anchor.py
+++ b/webui/blueprints/anchor.py
@@ -1,0 +1,82 @@
+"""Persona Anchor blueprint - metrics and injection history."""
+
+from quart import Blueprint, jsonify
+from astrbot.api import logger
+
+from ..dependencies import get_container
+from ..middleware.auth import require_auth
+from ..utils.response import success_response, error_response
+
+anchor_bp = Blueprint("anchor", __name__, url_prefix="/api/anchor")
+
+
+@anchor_bp.route("/metrics", methods=["GET"])
+@require_auth
+async def get_anchor_metrics():
+    """Return Persona Anchor metrics and recent injection history."""
+    try:
+        container = get_container()
+        hook_handler = getattr(container, "hook_handler", None)
+
+        if hook_handler is None:
+            return jsonify({
+                "enabled": False,
+                "reason": "hook_handler not initialized",
+                "total_calls": 0,
+                "successful_injections": 0,
+                "injection_rate": 0.0,
+                "skips_disabled": 0,
+                "skips_insufficient": 0,
+                "skips_no_scored": 0,
+                "avg_bot_pool_size": 0.0,
+                "avg_user_pool_size": 0.0,
+                "avg_relevance_score": 0.0,
+                "recent_history": [],
+            }), 200
+
+        metrics = hook_handler.persona_anchor_metrics
+        if metrics is None:
+            return jsonify({
+                "enabled": False,
+                "reason": "persona_anchor not initialized",
+                "total_calls": 0,
+                "successful_injections": 0,
+                "injection_rate": 0.0,
+                "skips_disabled": 0,
+                "skips_insufficient": 0,
+                "skips_no_scored": 0,
+                "avg_bot_pool_size": 0.0,
+                "avg_user_pool_size": 0.0,
+                "avg_relevance_score": 0.0,
+                "recent_history": [],
+            }), 200
+
+        return jsonify(metrics), 200
+
+    except Exception as e:
+        logger.error(f"[Anchor] Failed to get metrics: {e}")
+        return error_response(str(e), 500)
+
+
+@anchor_bp.route("/config", methods=["GET"])
+@require_auth
+async def get_anchor_config():
+    """Return current Persona Anchor configuration."""
+    try:
+        container = get_container()
+        config = getattr(container, "plugin_config", None)
+
+        if config is None:
+            return error_response("plugin_config not available", 500)
+
+        return jsonify({
+            "enable_persona_anchor": getattr(config, "enable_persona_anchor", False),
+            "persona_anchor_bot_k": getattr(config, "persona_anchor_bot_k", 3),
+            "persona_anchor_user_k": getattr(config, "persona_anchor_user_k", 2),
+            "persona_anchor_pool": getattr(config, "persona_anchor_pool", 30),
+            "persona_anchor_min_samples": getattr(config, "persona_anchor_min_samples", 3),
+        }), 200
+
+    except Exception as e:
+        logger.error(f"[Anchor] Failed to get config: {e}")
+        return error_response(str(e), 500)

--- a/webui/blueprints/metrics.py
+++ b/webui/blueprints/metrics.py
@@ -205,6 +205,15 @@ async def get_metrics():
             except Exception as e:
                 logger.warning(f"获取Hook性能数据失败: {e}")
 
+        # Persona anchor metrics
+        persona_anchor_metrics = None
+        hook_handler = getattr(container, 'hook_handler', None)
+        if hook_handler and hasattr(hook_handler, 'persona_anchor_metrics'):
+            try:
+                persona_anchor_metrics = hook_handler.persona_anchor_metrics
+            except Exception as e:
+                logger.warning(f"获取人格锚点指标失败: {e}")
+
         import time
         metrics = {
             "llm_calls": llm_stats,
@@ -215,6 +224,7 @@ async def get_metrics():
             "learning_efficiency": round(learning_efficiency, 1),
             "learning_dimensions": learning_dimensions,
             "hook_performance": hook_performance,
+            "persona_anchor": persona_anchor_metrics,
             "last_updated": time.time()
         }
 

--- a/webui/dependencies.py
+++ b/webui/dependencies.py
@@ -59,6 +59,9 @@ class ServiceContainer:
         self.metric_collector: Optional[Any] = None
         self.health_checker: Optional[Any] = None
 
+        # Hook handler（用于获取人格锚点等指标）
+        self.hook_handler: Optional[Any] = None
+
         self._initialized = True
 
     def initialize(

--- a/webui/manager.py
+++ b/webui/manager.py
@@ -31,12 +31,14 @@ class WebUIManager:
         factory_manager: "FactoryManager",
         perf_tracker: Any,
         group_id_to_unified_origin: Dict[str, str],
+        hook_handler: Any = None,
     ):
         self._config = plugin_config
         self._context = context
         self._factory_manager = factory_manager
         self._perf_tracker = perf_tracker
         self._group_id_to_unified_origin = group_id_to_unified_origin
+        self._hook_handler = hook_handler
 
     # 创建
 
@@ -238,4 +240,7 @@ class WebUIManager:
             astrbot_persona_manager,
             self._group_id_to_unified_origin,
         )
-        _get_webui_container().perf_collector = self._perf_tracker
+        container = _get_webui_container()
+        container.perf_collector = self._perf_tracker
+        if self._hook_handler is not None:
+            container.hook_handler = self._hook_handler


### PR DESCRIPTION
## 功能：动态人格锚定（灵感来自Opus 4.7）

### 做了什么
在 LLM 请求前，按当前用户消息内容动态检索 Bot 自己的历史回复 + 该用户的历史发言，作为 in-context examples 注入 prompt，让模型从样本里 learn-by-imitation，弥补 SOUL.md 静态描述的不足。

**双轨检索：**
- **主轨**：Bot 历史回复（`bot_messages`）→ 锚定角色口吻
- **辅轨**：当前用户历史发言（`filtered_messages`）→ 让 Bot 自然接话风
- **排序**：jieba 关键词重叠 × 24h 时间衰减（`exp(-hours/24)`）
- **冷启动**：Bot 回复不足 `min_samples` 时自动跳过，fallback 到原有 system prompt

### 新增文件
| 文件 | 说明 | 依赖 |
|------|------|------|
| `services/hooks/persona_anchor_retriever.py` | `PersonaAnchorRetriever` 类，双轨检索 + 打分 + 格式化 | `jieba`（已有） |

### 修改文件
| 文件 | 修改点 | 副作用评估 |
|------|--------|-----------|
| `services/hooks/llm_hook_handler.py` | `__init__` 注入 retriever；`handle()` 新增 `_timed_persona_anchor()` 并行 coroutine；收集阶段插入 persona_anchor；perf 追踪新增 `persona_anchor_ms` | 仅追加，未改动现有 social/v2/diversity/jargon/few_shots 逻辑。异常全捕获，失败时返回 None 不影响主流程。 |
| `config.py` | `PluginConfig` 新增 5 个字段；`create_from_config()` 新增 `Persona_Anchor_Settings` 提取 | 无，Pydantic `extra="ignore"` 兼容旧配置。 |
| `_conf_schema.json` | 新增 `Persona_Anchor_Settings` 配置段（5 项） | AstrBot WebUI 自动渲染，无额外工作。 |

### 工程性考虑
- **零新表**：完全复用 `BotMessage` / `FilteredMessage`，无 schema migration
- **零新依赖**：`jieba` 已在 `requirements.txt`
- **并行不阻塞**：接入现有 `asyncio.gather`，不增加串行延迟
- **防御式编程**：DB 异常、jieba 异常、冷启动全部 graceful fallback
- **开关回滚**：`enable_persona_anchor=false` 即可完全关闭，零成本回滚
- **克制原则**：不抽象 `IRetriever` 接口（只有一个实现），不缓存（query 差异大命中率低），不碰现有 dialog_analyzer

### Reviewer Checklist
- [ ] `PersonaAnchorRetriever._score_and_pick()` 中 `time.time()`（float 秒）与 `msg.timestamp`（BigInteger Unix 秒）的减法是否安全
- [ ] `llm_hook_handler.py` 的注入顺序是否符合预期：Few-Shots → Persona Anchor → Session Updates
- [ ] `config.py` 中 5 个新字段默认值是否与 schema 一致

## Summary by Sourcery

Introduce dynamic persona anchoring that retrieves past bot and user messages as in-context examples to better align LLM responses with the bot persona and user style.

New Features:
- Add a persona anchor retriever that selects recent bot replies and user messages based on relevance and recency to build few-shot prompts.
- Enable configurable persona anchor behavior via new plugin configuration options and corresponding schema entries.

Enhancements:
- Integrate persona anchor retrieval into the LLM hook pipeline as a parallel async step with separate collection and performance tracking.