### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 让 AstrBot 在群聊中持续采集、学习、审查并注入上下文，使 Bot 逐步具备表达风格、群组黑话、社交关系、长期记忆和人格演化能力。
 
-[![Version](https://img.shields.io/badge/version-3.0.16-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
+[![Version](https://img.shields.io/badge/version-3.1.0-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE)
 [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: "astrbot_plugin_self_learning"
 author: "NickMo, EterUltimate"
 display_name: "self-learning"
 description: "SELF LEARNING 自主学习插件 — 让 AI 聊天机器人自主学习对话风格、理解群组黑话、管理社交关系与好感度、自适应人格演化，像真人一样自然对话。(使用前必须手动备份人格数据)"
-version: "3.0.16"
+version: "3.1.0"
 repo: "https://github.com/NickCharlie/astrbot_plugin_self_learning"
 tags:
   - "自学习"


### PR DESCRIPTION
## Summary
- Bump metadata.yaml version from 3.0.16 to 3.1.0
- Update README version badge to 3.1.0

## Validation
- Real-instance smoke test on local AstrBot: SelfLearning WebUI status/config/memory graph routes returned 200; AstrBot Dashboard LivingMemory plugin page returned 200 text/html when authenticated.
- python -m pytest -q tests\\unit\\test_learning_chain_regressions.py tests\\unit\\test_integration_service.py tests\\integration\\test_webui_static_assets.py -o cache_dir=.tmp\\pytest_cache
- python -m py_compile services\\learning\\sample_filter.py webui\\services\\integration_service.py
- git diff --check

## Summary by Sourcery

Bump plugin version to 3.1.0 and align user-facing version references.

Documentation:
- Update README version badge to reflect version 3.1.0.

Chores:
- Update plugin metadata version from 3.0.16 to 3.1.0.