### PR TITLE
fix(database): improve sqlite compatibility and jargon safeguards

### DIFF
--- a/core/database/engine.py
+++ b/core/database/engine.py
@@ -10,6 +10,8 @@ SQLAlchemy 数据库引擎封装
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool
 from sqlalchemy.schema import CreateColumn
+from sqlalchemy.sql.schema import Column
+from sqlalchemy.types import JSON, LargeBinary, Text
 from astrbot.api import logger
 from typing import Optional
 import asyncio
@@ -293,7 +295,7 @@ class DatabaseEngine:
                     db_cols = existing[table.name]
                     for col in table.columns:
                         if col.name not in db_cols:
-                            compiled_col = str(CreateColumn(col).compile(dialect=dialect))
+                            compiled_col = self._compile_add_column(col, dialect)
                             alter_statements.append(
                                 f"ALTER TABLE {quote(table.name)} ADD COLUMN {compiled_col}"
                             )
@@ -316,6 +318,20 @@ class DatabaseEngine:
 
         except Exception as e:
             logger.warning(f"[DatabaseEngine] 自动列迁移检测失败（不影响运行）: {e}")
+
+    @staticmethod
+    def _compile_add_column(col: Column, dialect) -> str:
+        """编译 ADD COLUMN 子句，保留 MySQL 对 TEXT/BLOB/JSON 默认值限制。"""
+        if dialect.name not in ('mysql', 'mariadb'):
+            return str(CreateColumn(col).compile(dialect=dialect))
+
+        if not isinstance(col.type, (Text, LargeBinary, JSON)):
+            return str(CreateColumn(col).compile(dialect=dialect))
+
+        copied_col = col.copy()
+        copied_col.default = None
+        copied_col.server_default = None
+        return str(CreateColumn(copied_col).compile(dialect=dialect))
 
     async def drop_tables(self):
         """

--- a/core/database/engine.py
+++ b/core/database/engine.py
@@ -9,7 +9,7 @@ SQLAlchemy 数据库引擎封装
 """
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool
-from sqlalchemy import types as sa_types
+from sqlalchemy.schema import CreateColumn
 from astrbot.api import logger
 from typing import Optional
 import asyncio
@@ -285,30 +285,17 @@ class DatabaseEngine:
 
                 # 对比 ORM 定义，收集需要 ALTER 的列
                 alter_statements = []
+                dialect = self.engine.dialect
+                quote = dialect.identifier_preparer.quote
                 for table in Base.metadata.sorted_tables:
                     if table.name not in existing:
                         continue  # 刚创建的新表，无需 ALTER
                     db_cols = existing[table.name]
                     for col in table.columns:
                         if col.name not in db_cols:
-                            col_type = col.type.compile(self.engine.dialect)
-                            nullable = "NULL" if col.nullable else "NOT NULL"
-                            default = ""
-                            # MySQL/MariaDB 不允许 TEXT/BLOB 列有 DEFAULT 值
-                            is_mysql = self.engine.dialect.name in ("mysql", "mariadb")
-                            is_text_type = isinstance(
-                                col.type,
-                                (sa_types.Text, sa_types.LargeBinary, sa_types.JSON),
-                            )
-                            skip_default = is_mysql and is_text_type
-                            if not skip_default:
-                                if col.server_default is not None:
-                                    default = f" DEFAULT {col.server_default.arg!r}"
-                                elif col.default is not None and col.default.is_scalar:
-                                    default = f" DEFAULT {col.default.arg!r}"
+                            compiled_col = str(CreateColumn(col).compile(dialect=dialect))
                             alter_statements.append(
-                                f"ALTER TABLE `{table.name}` ADD COLUMN "
-                                f"`{col.name}` {col_type} {nullable}{default}"
+                                f"ALTER TABLE {quote(table.name)} ADD COLUMN {compiled_col}"
                             )
 
                 if alter_statements:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ aiomysql
 guardrails-ai
 pydantic
 sqlalchemy[asyncio]
+aiosqlite
 cachetools>=5.3.0
 apscheduler
 lightrag-hku>=1.4.0

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -307,7 +307,12 @@ class LLMHookHandler:
     @staticmethod
     def _collect_jargon(result: Optional[str], out: List[str]) -> None:
         if result:
