### PR TITLE
fix: tolerate duplicate expression patterns

### DIFF
--- a/services/analysis/expression_pattern_learner.py
+++ b/services/analysis/expression_pattern_learner.py
@@ -286,7 +286,7 @@ class ExpressionPatternLearner:
     async def _save_expression_patterns(self, patterns: List[ExpressionPattern], group_id: str):
         """保存表达模式到数据库（ORM 版本）"""
         try:
-            from sqlalchemy import select
+            from sqlalchemy import desc, select
             from ...models.orm.expression import ExpressionPattern as ExpressionPatternORM
 
             async with self.db_manager.get_session() as session:
@@ -296,9 +296,20 @@ class ExpressionPatternLearner:
                         ExpressionPatternORM.situation == pattern.situation,
                         ExpressionPatternORM.expression == pattern.expression,
                         ExpressionPatternORM.group_id == group_id,
+                    ).order_by(
+                        desc(ExpressionPatternORM.weight),
+                        desc(ExpressionPatternORM.last_active_time),
+                        desc(ExpressionPatternORM.id),
                     )
                     result = await session.execute(stmt)
-                    existing = result.scalar_one_or_none()
+                    matches = list(result.scalars().all())
+                    existing = matches[0] if matches else None
+                    if len(matches) > 1:
+                        logger.warning(
+                            "发现重复表达模式记录，已复用权重最高记录: "
+                            f"group_id={group_id}, situation={pattern.situation!r}, "
+                            f"expression={pattern.expression!r}, count={len(matches)}"
+                        )
 
                     if existing:
                         # 更新现有模式，权重增加，50%概率替换内容

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import select
 
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -24,6 +25,13 @@ from self_learning_EterU.services.core_learning.message_collector import (
 )
 from self_learning_EterU.services.database.sqlalchemy_database_manager import (
     SQLAlchemyDatabaseManager,
+)
+from self_learning_EterU.models.orm.expression import (
+    ExpressionPattern as ExpressionPatternORM,
+)
+from self_learning_EterU.services.analysis.expression_pattern_learner import (
+    ExpressionPattern,
+    ExpressionPatternLearner,
 )
 from self_learning_EterU.services.integration.maibot_enhanced_learning_manager import (
     MaiBotEnhancedLearningManager,
@@ -341,6 +349,91 @@ async def test_message_pipeline_collects_to_database_and_triggers_learning_paths
     finally:
         if spawned:
             await asyncio.gather(*spawned, return_exceptions=True)
+        await db.stop()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_expression_pattern_save_handles_duplicate_existing_rows(tmp_path):
+    config = PluginConfig(
+        data_dir=str(tmp_path),
+        db_type="sqlite",
+        enable_web_interface=False,
+    )
+    db = SQLAlchemyDatabaseManager(config)
+
+    try:
+        assert await db.start() is True
+        async with db.get_session() as session:
+            session.add_all(
+                [
+                    ExpressionPatternORM(
+                        situation="今晚安排",
+                        expression="偷偷刷视频",
+                        weight=1.0,
+                        last_active_time=10.0,
+                        create_time=1.0,
+                        group_id="group-a",
+                    ),
+                    ExpressionPatternORM(
+                        situation="今晚安排",
+                        expression="偷偷刷视频",
+                        weight=3.0,
+                        last_active_time=20.0,
+                        create_time=2.0,
+                        group_id="group-a",
+                    ),
+                ]
+            )
+            await session.commit()
+            rows_before = (
+                await session.execute(
+                    select(ExpressionPatternORM).where(
+                        ExpressionPatternORM.group_id == "group-a",
+                        ExpressionPatternORM.situation == "今晚安排",
+                        ExpressionPatternORM.expression == "偷偷刷视频",
+                    )
+                )
+            ).scalars().all()
+
+        assert len(rows_before) == 2
+        original_ids = {row.id for row in rows_before}
+        strongest_before_id = max(rows_before, key=lambda row: row.weight).id
+
+        learner = ExpressionPatternLearner.__new__(ExpressionPatternLearner)
+        learner.db_manager = db
+
+        await learner._save_expression_patterns(
+            [
+                ExpressionPattern(
+                    situation="今晚安排",
+                    expression="偷偷刷视频",
+                    weight=1.0,
+                    last_active_time=30.0,
+                    create_time=30.0,
+                    group_id="group-a",
+                )
+            ],
+            "group-a",
+        )
+
+        async with db.get_session() as session:
+            rows = (
+                await session.execute(
+                    select(ExpressionPatternORM).where(
+                        ExpressionPatternORM.group_id == "group-a",
+                        ExpressionPatternORM.situation == "今晚安排",
+                        ExpressionPatternORM.expression == "偷偷刷视频",
+                    )
+                )
+            ).scalars().all()
+
+        assert len(rows) == 2
+        assert {row.id for row in rows} == original_ids
+        strongest_after = max(rows, key=lambda row: row.weight)
+        assert strongest_after.id == strongest_before_id
+        assert strongest_after.weight == 4.0
+    finally:
         await db.stop()
 
 


### PR DESCRIPTION
## Summary
- Fixes #133 by making expression-pattern saves tolerate duplicate existing rows instead of raising `MultipleResultsFound`.
- Reuses the strongest existing row (weight, last active time, id) when duplicates are present and logs a warning for cleanup visibility.
- Adds a regression test that inserts duplicate expression pattern rows and verifies saving continues without deleting user data.

## Evidence
- Issue #133 reports MySQL logs from plugin version 3.0.8 showing `sqlalchemy.exc.MultipleResultsFound` at `services/analysis/expression_pattern_learner.py` while saving expression patterns.
- Current `upstream/main` still used `result.scalar_one_or_none()` for `(group_id, situation, expression)`, which reproduces that failure when duplicates already exist.

## Validation
- `python -m pytest tests\unit\test_learning_chain_regressions.py::test_expression_pattern_save_handles_duplicate_existing_rows -q`
- `python -m pytest tests\unit\test_learning_chain_regressions.py -q` (16 passed)
- `python -m ruff check services/analysis/expression_pattern_learner.py tests/unit/test_learning_chain_regressions.py`
- `python -m py_compile services\analysis\expression_pattern_learner.py tests\unit\test_learning_chain_regressions.py`
- `git diff --check -- services/analysis/expression_pattern_learner.py tests/unit/test_learning_chain_regressions.py`

## Summary by Sourcery

Handle duplicate expression pattern rows when saving and add regression coverage for this scenario.

Bug Fixes:
- Ensure saving expression patterns tolerates duplicate existing rows instead of failing on multiple matches.

Tests:
- Add a regression test verifying expression pattern saving logic preserves duplicate rows and correctly aggregates weights when duplicates exist.