### PR TITLE
fix: prefer grouped plugin settings in webui sync

### DIFF
--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -328,6 +328,46 @@ class TestConfigServiceSchema:
         assert saved["learning_interval_hours"] == 3
 
     @pytest.mark.asyncio
+    async def test_config_schema_refresh_prefers_grouped_realtime_plugin_page_values(self, tmp_path):
+        container = build_container(tmp_path)
+        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
+        container.plugin_config.save_to_file(str(config_file))
+        old_time = config_file.stat().st_mtime - 10
+        config_file.touch()
+        os.utime(config_file, (old_time, old_time))
+
+        astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
+        container.astrbot_config = SaveableConfig(
+            {
+                "Self_Learning_Basic": {
+                    "enable_realtime_learning": True,
+                    "enable_realtime_llm_filter": True,
+                },
+                "enable_realtime_learning": False,
+                "enable_realtime_llm_filter": False,
+            },
+            config_path=astrbot_path,
+        )
+        container.astrbot_config.save_config(dict(container.astrbot_config))
+
+        schema = await ConfigService(container).get_config_schema()
+
+        assert schema["config"]["enable_realtime_learning"] is True
+        assert schema["config"]["enable_realtime_llm_filter"] is True
+
+        fields = {
+            field["key"]: field
+            for group in schema["groups"]
+            for field in group["fields"]
+        }
+        assert fields["enable_realtime_learning"]["value"] is True
+        assert fields["enable_realtime_llm_filter"]["value"] is True
+
+        saved = json.loads(config_file.read_text(encoding="utf-8"))
+        assert saved["enable_realtime_learning"] is True
+        assert saved["enable_realtime_llm_filter"] is True
+
+    @pytest.mark.asyncio
     async def test_config_schema_refresh_pushes_newer_webui_config_to_plugin_page(self, tmp_path):
         container = build_container(tmp_path)
         container.plugin_config.target_qq_list = ["webui-saved"]

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -322,15 +322,17 @@ class ConfigService:
         return None
 
     def _flatten_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        flat: Dict[str, Any] = {}
+        grouped: Dict[str, Any] = {}
+        direct: Dict[str, Any] = {}
 
         for key, value in payload.items():
             if isinstance(value, dict):
-                flat.update(self._flatten_payload(value))
+                grouped.update(self._flatten_payload(value))
             else:
-                flat[key] = value
+                direct[key] = value
 
-        return flat
+        # AstrBot's grouped plugin-page config is authoritative over stale top-level compatibility keys.
+        return {**direct, **grouped}
 
     def _merged_schema_definition(self) -> Dict[str, Any]:
         return self._merge_schema_definitions(


### PR DESCRIPTION
## Summary
- Fix WebUI config import so grouped AstrBot plugin settings override stale top-level compatibility fields.
- Keeps `enable_realtime_learning` and `enable_realtime_llm_filter` synced when the plugin settings page has them enabled.
- Adds a regression test for the grouped realtime toggle import path.

## Validation
- `python -m pytest tests/unit/test_config_service.py::TestConfigServiceSchema::test_config_schema_refresh_prefers_grouped_realtime_plugin_page_values tests/unit/test_config_service.py::TestConfigServiceSchema::test_config_schema_refresh_imports_newer_plugin_page_config tests/integration/test_config_blueprint.py -q`
- `python -m pytest tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py -q`
- `python -m ruff check webui/services/config_service.py tests/unit/test_config_service.py tests/integration/test_config_blueprint.py tests/unit/test_config.py`
- `python -m py_compile webui\services\config_service.py tests\unit\test_config_service.py tests\integration\test_config_blueprint.py tests\unit\test_config.py`
- `git diff --check -- webui/services/config_service.py tests/unit/test_config_service.py`

## Summary by Sourcery

Ensure WebUI config import prefers grouped AstrBot realtime plugin settings over outdated top-level fields.

Bug Fixes:
- Fix config payload flattening so grouped plugin settings override legacy top-level realtime flags when syncing WebUI config.

Tests:
- Add regression test verifying grouped realtime AstrBot plugin page values are preferred and correctly persisted during config schema refresh.