### PR TITLE
fix: avoid modal delete confirms in dashboard

### DIFF
--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -62,6 +62,16 @@ def test_dashboard_review_details_use_backend_structured_fields():
     assert "renderContextExamples(item)" in text
 
 
+def test_dashboard_review_deletes_use_inline_confirmation():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert "pendingConfirm: null" in text
+    assert "requireDeleteConfirmation(action, id, '审查记录')" in text
+    assert "requireDeleteConfirmation(action, id, '黑话记录')" in text
+    assert "确定删除这条审查记录" not in text
+    assert "确定删除这条黑话记录" not in text
+
+
 def test_dashboard_exposes_structured_ai_insight_panel():
     text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
 

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -2214,6 +2214,8 @@
                     busy: false,
                 },
                 actionBusy: new Set(),
+                pendingConfirm: null,
+                confirmTimer: null,
                 graph: {
                     type: 'memory',
                     layout: 'force',
@@ -3202,18 +3204,58 @@
                 }
                 const busyKey = `${action}:${id}`;
                 const busy = state.actionBusy.has(busyKey);
+                const pending = state.pendingConfirm
+                    && state.pendingConfirm.action === action
+                    && state.pendingConfirm.id === String(id);
+                const displayIcon = pending ? 'check' : icon;
+                const displayLabel = pending ? '确认删除?' : label;
+                const displayTone = pending ? 'danger' : tone;
                 return `
                     <button
-                        class="action-btn ${tone}"
+                        class="action-btn ${displayTone}"
                         type="button"
                         data-dashboard-action="${escapeHtml(action)}"
                         data-id="${escapeHtml(id)}"
                         ${busy ? 'disabled' : ''}
                     >
-                        <span class="material-icons" style="font-size:15px;">${escapeHtml(icon)}</span>
-                        <span>${escapeHtml(label)}</span>
+                        <span class="material-icons" style="font-size:15px;">${escapeHtml(displayIcon)}</span>
+                        <span>${escapeHtml(displayLabel)}</span>
                     </button>
                 `;
+            }
+
+            function resetPendingConfirm() {
+                if (state.confirmTimer) {
+                    clearTimeout(state.confirmTimer);
+                    state.confirmTimer = null;
+                }
+                state.pendingConfirm = null;
+            }
+
+            function requireDeleteConfirmation(action, id, label) {
+                const normalizedId = String(id);
+                if (
+                    state.pendingConfirm
+                    && state.pendingConfirm.action === action
+                    && state.pendingConfirm.id === normalizedId
+                ) {
+                    resetPendingConfirm();
+                    return true;
+                }
+
+                resetPendingConfirm();
+                state.pendingConfirm = { action, id: normalizedId };
+                state.confirmTimer = setTimeout(() => {
+                    resetPendingConfirm();
+                    if (state.data) {
+                        renderAll(state.data);
+                    }
+                }, 3000);
+                setQueueStatus(`再次点击确认删除${label}。`);
+                if (state.data) {
+                    renderAll(state.data);
+                }
+                return false;
             }
 
             function setQueueStatus(message, tone = '') {
@@ -4699,6 +4741,13 @@
                     return;
                 }
 
+                if (action === 'persona-delete' && !requireDeleteConfirmation(action, id, '审查记录')) {
+                    return;
+                }
+                if (action === 'jargon-delete' && !requireDeleteConfirmation(action, id, '黑话记录')) {
+                    return;
+                }
+
                 state.actionBusy.add(busyKey);
                 renderAll(state.data || {});
                 setQueueStatus('正在处理操作。');
@@ -4710,10 +4759,6 @@
                             action: action === 'persona-approve' ? 'approve' : 'reject',
                         });
                     } else if (action === 'persona-delete') {
-                        if (!window.confirm('确定删除这条审查记录？')) {
-                            setQueueStatus('已取消操作。');
-                            return;
-                        }
                         payload = await postJson(`/api/persona_updates/${encodeURIComponent(id)}/delete`);
                     } else if (action === 'jargon-approve' || action === 'jargon-reject') {
                         payload = await postJson(`/api/jargon/${encodeURIComponent(id)}/review`, {
@@ -4722,10 +4767,6 @@
                     } else if (action === 'jargon-toggle-global') {
                         payload = await postJson(`/api/jargon/${encodeURIComponent(id)}/toggle_global`);
                     } else if (action === 'jargon-delete') {
-                        if (!window.confirm('确定删除这条黑话记录？')) {
-                            setQueueStatus('已取消操作。');
-                            return;
-                        }
                         payload = await deleteJson(`/api/jargon/${encodeURIComponent(id)}`);
                     } else if (action === 'batch-relearn') {
                         payload = await postJson('/api/relearn', { group_id: id });


### PR DESCRIPTION
## Summary
- Replace review-queue delete `window.confirm` calls with an inline two-click confirmation state.
- Keep persona and jargon delete actions modal-free for AstrBot Plugin Page compatibility.
- Add a static WebUI regression test so review deletes do not reintroduce modal confirm text.

## Evidence
- Daily scan found lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory#150: its dashboard delete flow failed in AstrBot Plugin Page because confirm dialogs were blocked and deletion was immediately cancelled.
- This dashboard used the same modal confirm pattern for persona-review and jargon deletes in `web_res/static/html/dashboard.html`.

## Tests
- `python -m pytest tests\integration\test_webui_static_assets.py -q` (11 passed)
- `git diff --check`

## Summary by Sourcery

Replace dashboard review delete modal confirmations with an inline two-click confirmation flow and guard against regressions with a static asset test.

New Features:
- Add an inline two-click confirmation state for persona and jargon delete actions in the dashboard review queue.

Enhancements:
- Introduce shared pending confirmation state and timeout handling to drive inline delete confirmation button UI.

Tests:
- Add an integration test over the static dashboard HTML to ensure review delete actions use inline confirmation and no longer reference modal confirm strings.