-            out.append(result)
+            out.append(
+                "[Jargon Comprehension Context]\n"
+                "以下黑话解释只用于理解用户当前消息。回复时不要主动复读、"
+                "模仿、扩散这些黑话，也不要把解释原样输出；仅在用户明确询问含义时才说明。\n"
+                f"{result}"
+            )
             logger.debug(f"[LLM Hook] 已准备黑话理解内容 (长度: {len(result)})")
         else:
             logger.debug("[LLM Hook] 用户消息中未检测到已知黑话")

--- a/services/jargon/jargon_miner.py
+++ b/services/jargon/jargon_miner.py
@@ -260,8 +260,12 @@ class JargonMiner(AsyncServiceBase):
 
 请判断以上候选词中，哪些是该群组的黑话/俚语/暗语/缩写/群内特有用语。
 
-**是黑话的特征：**
+**必须同时满足：**
 - 脱离该群组语境后普通人无法理解
+- 在近期聊天中有明确上下文支撑
+- 不是普通词、昵称、人名、地名、品牌名或完整句子
+
+**是黑话的特征：**
 - 拼音首字母缩写、谐音梗、群内暗语
 - 群成员自创或圈内流行的特殊表达
 
@@ -269,6 +273,7 @@ class JargonMiner(AsyncServiceBase):
 - 含义清晰的日常词语，即使不太常见
 - 常见名词、动词、形容词
 - 人名、地名、品牌名
+- 问句、感叹句、长短语、完整句子
 
 以JSON数组输出可能是黑话的词条（只输出词条文本）：
 ["词1", "词2"]
@@ -392,8 +397,16 @@ class JargonMiner(AsyncServiceBase):
         if re.match(r'^[^\w\u4e00-\u9fff]+$', content):
             return True
 
-        # 太短（单字）或太长（>15字符）
-        if len(content) < 2 or len(content) > 15:
+        # 太短（单字）或太长（>8字符），与提取提示保持一致
+        if len(content) < 2 or len(content) > 8:
+            return True
+
+        # 句子/短句不像词条，容易污染黑话库
+        if re.search(r'[，。！？!?、；;：:\s]', content):
+            return True
+
+        # 纯英文长词通常是普通单词/品牌/ID，保留短缩写
+        if re.match(r'^[A-Za-z]+$', content) and len(content) > 6:
             return True
 
         # [图片] [表情] 等标记
@@ -447,16 +460,16 @@ class JargonMiner(AsyncServiceBase):
             response = await self.llm.generate_response(prompt, temperature=0.2)
             if not response:
                 logger.warning(
-                    f"[{self.chat_id}] LLM pre-gate returned empty, keeping all candidates"
+                    f"[{self.chat_id}] LLM pre-gate returned empty, dropping candidates"
                 )
-                return candidates
+                return []
 
             confirmed = safe_parse_llm_json(response.strip())
             if not isinstance(confirmed, list):
                 logger.warning(
-                    f"[{self.chat_id}] LLM pre-gate parse failed, keeping all candidates"
+                    f"[{self.chat_id}] LLM pre-gate parse failed, dropping candidates"
                 )
-                return candidates
+                return []
 
             confirmed_set = {str(t).strip() for t in confirmed}
             validated = [c for c in candidates if c['content'] in confirmed_set]
@@ -473,9 +486,9 @@ class JargonMiner(AsyncServiceBase):
 
         except Exception as e:
             logger.error(
-                f"[{self.chat_id}] LLM pre-gate failed: {e}, keeping all candidates"
+                f"[{self.chat_id}] LLM pre-gate failed: {e}, dropping candidates"
             )
