### PR TITLE
fix: keep WebUI and plugin settings persisted

### DIFF
--- a/config.py
+++ b/config.py
@@ -324,6 +324,9 @@ class PluginConfig(BaseModel):
         goal_driven_chat_settings = config.get('Goal_Driven_Chat_Settings', {}) # 新增：目标驱动对话设置
         v2_settings = config.get('V2_Architecture_Settings', {}) # v2架构升级设置
         integration_settings = config.get('Integration_Settings', {}) # 功能融合设置
+        maibot_enhancement = config.get('MaiBot_Enhancement', {})
+        persona_evolution_settings = config.get('Persona_Evolution_Settings', {})
+        runtime_internal_settings = config.get('Runtime_Internal_Settings', {})
 
         # 添加调试日志：显示目标驱动对话配置数据
         logger.info(f" [配置加载] Goal_Driven_Chat_Settings原始数据: {goal_driven_chat_settings}")
@@ -339,6 +342,12 @@ class PluginConfig(BaseModel):
             enable_web_interface=basic_settings.get('enable_web_interface', True),
             web_interface_port=basic_settings.get('web_interface_port', 7833),
             web_interface_host=basic_settings.get('web_interface_host', '0.0.0.0'),
+
+            enable_maibot_features=maibot_enhancement.get('enable_maibot_features', True),
+            enable_expression_patterns=maibot_enhancement.get('enable_expression_patterns', True),
+            enable_memory_graph=maibot_enhancement.get('enable_memory_graph', True),
+            enable_knowledge_graph=maibot_enhancement.get('enable_knowledge_graph', True),
+            enable_time_decay=maibot_enhancement.get('enable_time_decay', True),
 
             target_qq_list=target_settings.get('target_qq_list', []),
             target_blacklist=target_settings.get('target_blacklist', []),
@@ -377,7 +386,7 @@ class PluginConfig(BaseModel):
             relevance_threshold=filter_params.get('relevance_threshold', 0.6),
 
             style_analysis_batch_size=style_analysis.get('style_analysis_batch_size', 100),
-            style_update_threshold=style_analysis.get('style_update_threshold', 0.8),
+            style_update_threshold=style_analysis.get('style_update_threshold', 0.6),
 
             # 消息统计 (这个字段通常不是从外部配置加载，而是内部维护的，这里保留默认值)
             total_messages_collected=0,
@@ -410,11 +419,26 @@ class PluginConfig(BaseModel):
             mood_change_hour=mood_settings.get('mood_change_hour', 6),
             mood_persistence_hours=mood_settings.get('mood_persistence_hours', 24),
 
-            # PersonaUpdater配置 (这些可能不是直接从 _conf_schema.json 的顶层获取，而是从其他地方或默认值)
-            persona_merge_strategy=config.get('persona_merge_strategy', 'smart'),
-            max_mood_imitation_dialogs=config.get('max_mood_imitation_dialogs', 20),
-            enable_persona_evolution=config.get('enable_persona_evolution', True),
-            persona_compatibility_threshold=config.get('persona_compatibility_threshold', 0.6),
+            # PersonaUpdater配置
+            persona_merge_strategy=persona_evolution_settings.get(
+                'persona_merge_strategy',
+                config.get('persona_merge_strategy', 'smart'),
+            ),
+            max_mood_imitation_dialogs=persona_evolution_settings.get(
+                'max_mood_imitation_dialogs',
+                config.get('max_mood_imitation_dialogs', 20),
+            ),
+            enable_persona_evolution=persona_evolution_settings.get(
+                'enable_persona_evolution',
+                config.get('enable_persona_evolution', True),
+            ),
+            persona_compatibility_threshold=persona_evolution_settings.get(
+                'persona_compatibility_threshold',
+                config.get('persona_compatibility_threshold', 0.6),
+            ),
+            use_persona_manager_updates=persona_evolution_settings.get('use_persona_manager_updates', True),
+            auto_apply_persona_updates=persona_evolution_settings.get('auto_apply_persona_updates', True),
+            persona_update_backup_enabled=persona_evolution_settings.get('persona_update_backup_enabled', True),
 
             # API设置
             api_key=api_settings.get('api_key', ''),
@@ -439,9 +463,25 @@ class PluginConfig(BaseModel):
             # 重构功能配置
             # 强制使用 SQLAlchemy ORM，忽略配置文件中的设置
             use_sqlalchemy=True, # 硬编码为 True
