### PR TITLE
fix: use plain log level schema options

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -233,22 +233,10 @@
         "hint": "控制插件在 AstrBot 日志中的详细程度。error 最少，debug 最多",
         "default": "info",
         "options": [
-          {
-            "value": "error",
-            "label": "error"
-          },
-          {
-            "value": "warning",
-            "label": "warning"
-          },
-          {
-            "value": "info",
-            "label": "info"
-          },
-          {
-            "value": "debug",
-            "label": "debug"
-          }
+          "error",
+          "warning",
+          "info",
+          "debug"
         ]
       },
       "save_raw_messages": {

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -128,6 +128,16 @@ def build_container(tmp_path: Path):
 
 @pytest.mark.unit
 class TestConfigServiceSchema:
+    def test_astrbot_plugin_schema_uses_plain_log_level_options(self):
+        """AstrBot plugin page renders object options as [object Object]."""
+        schema_path = Path(__file__).resolve().parents[2] / "_conf_schema.json"
+        schema = json.loads(schema_path.read_text(encoding="utf-8"))
+
+        options = schema["Advanced_Settings"]["items"]["log_level"]["options"]
+
+        assert options == ["error", "warning", "info", "debug"]
+        assert all(isinstance(option, str) for option in options)
+
     @pytest.mark.asyncio
     async def test_get_config_schema_includes_full_settings(self, tmp_path):
         container = build_container(tmp_path)


### PR DESCRIPTION
## Summary
- change AstrBot plugin-page `log_level` options to plain strings so the settings page no longer renders `[object Object]`
- keep the WebUI schema path covered by existing label/value option tests
- add a regression test for plugin-page schema compatibility

## Validation
- `python -m pytest tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py -q`
- `python -m ruff check tests/unit/test_config_service.py webui/services/config_service.py`
- `python -m py_compile webui\services\config_service.py tests\unit\test_config_service.py tests\integration\test_config_blueprint.py tests\unit\test_config.py`
- `git diff --check -- _conf_schema.json tests/unit/test_config_service.py`

## Summary by Sourcery

Ensure AstrBot plugin log level configuration uses plain string options compatible with the Web UI settings page.

Bug Fixes:
- Fix AstrBot plugin log level options so they render correctly instead of showing object representations in the settings UI.

Tests:
- Add a unit test verifying the AstrBot plugin log_level schema uses plain string options in the shared configuration schema.