### PR TITLE
fix: address database runtime regressions

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,9 +3,9 @@
 """
 import os
 import json
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, Field, ConfigDict, ValidationError, field_validator
 
 try:
     from .utils.logging_utils import apply_astrbot_log_level, get_astrbot_logger, normalize_log_level
@@ -472,6 +472,79 @@ class PluginConfig(BaseModel):
             # 传入数据目录 - 优先级：外部传入 > 配置文件 > 存储设置 > 默认值
             data_dir=data_dir if data_dir else storage_settings.get('data_dir', DEFAULT_DATA_DIR)
         )
+
+    @classmethod
+    def _flatten_config_payload(cls, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Flatten grouped config with direct fields taking precedence."""
+        grouped: Dict[str, Any] = {}
+        direct: Dict[str, Any] = {}
+        for key, value in payload.items():
+            if isinstance(value, dict) and key not in cls.model_fields:
+                nested = cls._flatten_config_payload(value)
+                duplicated = sorted(set(grouped) & set(nested))
+                if duplicated:
+                    logger.info(
+                        "持久化配置分组字段覆盖较早分组字段: "
+                        f"{', '.join(duplicated)}"
+                    )
+                grouped.update(nested)
+            else:
+                direct[key] = value
+
+        duplicated = sorted(set(grouped) & set(direct))
+        if duplicated:
+            logger.info(
+                "持久化配置顶层字段覆盖分组字段: "
+                f"{', '.join(duplicated)}"
+            )
+
+        return {**grouped, **direct}
+
+    @classmethod
+    def create_from_runtime_sources(
+        cls,
+        config: dict,
+        data_dir: Optional[str] = None,
+        config_file: Optional[str] = None,
+    ) -> 'PluginConfig':
+        """Create config from AstrBot settings and optional persisted WebUI config."""
+        runtime_config = cls.create_from_config(config or {}, data_dir=data_dir)
+        if not config_file or not os.path.exists(config_file):
+            return runtime_config
+
+        try:
+            with open(config_file, 'r', encoding='utf-8') as f:
+                persisted_data = json.load(f)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
+            logger.warning(f"读取持久化配置失败，继续使用AstrBot配置: {e}")
+            return runtime_config
+
+        if not isinstance(persisted_data, dict):
+            logger.warning("持久化配置格式无效，继续使用AstrBot配置")
+            return runtime_config
+
+        merged = runtime_config.to_dict()
+        persisted_config = cls._flatten_config_payload(persisted_data)
+        overridden = sorted(
+            key
+            for key, value in persisted_config.items()
+            if key in merged and merged[key] != value
+        )
+        if overridden:
+            logger.info(
+                "持久化配置覆盖AstrBot运行时字段: "
+                f"{', '.join(overridden)}"
+            )
+        merged.update(persisted_config)
+
+        try:
+            loaded_config = cls.model_validate(merged)
+        except ValidationError as e:
+            logger.warning(f"持久化配置校验失败，继续使用AstrBot配置: {e}")
+            return runtime_config
+
+        logger.info(f"已加载持久化插件配置: {config_file}")
+        return loaded_config
 
     @classmethod
     def create_default(cls) -> 'PluginConfig':

--- a/core/database/engine.py
+++ b/core/database/engine.py
@@ -137,7 +137,10 @@ class DatabaseEngine:
             pool_size=5,
             max_overflow=10,
             pool_recycle=3600,
-            pool_pre_ping=True,
+            # SQLAlchemy's MySQL ping path can call aiomysql.ping()
+            # without the required reconnect argument in some runtime
+            # combinations. Keep explicit health_check() as the liveness gate.
+            pool_pre_ping=False,
             connect_args={
                 'connect_timeout': 10,
                 'charset': 'utf8mb4',
@@ -145,7 +148,7 @@ class DatabaseEngine:
             }
         )
 
-        logger.debug("[DatabaseEngine] MySQL 引擎创建成功 (QueuePool, pre_ping=True)")
+        logger.debug("[DatabaseEngine] MySQL 引擎创建成功 (QueuePool, pre_ping=False)")
         return engine
 
     def _create_postgresql_engine(self):

--- a/main.py
+++ b/main.py
@@ -120,7 +120,12 @@ class SelfLearningPlugin(star.Star):
                 _migrate_legacy_data_dir(astrbot_data_path, plugin_data_dir)
 
             logger.info(f"最终插件数据目录: {plugin_data_dir}")
-            self.plugin_config = PluginConfig.create_from_config(self.config, data_dir=plugin_data_dir)
+            config_file = os.path.join(plugin_data_dir, FileNames.CONFIG_FILE)
+            self.plugin_config = PluginConfig.create_from_runtime_sources(
+                self.config,
+                data_dir=plugin_data_dir,
+                config_file=config_file,
+            )
 
             logger.info(f"[插件初始化] Provider配置已加载：")
             logger.info(f" - filter_provider_id: {self.plugin_config.filter_provider_id}")
@@ -131,7 +136,12 @@ class SelfLearningPlugin(star.Star):
             logger.error(f"初始化插件配置失败: {e}")
             default_data_dir = os.path.abspath(DEFAULT_DATA_DIR)
             logger.warning(f"使用默认数据目录: {default_data_dir}")
-            self.plugin_config = PluginConfig.create_from_config(self.config, data_dir=default_data_dir)
+            config_file = os.path.join(default_data_dir, FileNames.CONFIG_FILE)
+            self.plugin_config = PluginConfig.create_from_runtime_sources(
+                self.config,
+                data_dir=default_data_dir,
+                config_file=config_file,
+            )
 
         os.makedirs(self.plugin_config.data_dir, exist_ok=True)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -539,3 +539,101 @@ class TestPluginConfigSerialization:
             assert loaded_config.enable_message_capture is True
         finally:
             os.unlink(filepath)
