### PR TITLE
feat: default database to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ http://127.0.0.1:7833
 1. 备份当前人格。
 2. 设置学习目标：`Target_Settings.target_qq_list` 和 `target_blacklist`。
 3. 设置 Provider：`filter_provider_id`、`refine_provider_id`、`reinforce_provider_id`。
-4. 选择数据库：默认 SQLite；可切换 MySQL 或 PostgreSQL。
+4. 配置数据库：默认 PostgreSQL，会自动创建缺失数据库、schema 和表；可显式切换 SQLite 或 MySQL。
 5. 按需开启表达学习、黑话学习、自动学习、记忆图和知识图谱。
 
 Provider 未配置时插件仍可加载，但 LLM 相关功能会降级并写入日志。
@@ -248,11 +248,13 @@ WebUI 提供以下入口：
 
 | 类型 | Driver | 适用场景 |
 | --- | --- | --- |
-| SQLite | `sqlite+aiosqlite` | 默认单机部署 |
-| MySQL | `mysql+aiomysql` | 多实例或较大数据量 |
-| PostgreSQL | `postgresql+asyncpg` | 长期运行、schema 隔离、多实例部署 |
+| PostgreSQL | `postgresql+asyncpg` | 默认后端，长期运行、schema 隔离、多实例部署 |
+| SQLite | `sqlite+aiosqlite` | 显式配置的单机回退 |
+| MySQL | `mysql+aiomysql` | 显式配置的兼容后端 |
 
 数据库层使用 SQLAlchemy async ORM。`SQLAlchemyDatabaseManager` 对外保持旧接口兼容，内部通过 Domain Facade 路由到消息、学习、黑话、人格、社交、表达、心理状态、强化学习、指标和管理等领域。
+
+默认 PostgreSQL 启动时会先连接维护库 `postgres`，如果目标库不存在则创建 `astrbot_self_learning`，再创建缺失 schema 和 ORM 表。默认数据库用户需要具备创建数据库、schema 和表的权限。没有 PostgreSQL 服务时，可显式设置 `Database_Settings.db_type=sqlite` 回退到本地文件数据库。
 
 自动建表会执行：
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -190,7 +190,7 @@ Set the following key items in the AstrBot admin panel:
 - **Learning Target** — Specify user QQ IDs to learn from (leave empty to learn from everyone)
 - **Model Configuration** — Set the Provider IDs for filter and refinement models
 - **Learning Frequency** — Auto-learning interval (default: 6 hours)