-            return candidates
+            return []
 
     async def save_or_update_jargon(
         self,

--- a/services/jargon/jargon_query.py
+++ b/services/jargon/jargon_query.py
@@ -4,6 +4,7 @@
 提供给LLM使用的黑话查询工具,用于在生成回复时理解群组黑话
 """
 from typing import Optional, List, Dict, Any
+import re
 from astrbot.api import logger
 from cachetools import TTLCache
 
@@ -180,26 +181,61 @@ class JargonQueryService:
             if not jargon_list:
                 return None
 
-            # 检查文本中是否包含黑话
+            # 检查文本中是否包含黑话，避免短词/英文缩写的误命中导致污染
             found_jargon = []
+            seen_contents = set()
             for j in jargon_list:
-                if j['content'] and j['content'] in text:
-                    found_jargon.append(j)
+                content = str(j.get('content') or '').strip()
+                meaning = str(j.get('meaning') or '').strip()
+                if not content or content in seen_contents:
+                    continue
+                if not meaning or meaning == '含义待推断':
+                    continue
+                if not self._contains_jargon(text, content):
+                    continue
+                found_jargon.append(j)
+                seen_contents.add(content)
+                if len(found_jargon) >= 5:
+                    break
 
             if not found_jargon:
                 return None
 
-            # 格式化解释
-            lines = ["文本中包含的黑话:"]
+            # 格式化解释：强调理解用途，避免模型把黑话当作回复风格
+            lines = ["用户消息中命中的已确认群组黑话（仅供理解，不代表回复风格）:"]
             for j in found_jargon:
-                meaning = j['meaning'] if j['meaning'] else '含义待推断'
-                lines.append(f"- 「{j['content']}」: {meaning}")
+                content = str(j.get('content') or '').strip()
+                meaning = str(j.get('meaning') or '').strip()
+                lines.append(f"- 「{content}」: {meaning}")
 
             return "\n".join(lines)
 
         except Exception as e:
             logger.error(f"检查黑话失败: {e}")
             return None
+
+    @staticmethod
+    def _contains_jargon(text: str, content: str) -> bool:
+        """判断文本是否真正命中黑话，减少子串误匹配。"""
+        if not text or not content:
+            return False
+
+        # ASCII/数字缩写使用边界匹配，避免 abc 命中 xabcx。
+        if re.fullmatch(r'[A-Za-z0-9_+-]+', content):
+            return re.search(
+                rf'(?<![A-Za-z0-9_+-]){re.escape(content)}(?![A-Za-z0-9_+-])',
+                text,
+                flags=re.IGNORECASE,
+            ) is not None
+
+        # 两字中文词太容易误命中，要求完整出现且不被更长连续中文串包裹。
+        if len(content) <= 2 and re.fullmatch(r'[\u4e00-\u9fff]+', content):
+            return re.search(
+                rf'(?<![\u4e00-\u9fff]){re.escape(content)}(?![\u4e00-\u9fff])',
+                text,
+            ) is not None
+
+        return content in text
 
 
 # LLM工具函数定义 - 可直接注册为LLM工具


### PR DESCRIPTION
## Summary

fix(database): improve sqlite compatibility and jargon safeguards


## Changes

Use dialect-aware migration SQL and include the SQLite async driver while tightening jargon learning and injection to prevent reply pollution.

-
-

## Related Issues



## Type of Change

- [ 1] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other: <!-- describe -->

## Checklist

- [ 1] Code follows the project's coding style
- [ 1] Self-reviewed the code changes
- [ 1] No new warnings or errors introduced
- [ 1] Tested on SQLite mode
- [ 1] Tested on MySQL mode (if applicable)

## Summary by Sourcery

Improve database migration compatibility across SQL dialects and strengthen jargon detection and LLM context handling to avoid reply pollution.

Bug Fixes:
- Fix schema migration column additions to use dialect-aware SQL compilation for better compatibility with SQLite and other databases.
- Adjust LLM-based jargon candidate validation to drop unvalidated candidates when the pre-gate fails or returns invalid output, reducing noise in the jargon store.

Enhancements:
- Tighten jargon matching logic to avoid substring false positives, limit duplicate and low-quality hits, and cap the number of jargon explanations returned.
- Refine jargon mining prompts and local filters to exclude common words, long phrases, and likely non-jargon terms, keeping the jargon corpus cleaner.
- Wrap jargon explanations in an explicit LLM hook context that instructs models to use them only for comprehension and not as reply style or content.

Build:
- Add the aiosqlite dependency to support async SQLite usage.