-            enable_memory_cleanup=advanced_settings.get('enable_memory_cleanup', True),
-            memory_cleanup_days=advanced_settings.get('memory_cleanup_days', 30),
-            memory_importance_threshold=advanced_settings.get('memory_importance_threshold', 0.3),
+            enable_memory_cleanup=runtime_internal_settings.get(
+                'enable_memory_cleanup',
+                advanced_settings.get('enable_memory_cleanup', True),
+            ),
+            memory_cleanup_days=runtime_internal_settings.get(
+                'memory_cleanup_days',
+                advanced_settings.get('memory_cleanup_days', 30),
+            ),
+            memory_importance_threshold=runtime_internal_settings.get(
+                'memory_importance_threshold',
+                advanced_settings.get('memory_importance_threshold', 0.3),
+            ),
+            shutdown_step_timeout=runtime_internal_settings.get('shutdown_step_timeout', 8),
+            task_cancel_timeout=runtime_internal_settings.get('task_cancel_timeout', 3),
+            service_stop_timeout=runtime_internal_settings.get('service_stop_timeout', 5),
+            llm_hook_injection_target=runtime_internal_settings.get(
+                'llm_hook_injection_target',
+                'system_prompt',
+            ),
 
             # 社交上下文注入设置
             enable_social_context_injection=social_context_settings.get('enable_social_context_injection', True),

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -184,6 +184,29 @@ class SQLAlchemyDatabaseManager:
         return facade
 
     @staticmethod