+
+    def test_create_from_runtime_sources_loads_persisted_flat_config(self, tmp_path):
+        """Persisted WebUI config should override AstrBot startup defaults."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "db_type": "postgresql",
+                    "postgresql_host": "pg",
+                    "postgresql_database": "learning_db",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = PluginConfig.create_from_runtime_sources(
+            {},
+            data_dir=str(tmp_path),
+            config_file=str(config_file),
+        )
+
+        assert config.data_dir == str(tmp_path)
+        assert config.db_type == "postgresql"
+        assert config.postgresql_host == "pg"
+        assert config.postgresql_database == "learning_db"
+
+    def test_create_from_runtime_sources_loads_persisted_grouped_config(self, tmp_path):
+        """Grouped persisted config should use the same fields as AstrBot config."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "Database_Settings": {
+                        "db_type": "sqlite",
+                        "postgresql_host": "pg",
+                    },
+                    "Self_Learning_Basic": {
+                        "enable_message_capture": False,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = PluginConfig.create_from_runtime_sources(
+            {"Database_Settings": {"db_type": "postgresql"}},
+            data_dir=str(tmp_path),
+            config_file=str(config_file),
+        )
+
+        assert config.db_type == "sqlite"
+        assert config.postgresql_host == "pg"
+        assert config.enable_message_capture is False
+
+    def test_create_from_runtime_sources_top_level_overrides_grouped_config(self, tmp_path):
+        """Top-level persisted fields should win over grouped persisted fields."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "Database_Settings": {
+                        "db_type": "postgresql",
+                        "postgresql_host": "grouped-host",
+                    },
+                    "db_type": "sqlite",
+                    "postgresql_host": "top-level-host",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = PluginConfig.create_from_runtime_sources(
+            {},
+            data_dir=str(tmp_path),
+            config_file=str(config_file),
+        )
+
+        assert config.db_type == "sqlite"
+        assert config.postgresql_host == "top-level-host"
+
+    def test_create_from_runtime_sources_invalid_json_keeps_runtime_config(self, tmp_path):
+        """Malformed persisted JSON should fall back to AstrBot runtime config."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text("{not valid json", encoding="utf-8")
+
+        config = PluginConfig.create_from_runtime_sources(
+            {
+                "Database_Settings": {
+                    "db_type": "postgresql",
+                    "postgresql_host": "runtime-host",
+                }
+            },
+            data_dir=str(tmp_path),
+            config_file=str(config_file),
+        )
+
+        assert config.db_type == "postgresql"
+        assert config.postgresql_host == "runtime-host"

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -299,3 +299,29 @@ def test_database_engine_normalizes_sync_postgresql_url_to_asyncpg():
 
     assert url.drivername == "postgresql+asyncpg"
     assert url.database == "learning_db"
+
+
+def test_database_engine_mysql_uses_aiomysql_without_pool_pre_ping(monkeypatch):
+    captured = {}
+
+    def fake_create_async_engine(db_url, **kwargs):
+        captured["db_url"] = db_url
+        captured.update(kwargs)
+        return SimpleNamespace(pool=SimpleNamespace())
+
+    monkeypatch.setattr(
+        "core.database.engine.create_async_engine",
+        fake_create_async_engine,
+    )
+
+    engine = object.__new__(DatabaseEngine)
+    engine.database_url = "mysql://user:pass@localhost:3306/learning_db"
+    engine.echo = False
+
+    created = engine._create_mysql_engine()
+    url = make_url(captured["db_url"])
+
+    assert created is not None
+    assert url.drivername == "mysql+aiomysql"
+    assert captured["pool_pre_ping"] is False
+    assert captured["connect_args"]["charset"] == "utf8mb4"


### PR DESCRIPTION
## Summary
- Disable MySQL async pool pre-ping to avoid the `AsyncAdapt_aiomysql_connection.ping()` signature mismatch reported in #121.
- Load persisted WebUI/runtime config from `data_dir/config.json` during startup so database settings such as `postgresql_host` survive restart and override defaults, addressing the config path behind #122.
- Add regression tests for MySQL engine options and persisted flat/grouped config loading.

## Evidence
- #121 includes SQLAlchemy/MySQL stack traces failing at pool checkout with `AsyncAdapt_aiomysql_connection.ping() missing 1 required positional argument: 'reconnect'`.
- #122 reports PostgreSQL settings falling back to localhost after restart. This repo already persisted WebUI config to `data_dir/config.json`, but startup only rebuilt config from AstrBot settings.

## Validation
- `python -m pytest tests/unit/test_database_engine.py tests/unit/test_config.py -q`
- `python -m ruff check main.py config.py core\database\engine.py tests\unit\test_database_engine.py tests\unit\test_config.py`
- `git diff --check`

Fixes #121
Fixes #122

## Summary by Sourcery

Persist runtime plugin configuration from disk and adjust MySQL engine settings to avoid runtime regressions in database connectivity.

New Features:
- Load plugin configuration at startup from a persisted WebUI config file in the plugin data directory, overriding AstrBot defaults when valid.

Bug Fixes:
- Disable MySQL async engine pool pre-ping to avoid aiomysql ping signature mismatches in certain SQLAlchemy/runtime combinations.
- Ensure PostgreSQL and other database settings persisted in config.json survive restarts by merging them into the runtime PluginConfig.

Enhancements:
- Flatten grouped AstrBot-style configuration payloads into PluginConfig fields to support both flat and grouped persisted configs.

Tests:
- Add unit tests covering MySQL engine creation options, including disabled pool_pre_ping and charset settings.
- Add unit tests verifying loading of both flat and grouped persisted runtime configuration from config.json.