### PR TITLE
fix: filter plugin runtime logs from learning samples

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,10 @@ from astrbot.core.utils.astrbot_path import get_astrbot_data_path
 from .config import DEFAULT_DATA_DIR, PluginConfig
 from .core.plugin_lifecycle import PluginLifecycle
 from .services.hooks.perf_tracker import PerfTracker
-from .services.learning.sample_filter import should_ignore_learning_sample
+from .services.learning.sample_filter import (
+    extract_learning_event_metadata,
+    should_ignore_learning_sample,
+)
 from .statics.messages import StatusMessages, FileNames
 
 
@@ -268,7 +271,12 @@ class SelfLearningPlugin(star.Star):
 
             group_id = event.get_group_id() or event.get_sender_id()
             sender_id = event.get_sender_id()
-            if should_ignore_learning_sample(message_text, sender_id=sender_id):
+            event_metadata = extract_learning_event_metadata(event)
+            if should_ignore_learning_sample(
+                message_text,
+                sender_id=sender_id,
+                **event_metadata,
+            ):
                 logger.debug(f"检测到指令或系统模板消息，跳过学习数据收集: {message_text[:80]}")
                 self._log_message_capture_diag("skip:system_or_command_sample", event, message_text)
                 return

--- a/services/core_learning/message_collector.py
+++ b/services/core_learning/message_collector.py
@@ -54,6 +54,14 @@ class MessageCollectorService:
             if should_ignore_learning_sample(
                 message_data.get('message', ''),
                 sender_id=message_data.get('sender_id'),
+                source=message_data.get('source'),
+                message_type=message_data.get('message_type'),
+                event_type=message_data.get('event_type'),
+                post_type=message_data.get('post_type'),
+                sub_type=message_data.get('sub_type'),
+                notice_type=message_data.get('notice_type'),
+                plugin_name=message_data.get('plugin_name'),
+                metadata=message_data.get('metadata'),
             ):
                 logger.debug(
                     "检测到指令或系统模板消息，跳过保存学习样本: "

--- a/services/core_learning/message_collector.py
+++ b/services/core_learning/message_collector.py
@@ -20,7 +20,10 @@ except ImportError:
     from ...core.interfaces import MessageData
 
 from ..database import DatabaseManager
-from ..learning.sample_filter import should_ignore_learning_sample
+from ..learning.sample_filter import (
+    extract_learning_message_metadata,
+    should_ignore_learning_sample,
+)
 
 
 class MessageCollectorService:
@@ -51,17 +54,11 @@ class MessageCollectorService:
                     logger.warning(f"消息数据缺少必要字段: {field}")
                     return False
 
+            metadata = extract_learning_message_metadata(message_data)
             if should_ignore_learning_sample(
                 message_data.get('message', ''),
                 sender_id=message_data.get('sender_id'),
-                source=message_data.get('source'),
-                message_type=message_data.get('message_type'),
-                event_type=message_data.get('event_type'),
-                post_type=message_data.get('post_type'),
-                sub_type=message_data.get('sub_type'),
-                notice_type=message_data.get('notice_type'),
-                plugin_name=message_data.get('plugin_name'),
-                metadata=message_data.get('metadata'),
+                **metadata,
             ):
                 logger.debug(
                     "检测到指令或系统模板消息，跳过保存学习样本: "

--- a/services/learning/message_pipeline.py
+++ b/services/learning/message_pipeline.py
@@ -7,7 +7,11 @@ from astrbot.api import logger
 
 from ...core.interfaces import MessageData
 from ...statics.messages import LogMessages
-from .sample_filter import filter_learning_messages, should_ignore_learning_sample
+from .sample_filter import (
+    extract_learning_event_metadata,
+    filter_learning_messages,
+    should_ignore_learning_sample,
+)
 
 
 class MessagePipeline:
@@ -60,7 +64,12 @@ class MessagePipeline:
         """
         message_collected = False
         try:
-            if should_ignore_learning_sample(message_text, sender_id=sender_id):
+            event_metadata = extract_learning_event_metadata(event)
+            if should_ignore_learning_sample(
+                message_text,
+                sender_id=sender_id,
+                **event_metadata,
+            ):
                 logger.debug(
                     "检测到指令或系统模板消息，跳过学习流水线: "
                     f"{message_text[:80]}"
@@ -77,6 +86,7 @@ class MessagePipeline:
                         "group_id": group_id,
                         "timestamp": time.time(),
                         "platform": event.get_platform_name(),
+                        **event_metadata,
                     }
                 ))
             except RuntimeError as e:

--- a/services/learning/sample_filter.py
+++ b/services/learning/sample_filter.py
@@ -1,9 +1,9 @@
-"""Learning-sample filters for command and framework-generated messages."""
+"""Learning-sample filters for command, framework, and runtime log messages."""
 
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 
 COMMAND_PREFIXES = ("/", "!", "#", ".")
@@ -29,9 +29,225 @@ SYSTEM_RESPONSE_PATTERNS = (
     ),
 )
 
+NON_CHAT_EVENT_VALUES = {
+    "notice",
+    "request",
+    "meta_event",
+    "system",
+    "system_event",
+    "log",
+    "logger",
+    "runtime_log",
+    "plugin_log",
+    "plugin_output",
+    "console",
+    "lifecycle",
+    "heartbeat",
+    "status",
+}
+CHAT_EVENT_VALUES = {
+    "message",
+    "group",
+    "friend",
+    "private",
+    "group_message",
+    "friend_message",
+    "private_message",
+    "normal",
+}
+SOURCE_LOG_VALUES = {
+    "log",
+    "logger",
+    "runtime_log",
+    "plugin_log",
+    "plugin_output",
+    "console",
+    "system",
+}
+METADATA_FIELD_NAMES = (
+    "source",
+    "message_type",
+    "event_type",
+    "post_type",
+    "sub_type",
+    "notice_type",
+    "plugin_name",
+)
+
+LOG_LEVEL_PATTERN = r"(?:TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL)"
+PLUGIN_RUNTIME_CONTEXT_PATTERN = (
+    r"(?:LivingMemory|astrbot_plugin_livingmemory|MemoryEngine|"
+    r"ConversationManager|FaissVecDB|FAISS|BM25|WebUI|"
+    r"EventHandler|ConversationStore|MemoryProcessor)"
+)
+PLUGIN_RUNTIME_ACTION_PATTERN = (
+    r"(?:初始化|启动|停止|关闭|退出|失败|异常|成功|超时|耗时|"
+    r"重建|索引|检索|同步|清空|清理|连接|写入|删除|更新|回滚)"
+)
+CONVERSATIONAL_CUE_PATTERN = re.compile(
+    r"(?:\?|？|吗|呢|为什么|怎么|如何|什么时候|能不能|是不是|可以|有人|我|你)"
+)
+PLUGIN_LOG_PATTERNS = (
+    re.compile(
+        rf"^\s*(?:\[[^\]]+\]\s*){{0,3}}\[[^\]]*(?:{LOG_LEVEL_PATTERN})[^\]]*\].*"
+        rf"(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"^\s*(?:\d{{4}}-\d{{2}}-\d{{2}}[ T]\d{{2}}:\d{{2}}:\d{{2}}"
+        rf"(?:[.,]\d+)?|\d{{2}}:\d{{2}}:\d{{2}}(?:[.,]\d+)?)\s+"
+        rf"{LOG_LEVEL_PATTERN}\b.*(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        rf"^\s*(?:\[[^\]]*(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})[^\]]*\]\s*)?"
+        rf"(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})\b.*"
+        rf"(?:{PLUGIN_RUNTIME_ACTION_PATTERN})",
+        re.IGNORECASE,
+    ),
+)
+
 
 def _normalize_text(message_text: Any) -> str:
     return "" if message_text is None else str(message_text).strip()
+
+
+def _metadata_values(value: Any) -> List[str]:
+    if value is None:
+        return []
+
+    values: List[str] = []
+    for attr in ("value", "name"):
+        attr_value = getattr(value, attr, None)
+        if attr_value is not None and attr_value is not value:
+            values.append(str(attr_value))
+    values.append(str(value))
+    return [item.strip().lower() for item in values if str(item).strip()]
+
+
+def _normalize_metadata_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _is_chat_event_value(value: Any) -> bool:
+    for raw in _metadata_values(value):
+        token = _normalize_metadata_token(raw)
+        if token in CHAT_EVENT_VALUES:
+            return True
+        if any(chat_token in token for chat_token in (
+            "group_message",
+            "friend_message",
+            "private_message",
+        )):
+            return True
+    return False
+
+
+def _is_non_chat_event_value(value: Any) -> bool:
+    if value is None or _is_chat_event_value(value):
+        return False
+
+    for raw in _metadata_values(value):
+        token = _normalize_metadata_token(raw)
+        if token in NON_CHAT_EVENT_VALUES:
+            return True
+        token_parts = {part for part in token.split("_") if part}
+        if token_parts & NON_CHAT_EVENT_VALUES:
+            return True
+    return False
+
+
+def _is_log_source(value: Any) -> bool:
+    if value is None:
+        return False
+
+    for raw in _metadata_values(value):
+        token = _normalize_metadata_token(raw)
+        if token in SOURCE_LOG_VALUES:
+            return True
+        token_parts = {part for part in token.split("_") if part}
+        if token_parts & SOURCE_LOG_VALUES:
+            return True
+    return False
+
+
+def has_system_event_metadata(
+    *,
+    source: Any = None,
+    message_type: Any = None,
+    event_type: Any = None,
+    post_type: Any = None,
+    sub_type: Any = None,
+    notice_type: Any = None,
+    plugin_name: Any = None,
+    metadata: Any = None,
+) -> bool:
+    """Return true when structured event fields identify non-chat output."""
+    if any(
+        _is_non_chat_event_value(value)
+        for value in (message_type, event_type, post_type, sub_type, notice_type)
+    ):
+        return True
+
+    if _is_log_source(source):
+        return True
+
+    if _is_log_source(plugin_name) and (
+        event_type is not None or post_type is not None or message_type is not None
+    ):
+        return True
+
+    if isinstance(metadata, dict):
+        return has_system_event_metadata(
+            source=metadata.get("source", source),
+            message_type=metadata.get("message_type", message_type),
+            event_type=metadata.get("event_type", event_type),
+            post_type=metadata.get("post_type", post_type),
+            sub_type=metadata.get("sub_type", sub_type),
+            notice_type=metadata.get("notice_type", notice_type),
+            plugin_name=metadata.get("plugin_name", plugin_name),
+        )
+
+    return False
+
+
+def extract_learning_event_metadata(event: Any) -> Dict[str, Any]:
+    """Extract optional event metadata used by sample filtering."""
+    if event is None:
+        return {}
+
+    metadata: Dict[str, Any] = {}
+    method_map = {
+        "message_type": "get_message_type",
+        "event_type": "get_event_type",
+        "source": "get_source",
+    }
+    for key, method_name in method_map.items():
+        method = getattr(event, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            value = method()
+        except Exception:
+            continue
+        if value is not None:
+            metadata[key] = value
+
+    for key in METADATA_FIELD_NAMES:
+        if key in metadata:
+            continue
+        value = getattr(event, key, None)
+        if value is not None:
+            metadata[key] = value
+
+    raw_event = getattr(event, "raw_event", None) or getattr(event, "raw", None)
+    if isinstance(raw_event, dict):
+        metadata["metadata"] = raw_event
+        for key in METADATA_FIELD_NAMES:
+            if key not in metadata and raw_event.get(key) is not None:
+                metadata[key] = raw_event.get(key)
+
+    return metadata
 
 
 def is_command_message(message_text: Any) -> bool:
@@ -66,15 +282,59 @@ def is_system_response(message_text: Any) -> bool:
     return help_lines >= 2
 
 
+def is_plugin_log_message(message_text: Any) -> bool:
+    """Return true for plugin/runtime log lines that are not user chat."""
+    text = _normalize_text(message_text)
+    if not text:
+        return False
+
+    has_log_shape = bool(
+        re.match(rf"^\s*(?:\[.*{LOG_LEVEL_PATTERN}.*\]|{LOG_LEVEL_PATTERN}\b)", text, re.IGNORECASE)
+        or re.match(
+            r"^\s*(?:\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}|\d{2}:\d{2}:\d{2})",
+            text,
+        )
+    )
+    for idx, pattern in enumerate(PLUGIN_LOG_PATTERNS):
+        if not pattern.search(text):
+            continue
+        if idx < 2 or has_log_shape:
+            return True
+        if len(text) <= 180 and not CONVERSATIONAL_CUE_PATTERN.search(text):
+            return True
+    return False
+
+
 def should_ignore_learning_sample(
     message_text: Any,
     *,
     sender_id: Optional[str] = None,
     is_bot: bool = False,
+    source: Any = None,
+    message_type: Any = None,
+    event_type: Any = None,
+    post_type: Any = None,
+    sub_type: Any = None,
+    notice_type: Any = None,
+    plugin_name: Any = None,
+    metadata: Any = None,
 ) -> bool:
-    """Return true when a message is generated by commands or system templates."""
+    """Return true for messages that should not enter learning datasets."""
     text = _normalize_text(message_text)
     if not text:
+        return True
+    if has_system_event_metadata(
+        source=source,
+        message_type=message_type,
+        event_type=event_type,
+        post_type=post_type,
+        sub_type=sub_type,
+        notice_type=notice_type,
+        plugin_name=plugin_name,
+        metadata=metadata,
+    ):
+        return True
+    if is_plugin_log_message(text):
         return True
     if is_bot or str(sender_id or "").lower() == "bot":
         return is_system_response(text)
@@ -88,13 +348,18 @@ def filter_learning_messages(messages: Iterable[Any]) -> List[Any]:
         if isinstance(item, dict):
             text = item.get("message", "")
             sender_id = item.get("sender_id")
+            metadata = {key: item.get(key) for key in METADATA_FIELD_NAMES}
+            metadata["metadata"] = item.get("metadata") or item.get("raw_event")
         else:
             text = getattr(item, "message", "")
             sender_id = getattr(item, "sender_id", None)
+            metadata = {key: getattr(item, key, None) for key in METADATA_FIELD_NAMES}
+            metadata["metadata"] = getattr(item, "metadata", None)
         if should_ignore_learning_sample(
             text,
             sender_id=sender_id,
             is_bot=str(sender_id or "").lower() == "bot",
+            **metadata,
         ):
             continue
         filtered.append(item)

--- a/services/learning/sample_filter.py
+++ b/services/learning/sample_filter.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import re
+import logging
 from typing import Any, Dict, Iterable, List, Optional
 
+
+_LOGGER = logging.getLogger(__name__)
 
 COMMAND_PREFIXES = ("/", "!", "#", ".")
 BARE_COMMANDS = {
@@ -211,6 +214,32 @@ def has_system_event_metadata(
     return False
 
 
+def extract_learning_message_metadata(item: Any) -> Dict[str, Any]:
+    """Extract optional metadata from dict/object message containers."""
+    if item is None:
+        return {}
+
+    if isinstance(item, dict):
+        metadata = {key: item.get(key) for key in METADATA_FIELD_NAMES}
+        raw_metadata = item.get("metadata")
+        raw_event = item.get("raw_event") or item.get("raw")
+    else:
+        metadata = {key: getattr(item, key, None) for key in METADATA_FIELD_NAMES}
+        raw_metadata = getattr(item, "metadata", None)
+        raw_event = getattr(item, "raw_event", None) or getattr(item, "raw", None)
+
+    metadata["metadata"] = raw_metadata if raw_metadata is not None else raw_event
+
+    for source_data in (raw_metadata, raw_event):
+        if not isinstance(source_data, dict):
+            continue
+        for key in METADATA_FIELD_NAMES:
+            if metadata.get(key) is None and source_data.get(key) is not None:
+                metadata[key] = source_data.get(key)
+
+    return metadata
+
+
 def extract_learning_event_metadata(event: Any) -> Dict[str, Any]:
     """Extract optional event metadata used by sample filtering."""
     if event is None:
@@ -228,24 +257,22 @@ def extract_learning_event_metadata(event: Any) -> Dict[str, Any]:
             continue
         try:
             value = method()
+        except (AttributeError, TypeError):
+            continue
         except Exception:
+            _LOGGER.debug(
+                "Failed to read learning event metadata via %s.%s",
+                type(event).__name__,
+                method_name,
+                exc_info=True,
+            )
             continue
         if value is not None:
             metadata[key] = value
 
-    for key in METADATA_FIELD_NAMES:
-        if key in metadata:
-            continue
-        value = getattr(event, key, None)
-        if value is not None:
+    for key, value in extract_learning_message_metadata(event).items():
+        if metadata.get(key) is None and value is not None:
             metadata[key] = value
-
-    raw_event = getattr(event, "raw_event", None) or getattr(event, "raw", None)
-    if isinstance(raw_event, dict):
-        metadata["metadata"] = raw_event
-        for key in METADATA_FIELD_NAMES:
-            if key not in metadata and raw_event.get(key) is not None:
-                metadata[key] = raw_event.get(key)
 
     return metadata
 
@@ -348,13 +375,10 @@ def filter_learning_messages(messages: Iterable[Any]) -> List[Any]:
         if isinstance(item, dict):
             text = item.get("message", "")
             sender_id = item.get("sender_id")
-            metadata = {key: item.get(key) for key in METADATA_FIELD_NAMES}
-            metadata["metadata"] = item.get("metadata") or item.get("raw_event")
         else:
             text = getattr(item, "message", "")
             sender_id = getattr(item, "sender_id", None)
-            metadata = {key: getattr(item, key, None) for key in METADATA_FIELD_NAMES}
-            metadata["metadata"] = getattr(item, "metadata", None)
+        metadata = extract_learning_message_metadata(item)
         if should_ignore_learning_sample(
             text,
             sender_id=sender_id,

--- a/services/learning/sample_filter.py
+++ b/services/learning/sample_filter.py
@@ -81,11 +81,13 @@ LOG_LEVEL_PATTERN = r"(?:TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|CRITICAL|FATAL)"
 PLUGIN_RUNTIME_CONTEXT_PATTERN = (
     r"(?:LivingMemory|astrbot_plugin_livingmemory|MemoryEngine|"
     r"ConversationManager|FaissVecDB|FAISS|BM25|WebUI|"
-    r"EventHandler|ConversationStore|MemoryProcessor)"
+    r"EventHandler|ConversationStore|MemoryProcessor|PageAPI|"
+    r"BackupManager|AtomLifecycle|StorageMaintenance|VectorRetriever)"
 )
 PLUGIN_RUNTIME_ACTION_PATTERN = (
     r"(?:初始化|启动|停止|关闭|退出|失败|异常|成功|超时|耗时|"
-    r"重建|索引|检索|同步|清空|清理|连接|写入|删除|更新|回滚)"
+    r"完成|重建|索引|检索|查询|同步|清空|清理|连接|写入|"
+    r"删除|更新|回滚|跳过|过长)"
 )
 CONVERSATIONAL_CUE_PATTERN = re.compile(
     r"(?:\?|？|吗|呢|为什么|怎么|如何|什么时候|能不能|是不是|可以|有人|我|你)"
@@ -103,8 +105,8 @@ PLUGIN_LOG_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
-        rf"^\s*(?:\[[^\]]*(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})[^\]]*\]\s*)?"
-        rf"(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})\b.*"
+        rf"^\s*(?:(?:\[[^\]]*(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})[^\]]*\]\s*)|"
+        rf"(?:{PLUGIN_RUNTIME_CONTEXT_PATTERN})\b).*"
         rf"(?:{PLUGIN_RUNTIME_ACTION_PATTERN})",
         re.IGNORECASE,
     ),

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -97,6 +97,9 @@ def test_learning_sample_filter_blocks_commands_and_system_outputs():
         "/new - Create new conversation\n"
         "/provider - View or switch LLM Provider"
     )
+    livingmemory_shutdown_log = (
+        "[2026-06-02 11:54:17] [INFO] [LivingMemory] MemoryEngine 已关闭"
+    )
 
     assert should_ignore_learning_sample("/help") is True
     assert should_ignore_learning_sample("/help me") is True
@@ -104,6 +107,17 @@ def test_learning_sample_filter_blocks_commands_and_system_outputs():
     assert should_ignore_learning_sample("help me") is False
     assert should_ignore_learning_sample("/a hello") is False
     assert should_ignore_learning_sample(bot_help, sender_id="bot", is_bot=True) is True
+    assert should_ignore_learning_sample(livingmemory_shutdown_log) is True
+    assert should_ignore_learning_sample("MemoryEngine 已关闭") is True
+    assert should_ignore_learning_sample(
+        "这是一条普通聊天消息",
+        message_type="notice",
+    ) is True
+    assert should_ignore_learning_sample(
+        "这是一条普通群聊消息",
+        message_type="group_message",
+    ) is False
+    assert should_ignore_learning_sample("LivingMemory 今天真好用") is False
     assert should_ignore_learning_sample("这是一条普通聊天消息") is False
 
 
@@ -266,6 +280,58 @@ async def test_message_pipeline_runs_expression_learning_without_realtime_mode()
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_message_pipeline_skips_plugin_log_events_before_collection():
+    config = SimpleNamespace(
+        enable_jargon_learning=False,
+        enable_expression_patterns=True,
+        enable_realtime_learning=False,
+        enable_style_learning=False,
+        enable_goal_driven_chat=False,
+    )
+    collector = SimpleNamespace(collect_message=AsyncMock())
+    enhanced_interaction = SimpleNamespace(
+        update_conversation_context=AsyncMock(),
+    )
+    realtime_processor = SimpleNamespace(
+        process_expression_learning_background=AsyncMock(),
+        process_realtime_background=AsyncMock(),
+    )
+
+    pipeline = MessagePipeline(
+        plugin_config=config,
+        message_collector=collector,
+        enhanced_interaction=enhanced_interaction,
+        jargon_miner_manager=None,
+        jargon_statistical_filter=None,
+        v2_integration=None,
+        realtime_processor=realtime_processor,
+        group_orchestrator=SimpleNamespace(),
+        conversation_goal_manager=None,
+        affection_manager=SimpleNamespace(),
+        db_manager=SimpleNamespace(),
+    )
+    event = SimpleNamespace(
+        get_sender_name=lambda: "LivingMemory",
+        get_platform_name=lambda: "test",
+        get_message_type=lambda: "notice",
+    )
+
+    collected = await pipeline.process_learning(
+        "group-a",
+        "plugin",
+        "[INFO] [LivingMemory] MemoryEngine 已关闭",
+        event,
+    )
+
+    assert collected is False
+    collector.collect_message.assert_not_called()
+    enhanced_interaction.update_conversation_context.assert_not_called()
+    realtime_processor.process_expression_learning_background.assert_not_called()
+    realtime_processor.process_realtime_background.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_message_pipeline_collects_to_database_and_triggers_learning_paths(
     tmp_path,
 ):
@@ -328,6 +394,13 @@ async def test_message_pipeline_collects_to_database_and_triggers_learning_paths
             return task
 
         pipeline._spawn = spawn_now
+
+        await pipeline.process_learning(
+            "group-a",
+            "plugin",
+            "[INFO] [LivingMemory] MemoryEngine 已关闭",
+            Event(),
+        )
 
         for idx in range(10):
             await pipeline.process_learning(

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -111,6 +111,11 @@ def test_learning_sample_filter_blocks_commands_and_system_outputs():
     assert should_ignore_learning_sample(bot_help, sender_id="bot", is_bot=True) is True
     assert should_ignore_learning_sample(livingmemory_shutdown_log) is True
     assert should_ignore_learning_sample("MemoryEngine 已关闭") is True
+    assert should_ignore_learning_sample("[PageAPI] 获取图谱概览失败: timeout") is True
+    assert should_ignore_learning_sample("[BackupManager] 备份完成: 3 个文件") is True
+    assert should_ignore_learning_sample("[AtomLifecycle] 维护任务异常") is True
+    assert should_ignore_learning_sample("[StorageMaintenance] 执行存储维护失败") is True
+    assert should_ignore_learning_sample("[VectorRetriever] 查询文本过长 (2048 字符)") is True
     assert should_ignore_learning_sample(
         "这是一条普通聊天消息",
         message_type="notice",

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -41,6 +41,8 @@ from self_learning_EterU.webui.services.learning_service import LearningService
 from self_learning_EterU.services.learning.message_pipeline import MessagePipeline
 from self_learning_EterU.services.learning.realtime_processor import RealtimeProcessor
 from self_learning_EterU.services.learning.sample_filter import (
+    extract_learning_event_metadata,
+    filter_learning_messages,
     should_ignore_learning_sample,
 )
 from self_learning_EterU.services.state.enhanced_interaction import (
@@ -119,6 +121,37 @@ def test_learning_sample_filter_blocks_commands_and_system_outputs():
     ) is False
     assert should_ignore_learning_sample("LivingMemory 今天真好用") is False
     assert should_ignore_learning_sample("这是一条普通聊天消息") is False
+
+
+@pytest.mark.unit
+def test_learning_sample_filter_reads_raw_event_metadata_from_objects():
+    message = SimpleNamespace(
+        message="这是一条普通聊天消息",
+        sender_id="user-a",
+        raw_event={"message_type": "notice"},
+    )
+
+    assert filter_learning_messages([message]) == []
+
+
+@pytest.mark.unit
+def test_learning_event_metadata_logs_unexpected_accessor_failures(caplog):
+    class Event:
+        def get_message_type(self):
+            raise RuntimeError("metadata accessor failed")
+
+        def get_event_type(self):
+            return "message"
+
+    with caplog.at_level("DEBUG"):
+        metadata = extract_learning_event_metadata(Event())
+
+    assert metadata["event_type"] == "message"
+    assert any(
+        "Failed to read learning event metadata via Event.get_message_type"
+        in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Add shared learning-sample guards for non-chat/system/log event metadata.
- Filter conservative plugin runtime log lines such as LivingMemory/MemoryEngine/WebUI/BM25/FAISS output before raw message collection and downstream learning.
- Pass AstrBot event metadata from the message entrypoint through the learning pipeline into the collector.
- Add regressions covering issue #149 so plugin logs are not saved or sent into expression learning while ordinary chat mentioning LivingMemory is preserved.

## Root Cause
The learning pipeline only filtered commands and framework template output. Runtime logs from another plugin could still arrive as text-like events and pass through `main.py`, `MessagePipeline`, and `MessageCollectorService`, allowing them into raw messages and later begin_dialog/style-learning candidates.

## Validation
- `python -m pytest -q tests\\unit\\test_learning_chain_regressions.py -o cache_dir=.tmp\\pytest_cache`
- `python -m pytest -q tests\\integration\\test_package_imports.py -o cache_dir=.tmp\\pytest_cache`
- `python -m py_compile services\\learning\\sample_filter.py services\\learning\\message_pipeline.py services\\core_learning\\message_collector.py main.py`
- `git diff --check`

Closes #149

## Summary by Sourcery

Filter plugin and runtime log messages from entering learning datasets by leveraging shared event metadata and text-pattern guards across the learning pipeline.

Bug Fixes:
- Prevent plugin runtime and system log lines from being saved as raw learning samples or used in downstream learning pipelines while preserving normal chat mentioning plugin names.

Enhancements:
- Introduce structured event metadata extraction and classification helpers to distinguish chat events from non-chat/system/log events.
- Extend learning-sample filtering to use both event metadata and conservative log-pattern detection to identify plugin/runtime log messages.
- Propagate event metadata through the message pipeline and collector so all learning entrypoints consistently apply the same filtering rules.

Tests:
- Add regression tests ensuring plugin log events are skipped before collection and that ordinary chat messages mentioning LivingMemory are still learned.