### PR TITLE
fix: guard JargonFacade delegates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 所有重要更改都将记录在此文件中。
 
+## [3.0.8] - 2026-05-26
+
+### WebUI
+
+- 修复数据库 JargonFacade 尚未初始化时 WebUI 黑话统计和黑话列表可能抛出 `NoneType.get_jargon_statistics` / `NoneType.get_jargon_count` 错误的问题。
+
+### 版本
+
+- 将插件发布版本号提升至 `3.0.8`。
+
 ## [3.0.7] - 2026-05-26
 
 ### WebUI

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 让 AstrBot 在群聊中持续采集、学习、审查并注入上下文，使 Bot 逐步具备表达风格、群组黑话、社交关系、长期记忆和人格演化能力。
 
-[![Version](https://img.shields.io/badge/version-3.0.7-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
+[![Version](https://img.shields.io/badge/version-3.0.8-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE)
 [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-3.0.7-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+[![Version](https://img.shields.io/badge/version-3.0.8-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 
 [Features](#what-we-can-do) · [Quick Start](#quick-start) · [Web UI](#visual-management-interface) · [Community](#community) · [Contributing](CONTRIBUTING.md)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 # AstrBot 自学习插件
-__version__ = "3.0.7"
+__version__ = "3.0.8"
 
 # Ensure parent namespace packages ("data", "data.plugins") are
 # durably registered in sys.modules.  AstrBot loads plugins via

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: "astrbot_plugin_self_learning"
 author: "NickMo, EterUltimate"
 display_name: "self-learning"
 description: "SELF LEARNING 自主学习插件 — 让 AI 聊天机器人自主学习对话风格、理解群组黑话、管理社交关系与好感度、自适应人格演化，像真人一样自然对话。(使用前必须手动备份人格数据)"
-version: "3.0.7"
+version: "3.0.8"
 repo: "https://github.com/NickCharlie/astrbot_plugin_self_learning"
 tags:
   - "自学习"

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -140,8 +140,13 @@ class SQLAlchemyDatabaseManager:
         self._admin = AdminFacade(self.engine, self.config)
         logger.info("[DomainRouter] 11 个领域 Facade 已初始化")
 
-    def _learning_facade_or_none(self, operation: str = ""):
-        """Return LearningFacade, recovering when the DB engine exists but facades are missing."""
+    def _facade_or_none(
+        self,
+        attr_name: str,
+        facade_name: str,
+        operation: str = "",
+    ):
+        """Return a facade, recovering when the DB engine exists but facades are missing."""
         if self._starting:
             logger.warning(
                 "[DomainRouter] 数据库仍在启动，"
@@ -156,36 +161,58 @@ class SQLAlchemyDatabaseManager:
             )
             return None
 
-        if self._learning is not None:
-            return self._learning
+        facade = getattr(self, attr_name, None)
+        if facade is not None:
+            return facade
 
         try:
             self._init_facades()
         except Exception as e:
             logger.warning(
-                f"[DomainRouter] LearningFacade 初始化失败"
+                f"[DomainRouter] {facade_name} 初始化失败"
                 f"{f' ({operation})' if operation else ''}: {e}",
                 exc_info=True,
             )
             return None
 
-        if self._learning is None:
+        facade = getattr(self, attr_name, None)
+        if facade is None:
             logger.warning(
-                "[DomainRouter] LearningFacade 不可用，"
+                f"[DomainRouter] {facade_name} 不可用，"
                 f"跳过数据库操作{f' ({operation})' if operation else ''}"
             )
-        return self._learning
+        return facade
+
+    async def _call_facade(
+        self,
+        attr_name: str,
+        facade_name: str,
+        operation: str,
+        default: Any,
+        *args,
+        **kwargs,
+    ):
+        """Call a facade method if it is ready, otherwise return default."""
+        facade = self._facade_or_none(attr_name, facade_name, operation)
+        if facade is None:
+            return default
+        method = getattr(facade, operation, None)
+        if not callable(method):
+            logger.warning(f"[DomainRouter] {facade_name} 缺少方法: {operation}")
+            return default
+        return await method(*args, **kwargs)
 
     async def _call_learning(self, operation: str, default: Any, *args, **kwargs):
         """Call a LearningFacade method if it is ready, otherwise return default."""
-        learning = self._learning_facade_or_none(operation)
-        if learning is None:
-            return default
-        method = getattr(learning, operation, None)
-        if not callable(method):
-            logger.warning(f"[DomainRouter] LearningFacade 缺少方法: {operation}")
-            return default
-        return await method(*args, **kwargs)
+        return await self._call_facade(
+            "_learning", "LearningFacade", operation, default, *args, **kwargs,
+        )
+
+    async def _call_jargon(self, operation: str, default: Any, *args, **kwargs):
+        """Call a JargonFacade method if it is ready, otherwise return default."""
+        return await self._call_facade(
+            "_jargon", "JargonFacade", operation, default, *args, **kwargs,
+        )
 
     # Infrastructure: database URL
 
@@ -742,23 +769,36 @@ class SQLAlchemyDatabaseManager:
     # Domain delegates: JargonFacade
 
     async def get_jargon(self, chat_id: str, content: str) -> Optional[Dict[str, Any]]:
-        return await self._jargon.get_jargon(chat_id, content)
+        return await self._call_jargon("get_jargon", None, chat_id, content)
 
     async def insert_jargon(self, jargon_data: Dict[str, Any]) -> Optional[int]:
-        return await self._jargon.insert_jargon(jargon_data)
+        return await self._call_jargon("insert_jargon", None, jargon_data)
 
     async def update_jargon(self, jargon_data: Dict[str, Any]) -> bool:
-        return await self._jargon.update_jargon(jargon_data)
+        return await self._call_jargon("update_jargon", False, jargon_data)
 
     async def get_jargon_statistics(self, group_id: str = None) -> Dict[str, Any]:
-        return await self._jargon.get_jargon_statistics(group_id)
+        return await self._call_jargon(
+            "get_jargon_statistics",
+            {
+                'total_candidates': 0,
+                'confirmed_jargon': 0,
+                'completed_inference': 0,
+                'total_occurrences': 0,
+                'average_count': 0,
+                'active_groups': 0,
+            },
+            group_id,
+        )
 
     async def get_recent_jargon_list(
         self, group_id: str = None, chat_id: str = None,
         limit: int = 50, offset: int = 0, only_confirmed: bool = False,
         pending_only: bool = False,
     ) -> List[Dict[str, Any]]:
-        return await self._jargon.get_recent_jargon_list(
+        return await self._call_jargon(
+            "get_recent_jargon_list",
+            [],
             group_id, chat_id, limit, offset, only_confirmed, pending_only,
         )
 
@@ -766,43 +806,62 @@ class SQLAlchemyDatabaseManager:
         self, chat_id: str = None, only_confirmed: bool = False,
         pending_only: bool = False,
     ) -> int:
-        return await self._jargon.get_jargon_count(chat_id, only_confirmed, pending_only)
+        return await self._call_jargon(
+            "get_jargon_count",
+            0,
+            chat_id,
+            only_confirmed,
+            pending_only,
+        )
 
     async def search_jargon(
         self, keyword: str, chat_id: str = None,
         confirmed_only: bool = False, limit: int = 50,
     ) -> List[Dict[str, Any]]:
-        return await self._jargon.search_jargon(
+        return await self._call_jargon(
+            "search_jargon",
+            [],
             keyword=keyword, chat_id=chat_id,
             confirmed_only=confirmed_only, limit=limit,
         )
 
     async def get_jargon_by_id(self, jargon_id: int) -> Optional[Dict[str, Any]]:
-        return await self._jargon.get_jargon_by_id(jargon_id)
+        return await self._call_jargon("get_jargon_by_id", None, jargon_id)
 
     async def delete_jargon_by_id(self, jargon_id: int) -> bool:
-        return await self._jargon.delete_jargon_by_id(jargon_id)
+        return await self._call_jargon("delete_jargon_by_id", False, jargon_id)
 
     async def set_jargon_global(self, jargon_id: int, is_global: bool) -> bool:
-        return await self._jargon.set_jargon_global(jargon_id, is_global)
+        return await self._call_jargon(
+            "set_jargon_global",
+            False,
+            jargon_id,
+            is_global,
+        )
 
     async def sync_global_jargon_to_group(self, target_chat_id: str) -> int:
-        return await self._jargon.sync_global_jargon_to_group(target_chat_id)
+        return await self._call_jargon(
+            "sync_global_jargon_to_group",
+            0,
+            target_chat_id,
+        )
 
     async def save_or_update_jargon(
         self, chat_id: str, content: str, jargon_data: Dict[str, Any],
     ) -> Optional[int]:
-        return await self._jargon.save_or_update_jargon(
+        return await self._call_jargon(
+            "save_or_update_jargon",
+            None,
             chat_id, content, jargon_data,
         )
 
     async def get_global_jargon_list(
         self, limit: int = 100,
     ) -> List[Dict[str, Any]]:
-        return await self._jargon.get_global_jargon_list(limit)
+        return await self._call_jargon("get_global_jargon_list", [], limit)
 
     async def get_jargon_groups(self) -> List[Dict[str, Any]]:
-        return await self._jargon.get_jargon_groups()
+        return await self._call_jargon("get_jargon_groups", [])
 
     # Domain delegates: PersonaFacade
 

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -8,7 +8,7 @@ DomainRouter — 薄路由层，将所有数据库方法委托给领域 Facade
 import os
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Callable, Dict, List, Optional, Any
 from contextlib import asynccontextmanager
 
 from astrbot.api import logger
@@ -142,7 +142,7 @@ class SQLAlchemyDatabaseManager:
 
     def _facade_or_none(
         self,
-        attr_name: str,
+        facade_getter: Callable[[], Any],
         facade_name: str,
         operation: str = "",
     ):
@@ -161,7 +161,7 @@ class SQLAlchemyDatabaseManager:
             )
             return None
 
-        facade = getattr(self, attr_name, None)
+        facade = facade_getter()
         if facade is not None:
             return facade
 
@@ -175,7 +175,7 @@ class SQLAlchemyDatabaseManager:
             )
             return None
 
-        facade = getattr(self, attr_name, None)
+        facade = facade_getter()
         if facade is None:
             logger.warning(
                 f"[DomainRouter] {facade_name} 不可用，"
@@ -183,9 +183,20 @@ class SQLAlchemyDatabaseManager:
             )
         return facade
 
+    @staticmethod
+    def _empty_jargon_statistics() -> Dict[str, Any]:
+        return {
+            'total_candidates': 0,
+            'confirmed_jargon': 0,
+            'completed_inference': 0,
+            'total_occurrences': 0,
+            'average_count': 0,
+            'active_groups': 0,
+        }
+
     async def _call_facade(
         self,
-        attr_name: str,
+        facade_getter: Callable[[], Any],
         facade_name: str,
         operation: str,
         default: Any,
@@ -193,7 +204,7 @@ class SQLAlchemyDatabaseManager:
         **kwargs,
     ):
         """Call a facade method if it is ready, otherwise return default."""
-        facade = self._facade_or_none(attr_name, facade_name, operation)
+        facade = self._facade_or_none(facade_getter, facade_name, operation)
         if facade is None:
             return default
         method = getattr(facade, operation, None)
@@ -205,13 +216,23 @@ class SQLAlchemyDatabaseManager:
     async def _call_learning(self, operation: str, default: Any, *args, **kwargs):
         """Call a LearningFacade method if it is ready, otherwise return default."""
         return await self._call_facade(
-            "_learning", "LearningFacade", operation, default, *args, **kwargs,
+            lambda: self._learning,
+            "LearningFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
         )
 
     async def _call_jargon(self, operation: str, default: Any, *args, **kwargs):
         """Call a JargonFacade method if it is ready, otherwise return default."""
         return await self._call_facade(
-            "_jargon", "JargonFacade", operation, default, *args, **kwargs,
+            lambda: self._jargon,
+            "JargonFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
         )
 
     # Infrastructure: database URL
@@ -780,14 +801,7 @@ class SQLAlchemyDatabaseManager:
     async def get_jargon_statistics(self, group_id: str = None) -> Dict[str, Any]:
         return await self._call_jargon(
             "get_jargon_statistics",
-            {
-                'total_candidates': 0,
-                'confirmed_jargon': 0,
-                'completed_inference': 0,
-                'total_occurrences': 0,
-                'average_count': 0,
-                'active_groups': 0,
-            },
+            self._empty_jargon_statistics(),
             group_id,
         )
 

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -352,3 +352,38 @@ async def test_learning_review_queries_recover_missing_facade_after_start(tmp_pa
         assert manager._learning is not None
     finally:
         await manager.stop()
+
+
+@pytest.mark.asyncio
+async def test_jargon_queries_return_empty_before_database_start(tmp_path):
+    manager = SQLAlchemyDatabaseManager(
+        PluginConfig(data_dir=str(tmp_path), db_type="sqlite")
+    )
+
+    assert await manager.get_jargon_statistics() == {
+        "total_candidates": 0,
+        "confirmed_jargon": 0,
+        "completed_inference": 0,
+        "total_occurrences": 0,
+        "average_count": 0,
+        "active_groups": 0,
+    }
+    assert await manager.get_jargon_count() == 0
+    assert await manager.get_recent_jargon_list() == []
+
+
+@pytest.mark.asyncio
+async def test_jargon_queries_recover_missing_facade_after_start(tmp_path):
+    manager = SQLAlchemyDatabaseManager(
+        PluginConfig(data_dir=str(tmp_path), db_type="sqlite")
+    )
+
+    try:
+        assert await manager.start() is True
+        manager._jargon = None
+
+        assert await manager.get_jargon_count() == 0
+        assert await manager.get_recent_jargon_list() == []
+        assert manager._jargon is not None
+    finally:
+        await manager.stop()

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -360,14 +360,7 @@ async def test_jargon_queries_return_empty_before_database_start(tmp_path):
         PluginConfig(data_dir=str(tmp_path), db_type="sqlite")
     )
 
-    assert await manager.get_jargon_statistics() == {
-        "total_candidates": 0,
-        "confirmed_jargon": 0,
-        "completed_inference": 0,
-        "total_occurrences": 0,
-        "average_count": 0,
-        "active_groups": 0,
-    }
+    assert await manager.get_jargon_statistics() == manager._empty_jargon_statistics()
     assert await manager.get_jargon_count() == 0
     assert await manager.get_recent_jargon_list() == []
 


### PR DESCRIPTION
## Summary
- Guard JargonFacade delegates when the database is starting, not started, or the facade is temporarily missing
- Reuse a generic facade call helper so LearningFacade keeps the previous guard behavior and JargonFacade gets the same recovery path
- Bump plugin version to 3.0.8 and document the WebUI jargon crash fix

## User-visible fix
Fixes the reported WebUI jargon errors:
- `NoneType` object has no attribute `get_jargon_statistics`
- `NoneType` object has no attribute `get_jargon_count`

## Validation
- `python -m pytest tests/unit/test_database_engine.py tests/unit/test_jargon_service.py tests/unit/test_persona_review_service.py -q`
- `python -m ruff check services/database/sqlalchemy_database_manager.py tests/unit/test_database_engine.py tests/unit/test_jargon_service.py`
- `python -m py_compile services\database\sqlalchemy_database_manager.py webui\services\jargon_service.py`
- `git diff --check`

## Summary by Sourcery

Guard database facades used by WebUI jargon features so calls are safe while the database is starting or facades are temporarily unavailable, and align JargonFacade behavior with LearningFacade.

Bug Fixes:
- Prevent WebUI jargon statistics and count queries from raising NoneType attribute errors when the JargonFacade has not been initialized or is temporarily missing.

Enhancements:
- Introduce a shared helper for safely resolving and invoking database facades and apply it to both LearningFacade and JargonFacade to support recovery when facades are missing.

Build:
- Bump the plugin version metadata from 3.0.7 to 3.0.8 across the package and plugin manifest.

Documentation:
- Document the WebUI jargon crash fix in the changelog and update version badges in both Chinese and English READMEs.

Tests:
- Add unit tests to verify jargon queries return empty results before database start and that missing JargonFacade instances are re-initialized after startup.