+    def _empty_message_statistics() -> Dict[str, Any]:
+        return {
+            'total_messages': 0,
+            'raw_messages': 0,
+            'filtered_messages': 0,
+            'bot_messages': 0,
+        }
+
+    @staticmethod
+    def _empty_expression_patterns_statistics() -> Dict[str, Any]:
+        return {
+            'total_patterns': 0,
+            'groups_with_patterns': 0,
+        }
+
+    @staticmethod
+    def _empty_trends_data() -> Dict[str, Any]:
+        return {
+            'daily_messages': {},
+            'recent_batches': [],
+        }
+
+    @staticmethod
     def _empty_jargon_statistics() -> Dict[str, Any]:
         return {
             'total_candidates': 0,
@@ -229,6 +252,50 @@ class SQLAlchemyDatabaseManager:
         return await self._call_facade(
             lambda: self._jargon,
             "JargonFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
+        )
+
+    async def _call_message(self, operation: str, default: Any, *args, **kwargs):
+        """Call a MessageFacade method if it is ready, otherwise return default."""
+        return await self._call_facade(
+            lambda: self._message,
+            "MessageFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
+        )
+
+    async def _call_expression(self, operation: str, default: Any, *args, **kwargs):
+        """Call an ExpressionFacade method if it is ready, otherwise return default."""
+        return await self._call_facade(
+            lambda: self._expression,
+            "ExpressionFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
+        )
+
+    async def _call_reinforcement(self, operation: str, default: Any, *args, **kwargs):
+        """Call a ReinforcementFacade method if it is ready, otherwise return default."""
+        return await self._call_facade(
+            lambda: self._reinforcement,
+            "ReinforcementFacade",
+            operation,
+            default,
+            *args,
+            **kwargs,
+        )
+
+    async def _call_metrics(self, operation: str, default: Any, *args, **kwargs):
+        """Call a MetricsFacade method if it is ready, otherwise return default."""
+        return await self._call_facade(
+            lambda: self._metrics,
+            "MetricsFacade",
             operation,
             default,
             *args,
@@ -558,10 +625,23 @@ class SQLAlchemyDatabaseManager:
     async def get_message_statistics(
         self, group_id: str = None,
     ) -> Dict[str, Any]:
-        return await self._message.get_message_statistics(group_id)
+        if group_id is None:
+            default = self._empty_message_statistics()
+        else:
+            default = {
+                'total_messages': 0,
+                'unprocessed_messages': 0,
+                'filtered_messages': 0,
+                'raw_messages': 0,
+                'group_id': group_id,
+            }
+        return await self._call_message("get_message_statistics", default, group_id)
 
     async def get_messages_statistics(self) -> Dict[str, Any]:
-        return await self._message.get_messages_statistics()
+        return await self._call_message(
+            "get_messages_statistics",
+            self._empty_message_statistics(),
+        )
 
     async def get_group_messages_statistics(self, group_id: str) -> Dict[str, Any]:
         return await self._message.get_group_messages_statistics(group_id)
@@ -945,7 +1025,10 @@ class SQLAlchemyDatabaseManager:
         return await self._expression.get_all_expression_patterns()
 
     async def get_expression_patterns_statistics(self) -> Dict[str, Any]:
-        return await self._expression.get_expression_patterns_statistics()
+        return await self._call_expression(
+            "get_expression_patterns_statistics",
+            self._empty_expression_patterns_statistics(),
+        )
 
     async def get_group_expression_patterns(
         self, group_id: str, limit: int = None,
@@ -1026,8 +1109,11 @@ class SQLAlchemyDatabaseManager:
     async def get_learning_performance_history(
         self, group_id: str, limit: int = 30,
     ) -> List[Dict[str, Any]]:
-        return await self._reinforcement.get_learning_performance_history(
-            group_id, limit,
+        return await self._call_reinforcement(
+            "get_learning_performance_history",
+            [],
+            group_id,
+            limit,
         )
 
     async def save_strategy_optimization_result(
@@ -1050,7 +1136,7 @@ class SQLAlchemyDatabaseManager:
         return await self._metrics.get_detailed_metrics(group_id)
 
     async def get_trends_data(self) -> Dict[str, Any]:
-        return await self._metrics.get_trends_data()
+        return await self._call_metrics("get_trends_data", self._empty_trends_data())
 
     # Domain delegates: AdminFacade
 

--- a/tests/integration/test_config_blueprint.py
+++ b/tests/integration/test_config_blueprint.py
@@ -104,3 +104,40 @@ async def test_config_schema_route_returns_groups(client):
     )
     assert data["provider_options_by_type"]["embedding"][0]["value"] == "embed-a"
     assert data["provider_options_by_type"]["rerank"][0]["value"] == "rerank-a"
+
+
+@pytest.mark.asyncio
+async def test_config_post_then_schema_refresh_returns_saved_values(client):
+    response = await client.post(
+        "/api/config",
+        json={
+            "Target_Settings": {
+                "target_qq_list": ["10001", "group_20002"],
+            },
+            "Learning_Parameters": {
+                "learning_interval_hours": 2,
+            },
+            "Integration_Settings": {
+                "delegate_memory_to_livingmemory": False,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+
+    refresh = await client.get("/api/config/schema")
+
+    assert refresh.status_code == 200
+    data = await refresh.get_json()
+    assert data["config"]["target_qq_list"] == ["10001", "group_20002"]
+    assert data["config"]["learning_interval_hours"] == 2
+    assert data["config"]["delegate_memory_to_livingmemory"] is False
+
+    fields = {
+        field["key"]: field
+        for group in data["groups"]
+        for field in group["fields"]
+    }
+    assert fields["target_qq_list"]["value"] == ["10001", "group_20002"]
+    assert fields["learning_interval_hours"]["value"] == 2
+    assert fields["delegate_memory_to_livingmemory"]["value"] is False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -260,6 +260,58 @@ class TestPluginConfigFromDict:
         assert config.group_chat_plus_plugin_name == 'CustomReply'
         assert config.disable_local_reply_when_delegated is False
 
+    def test_create_from_config_with_webui_extra_setting_groups(self):
+        """WebUI-only setting groups should survive plugin-page refresh/restart."""
+        raw_config = {
+            'MaiBot_Enhancement': {
+                'enable_maibot_features': False,
+                'enable_expression_patterns': False,
+                'enable_memory_graph': False,
+                'enable_knowledge_graph': False,
+                'enable_time_decay': False,
+            },
+            'Persona_Evolution_Settings': {
+                'persona_merge_strategy': 'append',
+                'max_mood_imitation_dialogs': 12,
+                'enable_persona_evolution': False,
+                'persona_compatibility_threshold': 0.7,
+                'use_persona_manager_updates': False,
+                'auto_apply_persona_updates': False,
+                'persona_update_backup_enabled': False,
+            },
+            'Runtime_Internal_Settings': {
+                'llm_hook_injection_target': 'prompt',
+                'enable_memory_cleanup': False,
+                'memory_cleanup_days': 14,
+                'memory_importance_threshold': 0.45,
+                'shutdown_step_timeout': 11,
+                'task_cancel_timeout': 6,
+                'service_stop_timeout': 7,
+            },
+        }
+
+        config = PluginConfig.create_from_config(raw_config, data_dir="/tmp/test")
+
+        assert config.enable_maibot_features is False
+        assert config.enable_expression_patterns is False
+        assert config.enable_memory_graph is False
+        assert config.enable_knowledge_graph is False
+        assert config.enable_time_decay is False
+        assert config.persona_merge_strategy == 'append'
+        assert config.max_mood_imitation_dialogs == 12
+        assert config.enable_persona_evolution is False
+        assert config.persona_compatibility_threshold == 0.7
+        assert config.use_persona_manager_updates is False
+        assert config.auto_apply_persona_updates is False
+        assert config.persona_update_backup_enabled is False
+        assert config.llm_hook_injection_target == 'prompt'
+        assert config.enable_memory_cleanup is False
+        assert config.memory_cleanup_days == 14
+        assert config.memory_importance_threshold == 0.45
+        assert config.shutdown_step_timeout == 11
+        assert config.task_cancel_timeout == 6
+        assert config.service_stop_timeout == 7
+
     def test_create_from_empty_config(self):
         """Test config creation from empty dict uses all defaults."""
         config = PluginConfig.create_from_config({}, data_dir="/tmp/test")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -263,6 +263,7 @@ class TestPluginConfigFromDict:
     def test_create_from_config_with_webui_extra_setting_groups(self):
         """WebUI-only setting groups should survive plugin-page refresh/restart."""
         raw_config = {
+            'persona_merge_strategy': 'replace',
             'MaiBot_Enhancement': {
                 'enable_maibot_features': False,
                 'enable_expression_patterns': False,

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -345,6 +345,10 @@ class TestConfigServiceSchema:
             "webui-saved",
         ]
 
+        await ConfigService(container).get_config_schema()
+
+        assert container.astrbot_config.save_calls == 2
+
 
 @pytest.mark.unit
 class TestConfigServiceUpdate:

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import UserDict
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -17,11 +18,25 @@ from webui.services.config_service import ConfigService
 
 class SaveableConfig(UserDict):
     def __init__(self, *args, **kwargs):
+        self.config_path = kwargs.pop("config_path", None)
         super().__init__(*args, **kwargs)
         self.save_calls = 0
+        self.saved_payloads = []
 
-    def save_config(self):
+    def save_config(self, replace_config=None):
         self.save_calls += 1
+        if replace_config is not None:
+            self.data.clear()
+            self.data.update(replace_config)
+            self.saved_payloads.append(replace_config)
+        else:
+            self.saved_payloads.append(dict(self.data))
+        if self.config_path:
+            Path(self.config_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(self.config_path).write_text(
+                json.dumps(self.data),
+                encoding="utf-8",
+            )
 
 
 def build_container(tmp_path: Path):
@@ -258,6 +273,77 @@ class TestConfigServiceSchema:
             for field in group["fields"]
         }
         assert set(PluginConfig.model_fields) <= covered_fields
+
+    @pytest.mark.asyncio
+    async def test_config_schema_refresh_imports_newer_plugin_page_config(self, tmp_path):
+        container = build_container(tmp_path)
+        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
+        container.plugin_config.save_to_file(str(config_file))
+        old_time = config_file.stat().st_mtime - 10
+        config_file.touch()
+        os.utime(config_file, (old_time, old_time))
+
+        astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
+        container.astrbot_config = SaveableConfig(
+            {
+                "Target_Settings": {
+                    "target_qq_list": ["plugin-page"],
+                    "target_blacklist": ["blocked-from-plugin"],
+                },
+                "Learning_Parameters": {
+                    "learning_interval_hours": 3,
+                    "max_messages_per_batch": container.plugin_config.max_messages_per_batch,
+                },
+            },
+            config_path=astrbot_path,
+        )
+        container.astrbot_config.save_config(dict(container.astrbot_config))
+
+        schema = await ConfigService(container).get_config_schema()
+
+        assert schema["config"]["target_qq_list"] == ["plugin-page"]
+        assert schema["config"]["target_blacklist"] == ["blocked-from-plugin"]
+        assert schema["config"]["learning_interval_hours"] == 3
+
+        fields = {
+            field["key"]: field
+            for group in schema["groups"]
+            for field in group["fields"]
+        }
+        assert fields["target_qq_list"]["value"] == ["plugin-page"]
+        assert fields["learning_interval_hours"]["value"] == 3
+
+        saved = json.loads(config_file.read_text(encoding="utf-8"))
+        assert saved["target_qq_list"] == ["plugin-page"]
+        assert saved["learning_interval_hours"] == 3
+
+    @pytest.mark.asyncio
+    async def test_config_schema_refresh_pushes_newer_webui_config_to_plugin_page(self, tmp_path):
+        container = build_container(tmp_path)
+        container.plugin_config.target_qq_list = ["webui-saved"]
+        container.plugin_config.learning_interval_hours = 4
+
+        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
+        container.plugin_config.save_to_file(str(config_file))
+
+        astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
+        container.astrbot_config.config_path = str(astrbot_path)
+        container.astrbot_config.save_config(dict(container.astrbot_config))
+        old_time = config_file.stat().st_mtime - 10
+        os.utime(astrbot_path, (old_time, old_time))
+
+        schema = await ConfigService(container).get_config_schema()
+
+        assert schema["config"]["target_qq_list"] == ["webui-saved"]
+        assert schema["config"]["learning_interval_hours"] == 4
+        assert container.astrbot_config["Target_Settings"]["target_qq_list"] == [
+            "webui-saved",
+        ]
+        assert container.astrbot_config["Learning_Parameters"]["learning_interval_hours"] == 4
+        assert container.astrbot_config.save_calls == 2
+        assert container.astrbot_config.saved_payloads[-1]["Target_Settings"]["target_qq_list"] == [
+            "webui-saved",
+        ]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -366,6 +366,20 @@ async def test_jargon_queries_return_empty_before_database_start(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_dashboard_statistics_return_empty_before_database_start(tmp_path):
+    manager = SQLAlchemyDatabaseManager(
+        PluginConfig(data_dir=str(tmp_path), db_type="sqlite")
+    )
+
+    assert await manager.get_messages_statistics() == manager._empty_message_statistics()
+    assert await manager.get_expression_patterns_statistics() == (
+        manager._empty_expression_patterns_statistics()
+    )
+    assert await manager.get_learning_performance_history("default") == []
+    assert await manager.get_trends_data() == manager._empty_trends_data()
+
+
+@pytest.mark.asyncio
 async def test_jargon_queries_recover_missing_facade_after_start(tmp_path):
     manager = SQLAlchemyDatabaseManager(
         PluginConfig(data_dir=str(tmp_path), db_type="sqlite")

--- a/tests/unit/test_webui_dependencies.py
+++ b/tests/unit/test_webui_dependencies.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+
+import pytest
+
+from webui.dependencies import ServiceContainer
+
+
+class _ServiceFactory:
+    def __init__(self):
+        self.created_database_manager = object()
+        self.create_database_manager_called = False
+
+    def create_persona_manager(self):
+        return object()
+
+    def create_database_manager(self):
+        self.create_database_manager_called = True
+        return self.created_database_manager
+
+    def create_framework_llm_adapter(self):
+        return object()
+
+    def create_progressive_learning(self):
+        return object()
+
+    def get_persona_updater(self):
+        return object()
+
+    def get_service_registry(self):
+        return object()
+
+
+class _FactoryManager:
+    def __init__(self, service_factory):
+        self.service_factory = service_factory
+
+    def get_service_factory(self):
+        return self.service_factory
+
+
+def test_service_container_uses_injected_database_manager():
+    container = ServiceContainer()
+    service_factory = _ServiceFactory()
+    injected_database_manager = object()
+    plugin_config = SimpleNamespace(data_dir="./data")
+
+    container.initialize(
+        plugin_config=plugin_config,
+        factory_manager=_FactoryManager(service_factory),
+        database_manager=injected_database_manager,
+    )
+
+    assert container.database_manager is injected_database_manager
+    assert service_factory.create_database_manager_called is False
+
+
+def test_service_container_falls_back_to_factory_database_manager():
+    container = ServiceContainer()
+    service_factory = _ServiceFactory()
+    plugin_config = SimpleNamespace(data_dir="./data")
+
+    container.initialize(
+        plugin_config=plugin_config,
+        factory_manager=_FactoryManager(service_factory),
+    )
+
+    assert container.database_manager is service_factory.created_database_manager
+    assert service_factory.create_database_manager_called is True
+
+
+@pytest.mark.asyncio
+async def test_webui_manager_passes_plugin_database_manager(monkeypatch):
+    from webui import dependencies as dependencies_module
+    from webui.manager import WebUIManager
+
+    calls = {}
+    webui_container = SimpleNamespace(perf_collector=None)
+    database_manager = object()
+    plugin_instance = SimpleNamespace(db_manager=database_manager)
+
+    async def fake_set_plugin_services(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "set_plugin_services",
+        fake_set_plugin_services,
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "get_container",
+        lambda: webui_container,
+    )
+
+    manager = WebUIManager(
+        plugin_config=SimpleNamespace(data_dir="./data"),
+        context=object(),
+        factory_manager=object(),
+        perf_tracker="perf",
+        group_id_to_unified_origin={},
+        plugin_instance=plugin_instance,
+    )
+
+    await manager._setup_services(astrbot_persona_manager=None)
+
+    assert calls["database_manager"] is database_manager
+    assert webui_container.perf_collector == "perf"

--- a/webui/dependencies.py
+++ b/webui/dependencies.py
@@ -74,6 +74,7 @@ class ServiceContainer:
         feature_delegation=None,
         astrbot_config=None,
         plugin_instance=None,
+        database_manager=None,
     ):
         """
         初始化服务容器
@@ -84,6 +85,7 @@ class ServiceContainer:
             llm_client: LLM 客户端（废弃，保留兼容性）
             astrbot_persona_manager: AstrBot 人格管理器
             group_id_to_unified_origin: group_id到unified_msg_origin映射表
+            database_manager: 已由插件生命周期启动的数据库管理器
         """
         self.plugin_config = plugin_config
         self.astrbot_config = astrbot_config
@@ -97,7 +99,11 @@ class ServiceContainer:
         # 从工厂获取服务
         service_factory = factory_manager.get_service_factory()
         self.persona_manager = service_factory.create_persona_manager()
-        self.database_manager = service_factory.create_database_manager()
+        self.database_manager = (
+            database_manager
+            if database_manager is not None
+            else service_factory.create_database_manager()
+        )
         self.llm_adapter = service_factory.create_framework_llm_adapter()
         self.progressive_learning = service_factory.create_progressive_learning()
 
@@ -208,6 +214,7 @@ async def set_plugin_services(
     feature_delegation=None,
     astrbot_config=None,
     plugin_instance=None,
+    database_manager=None,
 ):
     """
     设置插件服务（兼容原有接口）
@@ -228,6 +235,7 @@ async def set_plugin_services(
         feature_delegation=feature_delegation,
         astrbot_config=astrbot_config,
         plugin_instance=plugin_instance,
+        database_manager=database_manager,
     )
 
     logger.info(" [WebUI] 插件服务设置完成")

--- a/webui/manager.py
+++ b/webui/manager.py
@@ -43,6 +43,7 @@ class WebUIManager:
         self._feature_delegation = feature_delegation
         self._astrbot_config = astrbot_config
         self._plugin_instance = plugin_instance
+        self._database_manager = getattr(plugin_instance, "db_manager", None)
 
     # 创建
 
@@ -103,6 +104,7 @@ class WebUIManager:
     async def immediate_start(self, db_manager: Any) -> None:
         """__init__ 阶段立即启动 WebUI（通过 asyncio.create_task 调用）"""
         await asyncio.sleep(1) # 等待插件完全初始化
+        self._database_manager = db_manager
 
         global _server_instance
         if not _server_instance or not self._config.enable_web_interface:
@@ -124,7 +126,7 @@ class WebUIManager:
         # 设置 WebUI 服务
         astrbot_pm = await self._acquire_persona_manager()
         try:
-            await self._setup_services(astrbot_pm)
+            await self._setup_services(astrbot_pm, db_manager)
         except Exception as e:
             logger.error(f"设置插件服务失败: {e}", exc_info=True)
             return
@@ -152,7 +154,7 @@ class WebUIManager:
         # 设置 WebUI 服务
         astrbot_pm = await self._acquire_persona_manager()
         try:
-            await self._setup_services(astrbot_pm)
+            await self._setup_services(astrbot_pm, self._database_manager)
             logger.info("Web 服务器插件服务设置完成")
         except Exception as e:
             logger.error(f"设置 Web 服务器插件服务失败: {e}", exc_info=True)
@@ -246,9 +248,20 @@ class WebUIManager:
 
         return astrbot_persona_manager
 
-    async def _setup_services(self, astrbot_persona_manager: Any) -> None:
+    async def _setup_services(
+        self,
+        astrbot_persona_manager: Any,
+        database_manager: Any = None,
+    ) -> None:
         """调用 set_plugin_services 注册服务到 WebUI 容器"""
         from .dependencies import get_container as _get_webui_container, set_plugin_services
+
+        database_manager = database_manager or getattr(
+            self._plugin_instance,
+            "db_manager",
+            None,
+        )
+        self._database_manager = database_manager
 
         await set_plugin_services(
             plugin_config=self._config,
@@ -259,5 +272,6 @@ class WebUIManager:
             feature_delegation=self._feature_delegation,
             astrbot_config=self._astrbot_config,
             plugin_instance=self._plugin_instance,
+            database_manager=database_manager,
         )
         _get_webui_container().perf_collector = self._perf_tracker

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from astrbot.api import logger
+from pydantic import ValidationError
 
 try:
     from ...statics.messages import FileNames
@@ -295,6 +296,12 @@ class ConfigService:
             attrs = {}
         return attrs.get(name, default)
 
+    def _set_container_attr(self, name: str, value: Any) -> None:
+        try:
+            setattr(self.container, name, value)
+        except (AttributeError, TypeError):
+            logger.debug(f"写入容器属性失败: {name}", exc_info=True)
+
     def _get_config_file_path(self) -> str:
         data_dir = getattr(self.plugin_config, "data_dir", None) if self.plugin_config else None
         if isinstance(data_dir, (str, os.PathLike)) and os.fspath(data_dir):
@@ -354,6 +361,47 @@ class ConfigService:
 
         return os.path.getmtime(os.fspath(astrbot_path)) > os.path.getmtime(config_file)
 
+    @staticmethod
+    def _file_mtime_signature(path: Any) -> Optional[float]:
+        if not path:
+            return None
+        try:
+            return os.path.getmtime(os.fspath(path))
+        except OSError:
+            return None
+
+    @staticmethod
+    def _payload_signature(payload: Dict[str, Any]) -> str:
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            ensure_ascii=False,
+            default=str,
+        )
+
+    def _config_source_signature(
+        self,
+        astrbot_config: MutableMapping[str, Any],
+    ) -> Tuple[Optional[float], Optional[float], str, str]:
+        return (
+            self._file_mtime_signature(getattr(astrbot_config, "config_path", None)),
+            self._file_mtime_signature(self._get_config_file_path()),
+            self._payload_signature(self._plain_mapping(astrbot_config)),
+            self._payload_signature(self.plugin_config.to_dict()),
+        )
+
+    def _remember_config_sync_state(
+        self,
+        astrbot_config: MutableMapping[str, Any],
+    ) -> None:
+        self._set_container_attr(
+            "_config_source_sync_signature",
+            self._config_source_signature(astrbot_config),
+        )
+
+    def _forget_config_sync_state(self) -> None:
+        self._set_container_attr("_config_source_sync_signature", None)
+
     def _apply_astrbot_config_to_plugin(
         self,
         astrbot_config: MutableMapping[str, Any],
@@ -383,7 +431,7 @@ class ConfigService:
         merged_config = {**original_config, **known_config}
         try:
             validated_config = self.plugin_config.__class__.model_validate(merged_config)
-        except Exception as e:
+        except ValidationError as e:
             logger.warning(f"同步 AstrBot 插件页配置到 WebUI 失败: {e}", exc_info=True)
             return False
 
@@ -410,20 +458,29 @@ class ConfigService:
         )
         return True
 
-    def _sync_config_sources(self) -> None:
+    def _sync_config_sources(self, *, force: bool = False) -> None:
         """Keep AstrBot plugin-page config and WebUI config on the same values."""
         astrbot_config = self._get_astrbot_config()
         if not astrbot_config or not self.plugin_config:
             return
 
+        signature = self._config_source_signature(astrbot_config)
+        if (
+            not force
+            and self._get_container_attr("_config_source_sync_signature") == signature
+        ):
+            return
+
         if self._astrbot_config_is_newer(astrbot_config):
             self._apply_astrbot_config_to_plugin(astrbot_config)
+            self._remember_config_sync_state(astrbot_config)
             return
 
         self._sync_astrbot_group_config(
             self.plugin_config,
             list(self.plugin_config.to_dict()),
         )
+        self._remember_config_sync_state(astrbot_config)
 
     @staticmethod
     def _field_group_index(schema_definition: Dict[str, Any]) -> Dict[str, str]:
@@ -939,7 +996,7 @@ class ConfigService:
 
         try:
             validated_config = self.plugin_config.__class__.model_validate(merged_config)
-        except Exception as e:
+        except ValidationError as e:
             logger.error(f"配置校验失败: {e}", exc_info=True)
             return False, f"配置校验失败: {str(e)}", original_config
 
@@ -992,6 +1049,11 @@ class ConfigService:
         config_file = self._get_config_file_path()
         if not self.plugin_config.save_to_file(config_file):
             return False, "配置已更新到内存，但持久化到文件失败", self.plugin_config.to_dict()
+        astrbot_config = self._get_astrbot_config()
+        if astrbot_config:
+            self._remember_config_sync_state(astrbot_config)
+        else:
+            self._forget_config_sync_state()
 
         if changed_keys:
             logger.info(f"配置已更新: {', '.join(changed_keys)}")

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -305,6 +305,15 @@ class ConfigService:
             from config import DEFAULT_DATA_DIR
         return os.path.join(DEFAULT_DATA_DIR, FileNames.CONFIG_FILE)
 
+    def _get_astrbot_config(self) -> Optional[MutableMapping[str, Any]]:
+        astrbot_config = self._get_container_attr("astrbot_config")
+        plugin = self._get_container_attr("plugin_instance")
+        if astrbot_config is None and plugin is not None:
+            astrbot_config = getattr(plugin, "config", None)
+        if isinstance(astrbot_config, MutableMapping):
+            return astrbot_config
+        return None
+
     def _flatten_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         flat: Dict[str, Any] = {}
 
@@ -320,6 +329,100 @@ class ConfigService:
         return self._merge_schema_definitions(
             _load_schema_definition(),
             self._collect_extra_schema(),
+        )
+
+    @staticmethod
+    def _plain_mapping(mapping: MutableMapping[str, Any]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {}
+        for key, value in mapping.items():
+            if isinstance(value, MutableMapping):
+                payload[key] = dict(value)
+            else:
+                payload[key] = value
+        return payload
+
+    def _astrbot_config_is_newer(self, astrbot_config: MutableMapping[str, Any]) -> bool:
+        astrbot_path = getattr(astrbot_config, "config_path", None)
+        if not astrbot_path:
+            return False
+
+        config_file = self._get_config_file_path()
+        if not os.path.exists(os.fspath(astrbot_path)):
+            return False
+        if not os.path.exists(config_file):
+            return True
+
+        return os.path.getmtime(os.fspath(astrbot_path)) > os.path.getmtime(config_file)
+
+    def _apply_astrbot_config_to_plugin(
+        self,
+        astrbot_config: MutableMapping[str, Any],
+    ) -> bool:
+        """Pull newer AstrBot plugin-page settings into the WebUI runtime config."""
+        if not self.plugin_config:
+            return False
+
+        flat_config = self._flatten_payload(self._plain_mapping(astrbot_config))
+        known_config = {
+            key: value
+            for key, value in flat_config.items()
+            if hasattr(self.plugin_config, key)
+        }
+        if not known_config:
+            return False
+
+        original_config = self.plugin_config.to_dict()
+        changed_keys = [
+            key
+            for key, value in known_config.items()
+            if original_config.get(key) != value
+        ]
+        if not changed_keys:
+            return False
+
+        merged_config = {**original_config, **known_config}
+        try:
+            validated_config = self.plugin_config.__class__.model_validate(merged_config)
+        except Exception as e:
+            logger.warning(f"同步 AstrBot 插件页配置到 WebUI 失败: {e}", exc_info=True)
+            return False
+
+        for field_name, value in validated_config.model_dump().items():
+            if hasattr(self.plugin_config, field_name):
+                setattr(self.plugin_config, field_name, value)
+
+        if getattr(self.plugin_config, "data_dir", None):
+            self.plugin_config.messages_db_path = os.path.join(
+                self.plugin_config.data_dir, FileNames.MESSAGES_DB_FILE
+            )
+            self.plugin_config.learning_log_path = os.path.join(
+                self.plugin_config.data_dir, FileNames.LEARNING_LOG_FILE
+            )
+
+        self._sync_runtime_components(changed_keys)
+        config_file = self._get_config_file_path()
+        if not self.plugin_config.save_to_file(config_file):
+            logger.warning("AstrBot 插件页配置已同步到内存，但写入 WebUI 配置文件失败")
+
+        logger.info(
+            "AstrBot 插件页配置已同步到 WebUI: "
+            f"{', '.join(sorted(changed_keys))}"
+        )
+        return True
+
+    def _sync_config_sources(self) -> None:
+        """Keep AstrBot plugin-page config and WebUI config on the same values."""
+        astrbot_config = self._get_astrbot_config()
+        if not astrbot_config or not self.plugin_config:
+            return
+
+        if self._astrbot_config_is_newer(astrbot_config):
+            self._apply_astrbot_config_to_plugin(astrbot_config)
+            return
+
+        self._sync_astrbot_group_config(
+            self.plugin_config,
+            list(self.plugin_config.to_dict()),
         )
 
     @staticmethod
@@ -341,11 +444,8 @@ class ConfigService:
         submitted_keys: List[str],
     ) -> bool:
         """Mirror WebUI changes into AstrBot's grouped plugin-page config."""
-        astrbot_config = self._get_container_attr("astrbot_config")
-        plugin = self._get_container_attr("plugin_instance")
-        if astrbot_config is None and plugin is not None:
-            astrbot_config = getattr(plugin, "config", None)
-        if not isinstance(astrbot_config, MutableMapping):
+        astrbot_config = self._get_astrbot_config()
+        if not astrbot_config:
             return False
 
         field_to_group = self._field_group_index(self._merged_schema_definition())
@@ -357,7 +457,10 @@ class ConfigService:
             group = astrbot_config.get(group_key)
             if not isinstance(group, MutableMapping):
                 group = {}
-            group[field_name] = getattr(validated_config, field_name)
+            next_value = getattr(validated_config, field_name)
+            if group.get(field_name) == next_value:
+                continue
+            group[field_name] = next_value
             astrbot_config[group_key] = group
             synced_groups.add(group_key)
 
@@ -367,7 +470,13 @@ class ConfigService:
         save_config = getattr(astrbot_config, "save_config", None)
         if callable(save_config):
             try:
-                save_config()
+                save_config(self._plain_mapping(astrbot_config))
+            except TypeError:
+                try:
+                    save_config()
+                except Exception as e:
+                    logger.warning(f"同步 AstrBot 插件页配置失败: {e}", exc_info=True)
+                    return False
             except Exception as e:
                 logger.warning(f"同步 AstrBot 插件页配置失败: {e}", exc_info=True)
                 return False
@@ -771,6 +880,7 @@ class ConfigService:
             Dict: 插件配置字典
         """
         if self.plugin_config:
+            self._sync_config_sources()
             return self.plugin_config.to_dict()
         raise ValueError("Plugin config not initialized")
 
@@ -779,6 +889,7 @@ class ConfigService:
         if not self.plugin_config:
             raise ValueError("Plugin config not initialized")
 
+        self._sync_config_sources()
         merged_schema = self._merged_schema_definition()
 
         return {


### PR DESCRIPTION
## Summary
- load persisted WebUI `config.json` values on plugin startup so refreshed settings are not reset to AstrBot defaults
- reconcile WebUI `config.json` and AstrBot plugin-page grouped config before `/api/config` and `/api/config/schema` reads
- persist WebUI-origin values back through AstrBot plugin config and add regressions for both sync directions

## Testing
- `python -m pytest tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py -q`
- `python -m ruff check webui/services/config_service.py tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py`
- `python -m py_compile config.py webui\services\config_service.py tests\unit\test_config_service.py tests\integration\test_config_blueprint.py tests\unit\test_config.py`
- `git diff --check -- config.py webui/services/config_service.py tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py`

## Summary by Sourcery

Keep WebUI and AstrBot plugin-page configuration in sync so user settings persist across refreshes and restarts.

Bug Fixes:
- Ensure WebUI config values loaded from config.json are preserved instead of being reset to AstrBot defaults after refresh or restart.
- Synchronize newer settings between WebUI config and AstrBot grouped plugin config in both directions based on modification times.
- Avoid unnecessary AstrBot config writes when values have not changed and handle save_config APIs that accept or ignore replacement payloads.

Enhancements:
- Introduce support for additional WebUI-only setting groups (MaiBot enhancement, persona evolution, and runtime internal settings) when creating PluginConfig from raw config.
- Adjust default style_update_threshold to better align with updated configuration behavior.

Tests:
- Add unit tests covering bidirectional sync between WebUI config and AstrBot plugin-page config, including timestamp precedence and persistence to disk.
- Extend config creation tests to validate handling of new WebUI-only setting groups and their fields.
- Add integration test to verify that posting config via /api/config and then reading /api/config/schema returns the saved values.