-- **Database** — Supports SQLite (works out of the box), MySQL, PostgreSQL
+- **Database** — Defaults to PostgreSQL with automatic database/schema/table creation; SQLite and MySQL remain available as explicit choices
 
 More configuration options are available in the WebUI settings page.
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -485,13 +485,13 @@
   "Database_Settings": {
     "description": "数据库配置",
     "type": "object",
-    "hint": "配置数据库类型和连接参数。支持 SQLite（默认，无需配置）、MySQL 和 PostgreSQL（自动创建数据库以及数据库表）",
+    "hint": "配置数据库类型和连接参数。默认使用 PostgreSQL；插件会尝试自动创建 PostgreSQL 数据库、schema 和 ORM 表。SQLite 和 MySQL 可作为显式配置的兼容后端。",
     "items": {
       "db_type": {
         "description": "数据库类型",
         "type": "string",
-        "hint": "填写 sqlite、mysql 或 postgresql。默认使用 sqlite，适合单机部署；如需分布式部署或大规模数据，可填写 mysql 或 postgresql",
-        "default": "sqlite"
+        "hint": "填写 postgresql、pgsql、sqlite 或 mysql。默认使用 PostgreSQL，启动时会先建库和 schema，再同步 ORM 表；单机无 PostgreSQL 服务时可显式改为 sqlite",
+        "default": "postgresql"
       },
       "mysql_host": {
         "description": "MySQL服务器地址",

--- a/config.py
+++ b/config.py
@@ -182,7 +182,7 @@ class PluginConfig(BaseModel):
     enable_api_auth: bool = False # 是否启用API密钥认证
 
     # 数据库设置
-    db_type: str = "sqlite" # 数据库类型: sqlite、mysql 或 postgresql
+    db_type: str = "postgresql" # 数据库类型: postgresql、sqlite 或 mysql
 
     # MySQL 配置
     mysql_host: str = "localhost" # MySQL主机地址
@@ -223,7 +223,7 @@ class PluginConfig(BaseModel):
     goal_max_conversation_history: int = 40 # 最大对话历史（轮次*2）
 
     # 重构功能配置（新增）
-    # 强制使用 SQLAlchemy ORM：统一 SQLite 和 MySQL 的表结构定义
+    # 强制使用 SQLAlchemy ORM：统一 PostgreSQL、SQLite 和 MySQL 的表结构定义
     use_sqlalchemy: bool = True # 硬编码为 True，确保所有数据库操作使用 ORM 模型
     enable_memory_cleanup: bool = True # 启用记忆自动清理（每天凌晨3点）
     memory_cleanup_days: int = 30 # 记忆保留天数（低于阈值的旧记忆会被清理）
@@ -408,7 +408,7 @@ class PluginConfig(BaseModel):
             enable_api_auth=api_settings.get('enable_api_auth', False),
 
             # 数据库设置
-            db_type=database_settings.get('db_type', 'sqlite'),
+            db_type=database_settings.get('db_type', 'postgresql'),
             mysql_host=database_settings.get('mysql_host', 'localhost'),
             mysql_port=database_settings.get('mysql_port', 3306),
             mysql_user=database_settings.get('mysql_user', 'root'),
@@ -500,11 +500,11 @@ class PluginConfig(BaseModel):
         if normalize_log_level(self.log_level, fallback="") not in {'error', 'warning', 'info', 'debug'}:
             errors.append("日志等级必须是 error、warning、info 或 debug")
 
-        db_type = (self.db_type or 'sqlite').strip().lower()
-        if db_type in ('postgres', 'pg'):
+        db_type = (self.db_type or 'postgresql').strip().lower()
+        if db_type in ('postgres', 'pg', 'pgsql'):
             db_type = 'postgresql'
         if db_type not in {'sqlite', 'mysql', 'postgresql'}:
-            errors.append("数据库类型必须是 sqlite、mysql 或 postgresql")
+            errors.append("数据库类型必须是 postgresql、sqlite 或 mysql")
         if db_type == 'mysql' and self.mysql_port <= 0:
             errors.append("MySQL 端口必须大于0")
         if db_type == 'postgresql':

--- a/config.py
+++ b/config.py
@@ -16,6 +16,19 @@ logger = get_astrbot_logger("self_learning.config")
 
 FULL_LEARNING_TARGET_MARKERS = {"*", "all", "all_users", "all_groups", "全部", "全量", "全体", "所有"}
 DEFAULT_DATA_DIR = "./data/plugin_data/astrbot_plugin_self_learning"
+DEFAULT_DB_TYPE = "postgresql"
+SUPPORTED_DB_TYPES = {"sqlite", "mysql", "postgresql"}
+POSTGRESQL_DB_TYPE_ALIASES = {"postgres", "pg", "pgsql"}
+
+
+def normalize_db_type(db_type: Any) -> Optional[str]:
+    """Normalize configured database type, including PostgreSQL aliases."""
+    value = str(db_type or DEFAULT_DB_TYPE).strip().lower()
+    if value in POSTGRESQL_DB_TYPE_ALIASES:
+        value = DEFAULT_DB_TYPE
+    if value not in SUPPORTED_DB_TYPES:
+        return None
+    return value
 
 
 def normalize_identifier_list(value: Any, *, full_learning_markers: bool = False) -> List[str]:
@@ -182,7 +195,7 @@ class PluginConfig(BaseModel):
     enable_api_auth: bool = False # 是否启用API密钥认证
 
     # 数据库设置
-    db_type: str = "postgresql" # 数据库类型: postgresql、sqlite 或 mysql
+    db_type: str = DEFAULT_DB_TYPE # 数据库类型: postgresql、sqlite 或 mysql
 
     # MySQL 配置
     mysql_host: str = "localhost" # MySQL主机地址
@@ -408,7 +421,7 @@ class PluginConfig(BaseModel):
             enable_api_auth=api_settings.get('enable_api_auth', False),
 
             # 数据库设置
-            db_type=database_settings.get('db_type', 'postgresql'),
+            db_type=database_settings.get('db_type', DEFAULT_DB_TYPE),
             mysql_host=database_settings.get('mysql_host', 'localhost'),
             mysql_port=database_settings.get('mysql_port', 3306),
             mysql_user=database_settings.get('mysql_user', 'root'),
@@ -500,10 +513,8 @@ class PluginConfig(BaseModel):
         if normalize_log_level(self.log_level, fallback="") not in {'error', 'warning', 'info', 'debug'}:
             errors.append("日志等级必须是 error、warning、info 或 debug")
 
-        db_type = (self.db_type or 'postgresql').strip().lower()
-        if db_type in ('postgres', 'pg', 'pgsql'):
-            db_type = 'postgresql'
-        if db_type not in {'sqlite', 'mysql', 'postgresql'}:
+        db_type = normalize_db_type(self.db_type)
+        if db_type is None:
             errors.append("数据库类型必须是 postgresql、sqlite 或 mysql")
         if db_type == 'mysql' and self.mysql_port <= 0:
             errors.append("MySQL 端口必须大于0")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,9 +103,11 @@ WebUI 会按 AstrBot Provider 类型过滤选项:
 
 配置组: `Database_Settings`
 
-默认 `sqlite`，无需额外服务。MySQL 和 PostgreSQL 会尝试自动创建数据库和表。
+默认 `postgresql`。插件启动时会连接 PostgreSQL 维护库 `postgres`，自动创建缺失的目标数据库、schema 和 ORM 表。
 
 PostgreSQL 支持 `postgresql_schema`，非 `public` 时会自动创建 schema 并设置 search path。
+
+如果部署环境没有 PostgreSQL 服务，可显式设置 `db_type=sqlite` 回退到本地文件数据库。MySQL 仍作为兼容后端保留。
 
 修改以下字段需要重启:
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -13,6 +13,7 @@
 配置字段位于 `Database_Settings`:
 
 - `db_type`: `postgresql`, `pgsql`, `sqlite`, `mysql`
+  - `pgsql` 是 `postgresql` 的别名，仅用于兼容历史/外部配置，功能和行为完全相同，推荐优先使用 `postgresql`。
 - `mysql_host`, `mysql_port`, `mysql_user`, `mysql_password`, `mysql_database`
 - `postgresql_host`, `postgresql_port`, `postgresql_user`, `postgresql_password`, `postgresql_database`, `postgresql_schema`
 - `max_connections`, `min_connections`

--- a/docs/database.md
+++ b/docs/database.md
@@ -6,13 +6,13 @@
 
 | 类型 | Driver | 默认用途 |
 | --- | --- | --- |
-| SQLite | `sqlite+aiosqlite` | 默认单机部署 |
-| MySQL | `mysql+aiomysql` | 多实例或较大数据量 |
-| PostgreSQL | `postgresql+asyncpg` | 多实例、schema 隔离、长期运行 |
+| PostgreSQL | `postgresql+asyncpg` | 默认后端，多实例、schema 隔离、长期运行 |
+| SQLite | `sqlite+aiosqlite` | 显式配置的单机回退 |
+| MySQL | `mysql+aiomysql` | 显式配置的兼容后端 |
 
 配置字段位于 `Database_Settings`:
 
-- `db_type`: `sqlite`, `mysql`, `postgresql`
+- `db_type`: `postgresql`, `pgsql`, `sqlite`, `mysql`
 - `mysql_host`, `mysql_port`, `mysql_user`, `mysql_password`, `mysql_database`
 - `postgresql_host`, `postgresql_port`, `postgresql_user`, `postgresql_password`, `postgresql_database`, `postgresql_schema`
 - `max_connections`, `min_connections`
@@ -22,13 +22,41 @@
 入口: `services/database/sqlalchemy_database_manager.py::start`
 
 1. 标准化 `db_type`。
-2. 构造数据库 URL。
+2. 构造数据库 URL；未配置 `db_type` 时默认使用 PostgreSQL。
 3. MySQL: 连接服务器并创建缺失数据库。
 4. PostgreSQL: 连接 `postgres` 数据库并创建缺失数据库，再创建缺失 schema。
 5. 创建 `DatabaseEngine`。
 6. 调用 `create_tables(enable_auto_migration=True)`。
 7. 执行 `SELECT 1` 健康检查。
 8. 初始化 11 个 Facade。
+
+## 默认 PostgreSQL
+
+默认配置等价于:
+
+```json
+{
+  "Database_Settings": {
+    "db_type": "postgresql",
+    "postgresql_host": "localhost",
+    "postgresql_port": 5432,
+    "postgresql_user": "postgres",
+    "postgresql_password": "",
+    "postgresql_database": "astrbot_self_learning",
+    "postgresql_schema": "public"
+  }
+}
+```
+
+启动时会先连接维护库 `postgres`，如果 `postgresql_database` 不存在则执行 `CREATE DATABASE`；随后连接目标数据库，创建缺失 schema，最后由 SQLAlchemy ORM 同步所有表。
+
+运行默认配置的数据库用户必须具备:
+
+- 连接 `postgres` 维护库的权限。
+- 创建目标数据库的权限。
+- 在目标数据库内创建 schema 和表的权限。
+
+没有本地 PostgreSQL 服务时，可显式设置 `db_type=sqlite` 使用文件数据库。
 
 ## SQLite 路径规则
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,8 +20,8 @@ webui/blueprints/config.py
 
 依赖分两档:
 
-- `BASIC_DEPENDENCY_PACKAGES`: WebUI、SQLite、人格审查、黑话和表达方式学习所需依赖。
-- `FULL_DEPENDENCY_PACKAGES`: 基础依赖 + 数据库驱动、监控、图谱、V2 高级引擎依赖。
+- `BASIC_DEPENDENCY_PACKAGES`: WebUI、SQLite/PostgreSQL、人格审查、黑话和表达方式学习所需依赖。
+- `FULL_DEPENDENCY_PACKAGES`: 基础依赖 + MySQL 驱动、监控、图谱、V2 高级引擎依赖。
 
 ## 常用命令
 
@@ -132,7 +132,7 @@ python -m pytest tests/integration/test_package_imports.py
 2. 确认该模型被 `models/orm/__init__.py` 导入。
 3. 选择或新增 Facade 方法。
 4. 在 `SQLAlchemyDatabaseManager` 添加兼容委托方法。
-5. 为 SQLite 建表添加测试。
+5. 为默认 PostgreSQL URL、建库建表路径或显式 SQLite 回退添加测试。
 6. 对 MySQL/PostgreSQL 注意索引名全局唯一。
 
 当前迁移能力只会自动新增表和列，不支持删除列、重命名列和复杂类型迁移。复杂迁移需要显式 DDL 和回滚策略。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,8 +27,8 @@ git clone https://github.com/EterUltimate/self_learning_EterU.git astrbot_plugin
 
 | 档位 | 用途 |
 | --- | --- |
-| 基础能力依赖 | WebUI、SQLite、人格审查、黑话学习、表达方式学习 |
-| 全能力依赖 | 基础能力 + MySQL/PostgreSQL、监控指标、图谱、LightRAG、mem0 |
+| 基础能力依赖 | WebUI、SQLite/PostgreSQL、人格审查、黑话学习、表达方式学习 |
+| 全能力依赖 | 基础能力 + MySQL、监控指标、图谱、LightRAG、mem0 |
 
 依赖安装接口只接受设置页确认请求:
 
@@ -92,15 +92,9 @@ WebUI 相关配置:
 
 未配置 Provider 时插件仍可加载，但 LLM 相关功能会降级。
 
-### 4. 选择数据库
+### 4. 配置数据库
 
-默认 SQLite:
-
-```json
-{"Database_Settings": {"db_type": "sqlite"}}
-```
-
-PostgreSQL:
+默认 PostgreSQL:
 
 ```json
 {
@@ -109,9 +103,21 @@ PostgreSQL:
     "postgresql_host": "localhost",
     "postgresql_port": 5432,
     "postgresql_user": "postgres",
-    "postgresql_password": "password",
+    "postgresql_password": "",
     "postgresql_database": "astrbot_self_learning",
     "postgresql_schema": "public"
+  }
+}
+```
+
+插件会在启动时自动创建缺失的 PostgreSQL 数据库、schema 和 ORM 表。默认数据库用户需要具备连接 `postgres` 维护库、创建数据库、创建 schema 和建表权限。
+
+SQLite 回退:
+
+```json
+{
+  "Database_Settings": {
+    "db_type": "sqlite"
   }
 }
 ```

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -144,8 +144,8 @@ class SQLAlchemyDatabaseManager:
 
     def _get_db_type(self) -> str:
         """获取标准化数据库类型。"""
-        db_type = (getattr(self.config, 'db_type', 'sqlite') or 'sqlite').strip().lower()
-        if db_type in ('postgres', 'pg'):
+        db_type = (getattr(self.config, 'db_type', 'postgresql') or 'postgresql').strip().lower()
+        if db_type in ('postgres', 'pg', 'pgsql'):
             return 'postgresql'
         return db_type
 

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -15,10 +15,10 @@ from astrbot.api import logger
 from sqlalchemy.engine import URL
 
 try:
-    from ...config import PluginConfig
+    from ...config import DEFAULT_DB_TYPE, PluginConfig, normalize_db_type
     from ...core.database.engine import DatabaseEngine
 except ImportError:
-    from config import PluginConfig
+    from config import DEFAULT_DB_TYPE, PluginConfig, normalize_db_type
     from core.database.engine import DatabaseEngine
 
 
@@ -144,9 +144,10 @@ class SQLAlchemyDatabaseManager:
 
     def _get_db_type(self) -> str:
         """获取标准化数据库类型。"""
-        db_type = (getattr(self.config, 'db_type', 'postgresql') or 'postgresql').strip().lower()
-        if db_type in ('postgres', 'pg', 'pgsql'):
-            return 'postgresql'
+        raw_db_type = getattr(self.config, 'db_type', DEFAULT_DB_TYPE)
+        db_type = normalize_db_type(raw_db_type)
+        if db_type is None:
+            raise ValueError(f"不支持的数据库类型: {raw_db_type}")
         return db_type
 
     def _get_database_url(self) -> str:

--- a/tests/integration/test_config_dependency_install.py
+++ b/tests/integration/test_config_dependency_install.py
@@ -24,7 +24,12 @@ async def app():
     app = Quart(__name__)
     app.config["TESTING"] = True
     app.config["ENABLE_WEB_DEP_INSTALL"] = True
-    app.config["ALLOWED_DEPENDENCY_PACKAGES"] = ["quart", "jieba", "networkx>=3.2,<3.5"]
+    app.config["ALLOWED_DEPENDENCY_PACKAGES"] = [
+        "quart",
+        "jieba",
+        "asyncpg",
+        "networkx>=3.2,<3.5",
+    ]
     app.secret_key = "test-secret-key"
     app.register_blueprint(config_bp)
     yield app
@@ -78,6 +83,7 @@ class TestDependencyInstallEndpoint:
         assert "--no-input" in cmd
         assert "quart" in cmd
         assert "jieba" in cmd
+        assert "asyncpg" in cmd
         assert "networkx>=3.2,<3.5" in cmd
         payload = await response.get_json()
         assert payload["tier"] == "full"
@@ -105,6 +111,7 @@ class TestDependencyInstallEndpoint:
         cmd = create_process.await_args.args
         assert "quart" in cmd
         assert "jieba" in cmd
+        assert "asyncpg" in cmd
         assert "networkx>=3.2,<3.5" not in cmd
         payload = await response.get_json()
         assert payload["tier"] == "basic"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -60,7 +60,7 @@ class TestPluginConfigDefaults:
         """Test default database configuration values."""
         config = PluginConfig()
 
-        assert config.db_type == "sqlite"
+        assert config.db_type == "postgresql"
         assert config.mysql_host == "localhost"
         assert config.mysql_port == 3306
         assert config.postgresql_host == "localhost"
@@ -267,7 +267,7 @@ class TestPluginConfigFromDict:
         assert config.enable_message_capture is True
         assert config.target_qq_list == []
         assert config.learning_interval_hours == 6
-        assert config.db_type == 'sqlite'
+        assert config.db_type == 'postgresql'
 
     def test_target_list_blank_values_keep_full_learning_default(self):
         """Blank settings-page rows should not disable full learning."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,7 +14,7 @@ import tempfile
 import pytest
 from unittest.mock import patch, MagicMock
 
-from config import DEFAULT_DATA_DIR, PluginConfig
+from config import DEFAULT_DATA_DIR, DEFAULT_DB_TYPE, PluginConfig, normalize_db_type
 
 
 @pytest.mark.unit
@@ -386,6 +386,46 @@ class TestPluginConfigValidation:
         # Should have warnings but no blocking errors
         blocking_errors = [e for e in errors if not e.startswith(" ")]
         assert len(blocking_errors) == 0
+
+    @pytest.mark.parametrize(
+        "raw_db_type",
+        ["postgres", "pg", "pgsql", "postgresql", "", None],
+    )
+    def test_normalize_db_type_defaults_and_postgresql_aliases(self, raw_db_type):
+        """PostgreSQL aliases and empty values should resolve to the default type."""
+        assert normalize_db_type(raw_db_type) == DEFAULT_DB_TYPE
+
+    @pytest.mark.parametrize("alias", ["postgres", "pg", "pgsql"])
+    def test_validate_config_accepts_postgresql_aliases(self, alias):
+        """Validation accepts supported PostgreSQL aliases."""
+        config = PluginConfig(
+            db_type=alias,
+            filter_provider_id="provider_1",
+        )
+        errors = config.validate_config()
+
+        assert "数据库类型必须是 postgresql、sqlite 或 mysql" not in errors
+
+    @pytest.mark.parametrize("raw_db_type", [DEFAULT_DB_TYPE, ""])
+    def test_validate_config_accepts_default_and_empty_db_type(self, raw_db_type):
+        """Validation defaults missing or empty database type to PostgreSQL."""
+        config = PluginConfig(
+            db_type=raw_db_type,
+            filter_provider_id="provider_1",
+        )
+        errors = config.validate_config()
+
+        assert "数据库类型必须是 postgresql、sqlite 或 mysql" not in errors
+
+    def test_validate_config_rejects_invalid_db_type(self):
+        """Validation rejects unsupported database types."""
+        config = PluginConfig(
+            db_type="oracle",
+            filter_provider_id="provider_1",
+        )
+        errors = config.validate_config()
+
+        assert "数据库类型必须是 postgresql、sqlite 或 mysql" in errors
 
     def test_invalid_log_level_rejected(self):
         """Test validation catches invalid log levels."""

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import select
@@ -52,7 +53,11 @@ async def test_sqlite_create_tables_creates_all_orm_tables(tmp_path):
 async def test_database_manager_start_initializes_facades_and_learning_storage(tmp_path):
     """Runtime manager startup must create tables and load domain facades."""
     manager = SQLAlchemyDatabaseManager(
-        PluginConfig(data_dir=str(tmp_path), enable_web_interface=False)
+        PluginConfig(
+            data_dir=str(tmp_path),
+            enable_web_interface=False,
+            db_type="sqlite",
+        )
     )
 
     try:
@@ -130,7 +135,7 @@ async def test_database_manager_start_initializes_facades_and_learning_storage(t
 
 
 def test_database_manager_sqlite_url_uses_aiosqlite_and_absolute_path(tmp_path):
-    config = PluginConfig(data_dir=str(tmp_path))
+    config = PluginConfig(data_dir=str(tmp_path), db_type="sqlite")
     manager = SQLAlchemyDatabaseManager(config)
 
     url = make_url(manager._get_database_url())
@@ -138,6 +143,25 @@ def test_database_manager_sqlite_url_uses_aiosqlite_and_absolute_path(tmp_path):
     assert url.drivername == "sqlite+aiosqlite"
     assert Path(url.database).is_absolute()
     assert url.database.endswith("messages.db")
+
+
+def test_database_manager_default_url_uses_postgresql():
+    manager = SQLAlchemyDatabaseManager(PluginConfig())
+
+    url = make_url(manager._get_database_url())
+
+    assert url.drivername == "postgresql+asyncpg"
+    assert url.username == "postgres"
+    assert url.host == "localhost"
+    assert url.port == 5432
+    assert url.database == "astrbot_self_learning"
+
+
+@pytest.mark.parametrize("alias", ["postgres", "pg", "pgsql", "postgresql"])
+def test_database_manager_accepts_postgresql_aliases(alias):
+    manager = SQLAlchemyDatabaseManager(PluginConfig(db_type=alias))
+
+    assert manager._get_db_type() == "postgresql"
 
 
 def test_database_manager_postgresql_url_preserves_credentials_and_schema():
@@ -161,6 +185,57 @@ def test_database_manager_postgresql_url_preserves_credentials_and_schema():
     assert url.port == 5433
     assert url.database == "learning_db"
     assert url.query["search_path"] == "bot_space"
+
+
+@pytest.mark.asyncio
+async def test_ensure_postgresql_database_exists_creates_missing_database(monkeypatch):
+    executed = []
+
+    class FakeConnection:
+        async def fetchval(self, query, database):
+            assert query == "SELECT 1 FROM pg_database WHERE datname = $1"
+            assert database == "learning_db"
+            return None
+
+        async def execute(self, query):
+            executed.append(query)
+
+        async def close(self):
+            executed.append("closed")
+
+    async def fake_connect(**kwargs):
+        assert kwargs["host"] == "localhost"
+        assert kwargs["port"] == 5432
+        assert kwargs["user"] == "postgres"
+        assert kwargs["database"] == "postgres"
+        return FakeConnection()
+
+    manager = SQLAlchemyDatabaseManager(
+        PluginConfig(
+            db_type="postgresql",
+            postgresql_database="learning_db",
+        )
+    )
+    monkeypatch.setattr(
+        manager,
+        "_connect_postgresql",
+        lambda asyncpg, database: fake_connect(
+            host=manager.config.postgresql_host,
+            port=manager.config.postgresql_port,
+            user=manager.config.postgresql_user,
+            password=manager.config.postgresql_password,
+            database=database,
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "asyncpg",
+        SimpleNamespace(connect=fake_connect),
+    )
+
+    await manager._ensure_postgresql_database_exists()
+
+    assert executed == ['CREATE DATABASE "learning_db"', "closed"]
 
 
 def test_database_engine_normalizes_sync_postgresql_url_to_asyncpg():

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -238,6 +238,57 @@ async def test_ensure_postgresql_database_exists_creates_missing_database(monkey
     assert executed == ['CREATE DATABASE "learning_db"', "closed"]
 
 
+@pytest.mark.asyncio
+async def test_ensure_postgresql_database_exists_skips_existing_database(monkeypatch):
+    executed = []
+
+    class FakeConnection:
+        async def fetchval(self, query, database):
+            assert query == "SELECT 1 FROM pg_database WHERE datname = $1"
+            assert database == "learning_db"
+            return 1
+
+        async def execute(self, query):
+            executed.append(query)
+
+        async def close(self):
+            executed.append("closed")
+
+    async def fake_connect(**kwargs):
+        assert kwargs["host"] == "localhost"
+        assert kwargs["port"] == 5432
+        assert kwargs["user"] == "postgres"
+        assert kwargs["database"] == "postgres"
+        return FakeConnection()
+
+    manager = SQLAlchemyDatabaseManager(
+        PluginConfig(
+            db_type="pgsql",
+            postgresql_database="learning_db",
+        )
+    )
+    monkeypatch.setattr(
+        manager,
+        "_connect_postgresql",
+        lambda asyncpg, database: fake_connect(
+            host=manager.config.postgresql_host,
+            port=manager.config.postgresql_port,
+            user=manager.config.postgresql_user,
+            password=manager.config.postgresql_password,
+            database=database,
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "asyncpg",
+        SimpleNamespace(connect=fake_connect),
+    )
+
+    await manager._ensure_postgresql_database_exists()
+
+    assert executed == ["closed"]
+
+
 def test_database_engine_normalizes_sync_postgresql_url_to_asyncpg():
     normalized = DatabaseEngine._normalize_driver_url(
         "postgresql://user:pass@localhost:5432/learning_db",

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -183,6 +183,7 @@ async def test_message_pipeline_collects_to_database_and_triggers_learning_paths
 ):
     config = PluginConfig(
         data_dir=str(tmp_path),
+        db_type="sqlite",
         enable_web_interface=False,
         enable_jargon_learning=True,
         enable_expression_patterns=True,

--- a/webui/blueprints/config.py
+++ b/webui/blueprints/config.py
@@ -24,6 +24,7 @@ BASIC_DEPENDENCY_PACKAGES = [
     "pydantic",
     "sqlalchemy[asyncio]",
     "aiosqlite",
+    "asyncpg",
     "cachetools>=5.3.0",
     "apscheduler",
 ]
@@ -32,7 +33,6 @@ FULL_DEPENDENCY_PACKAGES = list(dict.fromkeys([
     *BASIC_DEPENDENCY_PACKAGES,
     "psutil",
     "aiomysql",
-    "asyncpg",
     "prometheus_client>=0.20.0",
     "prometheus-async>=22.2.0",
     "networkx>=3.2,<3.5",

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -211,9 +211,9 @@ _EXTRA_SCHEMA_DEFINITION: Dict[str, Dict[str, Any]] = {
 
 _ENUM_FIELD_OPTIONS: Dict[str, List[Dict[str, str]]] = {
     "db_type": [
+        {"value": "postgresql", "label": "PostgreSQL"},
         {"value": "sqlite", "label": "SQLite"},
         {"value": "mysql", "label": "MySQL"},
-        {"value": "postgresql", "label": "PostgreSQL"},
     ],
     "knowledge_engine": [
         {"value": "legacy", "label": "legacy"},


### PR DESCRIPTION
## Summary
- default new plugin configs to PostgreSQL and accept pg/pgsql aliases
- keep SQLite/MySQL as explicit compatibility backends and include asyncpg in basic dependency installs
- document PostgreSQL auto database/schema/table creation and add regression coverage

## Tests
- python -m pytest tests/unit/test_config.py tests/unit/test_database_engine.py tests/unit/test_config_service.py tests/unit/test_learning_chain_regressions.py tests/integration/test_config_dependency_install.py
- python -m ruff check config.py services\\database\\sqlalchemy_database_manager.py webui\\blueprints\\config.py webui\\services\\config_service.py tests\\unit\\test_config.py tests\\unit\\test_database_engine.py tests\\unit\\test_learning_chain_regressions.py tests\\integration\\test_config_dependency_install.py
- git diff --check upstream/main..HEAD

## Summary by Sourcery

Default the plugin database backend to PostgreSQL, including automatic database/schema/table creation and updated configuration, dependency tiers, and documentation to reflect PostgreSQL as the primary backend with SQLite/MySQL as explicit fallbacks.

New Features:
- Use PostgreSQL as the default database backend when no db_type is configured, with a standardized asyncpg connection URL.
- Automatically create missing PostgreSQL databases and schemas on startup before syncing ORM tables.

Enhancements:
- Normalize db_type values to accept common PostgreSQL aliases such as postgres, pg, and pgsql.
- Include asyncpg in the basic dependency tier and adjust WebUI configuration options to prioritize PostgreSQL as the primary choice.
- Keep SQLite and MySQL as explicit compatibility backends, requiring explicit selection when not using PostgreSQL.

Documentation:
- Update database and usage documentation to describe PostgreSQL as the default backend, its automatic creation behavior, and required permissions.
- Revise README, configuration, and development docs to explain the new default, fallback options to SQLite, and clarified dependency tiers for database drivers.

Tests:
- Add unit coverage for the default PostgreSQL URL, db_type alias normalization, and PostgreSQL database creation path.
- Update existing tests to explicitly configure sqlite where needed and to validate that asyncpg is installed in both basic and full dependency tiers.