### PR TITLE
[codex] fix LivingMemory dashboard page routing

### DIFF
--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -264,6 +264,9 @@ class PluginLifecycle:
             # ------ WebUI 管理器 ------
             from ..webui.manager import WebUIManager
 
+            get_astrbot_config = getattr(context, "get_config", None)
+            astrbot_core_config = get_astrbot_config() if callable(get_astrbot_config) else None
+
             self._webui_manager = WebUIManager(
                 plugin_config=plugin_config,
                 context=context,
@@ -272,6 +275,7 @@ class PluginLifecycle:
                 group_id_to_unified_origin=group_id_to_unified_origin,
                 feature_delegation=getattr(p, "feature_delegation", None),
                 astrbot_config=getattr(p, "config", None),
+                astrbot_core_config=astrbot_core_config,
                 plugin_instance=p,
                 v2_integration=getattr(p, "v2_integration", None),
             )

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -142,8 +142,14 @@ Dashboard -> 功能融合
 AstrBot 页面入口:
 
 ```text
-/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/
+http://<astrbot-dashboard-host>:<astrbot-dashboard-port>/api/plugin/page/content/LivingMemory/dashboard/
 ```
+
+Self Learning 的独立 WebUI 会把旧入口
+`/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/`
+重定向到 AstrBot Dashboard 的正式页面，避免在 `web_interface_port` 上返回 404。
+
+注意: AstrBot 官方插件页路由使用插件运行名 `LivingMemory`，不是安装目录名 `astrbot_plugin_livingmemory`。LivingMemory 自己注册的 Page API 仍使用 `/astrbot_plugin_livingmemory/page/...` 前缀。AstrBot Plugin Page 带有同源 iframe 限制，所以 Self Learning 只把它作为新窗口入口；可嵌入 iframe 的优先入口仍是 LivingMemory 自己启用的独立 WebUI。
 
 ### Group Chat Plus
 

--- a/tests/integration/test_integration_blueprint.py
+++ b/tests/integration/test_integration_blueprint.py
@@ -1,0 +1,78 @@
+"""Integration tests for companion dashboard routes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from quart import Quart
+
+import webui.blueprints.integrations as integrations_module
+from webui.blueprints.integrations import integrations_bp
+
+
+def _star(name, plugin, *, root_dir_name=None):
+    return SimpleNamespace(
+        name=name,
+        display_name=name,
+        root_dir_name=root_dir_name or name,
+        module_path=f"data.plugins.{root_dir_name or name}.main",
+        star_cls=plugin,
+    )
+
+
+@pytest.fixture
+async def app(monkeypatch):
+    livingmemory_star = _star(
+        "LivingMemory",
+        SimpleNamespace(config_manager=SimpleNamespace(webui_settings={"enabled": False})),
+        root_dir_name="astrbot_plugin_livingmemory",
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+            "reply_delegated": False,
+            "reply_plugin": None,
+        },
+        memory_plugin=lambda: livingmemory_star,
+        reply_plugin=lambda: None,
+    )
+    container = SimpleNamespace(
+        plugin_config=SimpleNamespace(),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=7833),
+        astrbot_core_config={"dashboard": {"enable": True, "host": "0.0.0.0", "port": 6185}},
+        feature_delegation=delegation,
+    )
+    monkeypatch.setattr(integrations_module, "get_container", lambda: container)
+
+    app = Quart(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(integrations_bp)
+    yield app
+
+
+@pytest.fixture
+async def client(app):
+    return app.test_client()
+
+
+@pytest.mark.asyncio
+async def test_livingmemory_old_plugin_page_url_redirects_to_astrbot_dashboard(client):
+    response = await client.get(
+        "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/",
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == (
+        "http://127.0.0.1:6185/api/plugin/page/content/LivingMemory/dashboard/"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_plugin_page_url_is_not_claimed_by_self_learning(client):
+    response = await client.get("/api/plugin/page/content/unknown/dashboard/")
+
+    assert response.status_code == 404
+    data = await response.get_json()
+    assert data["success"] is False

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -121,7 +121,8 @@ def test_dashboard_exposes_companion_plugin_api_hub():
     assert "/api/integrations/embed/group_chat_plus" in text + service
     assert "reply-strategy" in text + service
     assert "astrbot_plugin_livingmemory/page" in service
-    assert "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/" in service
+    assert "/api/plugin/page/content/" in service
+    assert "LIVINGMEMORY_PAGE_NAME" in service
     assert "Group Chat Plus" in service
     assert "POST /api/auth/login" in service
     assert "GET /api/data/overview" in service

--- a/tests/unit/test_integration_service.py
+++ b/tests/unit/test_integration_service.py
@@ -2,12 +2,27 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 PARENT = PACKAGE_ROOT.parent
 if str(PARENT) not in sys.path:
     sys.path.insert(0, str(PARENT))
 
 from self_learning_EterU.webui.services.integration_service import IntegrationService
+
+
+@pytest.fixture(autouse=True)
+def _clear_dashboard_env(monkeypatch):
+    for key in (
+        "DASHBOARD_HOST",
+        "ASTRBOT_DASHBOARD_HOST",
+        "DASHBOARD_PORT",
+        "ASTRBOT_DASHBOARD_PORT",
+        "DASHBOARD_SSL_ENABLE",
+        "ASTRBOT_DASHBOARD_SSL_ENABLE",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 def _star(name, plugin, *, root_dir_name=None):
@@ -64,6 +79,13 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
             disable_local_reply_when_delegated=True,
         ),
         webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        astrbot_core_config={
+            "dashboard": {
+                "enable": True,
+                "host": "0.0.0.0",
+                "port": 6185,
+            }
+        },
         feature_delegation=delegation,
     )
 
@@ -74,6 +96,7 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
     assert dashboards["self_learning"]["dev_api"]["base"] == "/api"
     assert dashboards["livingmemory"]["dashboard"]["url"] == "/api/integrations/embed/livingmemory"
     assert dashboards["livingmemory"]["dashboard"]["external_url"] == "http://127.0.0.1:8888"
+    assert dashboards["livingmemory"]["dashboard"]["official_page_url"] == "http://127.0.0.1:6185/api/plugin/page/content/LivingMemory/dashboard/"
     assert dashboards["livingmemory"]["dashboard"]["route"] == "#/graphs"
     assert dashboards["livingmemory"]["dev_api"]["base"] == "/astrbot_plugin_livingmemory/page"
     assert "POST /astrbot_plugin_livingmemory/page/graph/query" in dashboards["livingmemory"]["dev_api"]["endpoints"]
@@ -86,3 +109,140 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
     group_chat_plus_embed = IntegrationService(container).get_embed_target("reply-strategy")
     assert livingmemory_embed["target_url"] == "http://127.0.0.1:8888"
     assert group_chat_plus_embed["target_url"] == "http://127.0.0.1:8787/panel?embed=1"
+
+
+def test_integration_service_uses_livingmemory_runtime_name_for_plugin_page():
+    livingmemory_star = _star(
+        "LivingMemory",
+        SimpleNamespace(config_manager=SimpleNamespace(webui_settings={"enabled": False})),
+        root_dir_name="astrbot_plugin_livingmemory",
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+            "reply_delegated": False,
+            "reply_plugin": None,
+        },
+        memory_plugin=lambda: livingmemory_star,
+        reply_plugin=lambda: None,
+    )
+    container = SimpleNamespace(
+        plugin_config=SimpleNamespace(),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        astrbot_core_config={
+            "dashboard": {
+                "enable": True,
+                "host": "localhost",
+                "port": 6185,
+            }
+        },
+        feature_delegation=delegation,
+    )
+
+    dashboards = {
+        item["id"]: item
+        for item in IntegrationService(container).get_status()["dashboards"]
+    }
+
+    assert dashboards["livingmemory"]["dashboard"]["official_page_url"] == "http://localhost:6185/api/plugin/page/content/LivingMemory/dashboard/"
+    assert "astrbot_plugin_livingmemory/dashboard" not in dashboards["livingmemory"]["dashboard"]["official_page_url"]
+
+
+def test_integration_service_does_not_embed_astrbot_page_without_external_panel():
+    livingmemory_star = _star(
+        "LivingMemory",
+        SimpleNamespace(config_manager=SimpleNamespace(webui_settings={"enabled": False})),
+        root_dir_name="astrbot_plugin_livingmemory",
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+            "reply_delegated": False,
+            "reply_plugin": None,
+        },
+        memory_plugin=lambda: livingmemory_star,
+        reply_plugin=lambda: None,
+    )
+    container = SimpleNamespace(
+        plugin_config=SimpleNamespace(),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        astrbot_core_config={"dashboard": {"enable": True, "host": "0.0.0.0", "port": 6185}},
+        feature_delegation=delegation,
+    )
+
+    target = IntegrationService(container).get_embed_target("livingmemory")
+
+    assert target["available"] is False
+    assert target["target_url"] is None
+    assert target["open_url"] == "http://127.0.0.1:6185/api/plugin/page/content/LivingMemory/dashboard/"
+    assert "AstrBot Dashboard" in target["message"]
+
+
+def test_integration_service_omits_astrbot_page_url_when_dashboard_base_unknown():
+    livingmemory_star = _star(
+        "LivingMemory",
+        SimpleNamespace(config_manager=SimpleNamespace(webui_settings={"enabled": False})),
+        root_dir_name="astrbot_plugin_livingmemory",
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+            "reply_delegated": False,
+            "reply_plugin": None,
+        },
+        memory_plugin=lambda: livingmemory_star,
+        reply_plugin=lambda: None,
+    )
+    container = SimpleNamespace(
+        plugin_config=SimpleNamespace(),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        feature_delegation=delegation,
+    )
+
+    dashboards = {
+        item["id"]: item
+        for item in IntegrationService(container).get_status()["dashboards"]
+    }
+    target = IntegrationService(container).get_embed_target("livingmemory")
+
+    assert dashboards["livingmemory"]["dashboard"]["official_page_url"] is None
+    assert target["available"] is False
+    assert target["target_url"] is None
+    assert target["open_url"] is None
+
+
+def test_integration_service_redirects_old_livingmemory_page_name_to_runtime_name():
+    livingmemory_star = _star(
+        "LivingMemory",
+        SimpleNamespace(config_manager=SimpleNamespace(webui_settings={"enabled": False})),
+        root_dir_name="astrbot_plugin_livingmemory",
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+            "reply_delegated": False,
+            "reply_plugin": None,
+        },
+        memory_plugin=lambda: livingmemory_star,
+        reply_plugin=lambda: None,
+    )
+    container = SimpleNamespace(
+        plugin_config=SimpleNamespace(),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        astrbot_core_config={"dashboard": {"enable": True, "host": "0.0.0.0", "port": 6185}},
+        feature_delegation=delegation,
+    )
+
+    assert IntegrationService(container).get_plugin_page_url(
+        "astrbot_plugin_livingmemory",
+        "dashboard",
+    ) == "http://127.0.0.1:6185/api/plugin/page/content/LivingMemory/dashboard/"
+    assert IntegrationService(container).get_plugin_page_url(
+        "astrbot_plugin_livingmemory",
+        "dashboard",
+        "assets/app.js",
+    ) == "http://127.0.0.1:6185/api/plugin/page/content/LivingMemory/dashboard/assets/app.js"

--- a/tests/unit/test_webui_dependencies.py
+++ b/tests/unit/test_webui_dependencies.py
@@ -79,6 +79,24 @@ def test_service_container_records_v2_integration():
     assert container.v2_integration is v2_integration
 
 
+def test_service_container_records_astrbot_core_config_separately():
+    container = ServiceContainer()
+    service_factory = _ServiceFactory()
+    plugin_config = SimpleNamespace(data_dir="./data")
+    astrbot_config = {"Self_Learning_Basic": {"web_interface_port": 7833}}
+    astrbot_core_config = {"dashboard": {"port": 6185}}
+
+    container.initialize(
+        plugin_config=plugin_config,
+        factory_manager=_FactoryManager(service_factory),
+        astrbot_config=astrbot_config,
+        astrbot_core_config=astrbot_core_config,
+    )
+
+    assert container.astrbot_config is astrbot_config
+    assert container.astrbot_core_config is astrbot_core_config
+
+
 def test_service_container_exposes_component_factory():
     container = ServiceContainer()
     service_factory = _ServiceFactory()
@@ -206,6 +224,46 @@ async def test_webui_manager_passes_v2_integration(monkeypatch):
     await manager._setup_services(astrbot_persona_manager=None)
 
     assert calls["v2_integration"] is v2_integration
+
+
+@pytest.mark.asyncio
+async def test_webui_manager_passes_astrbot_core_config(monkeypatch):
+    from webui import dependencies as dependencies_module
+    from webui.manager import WebUIManager
+
+    calls = {}
+    webui_container = SimpleNamespace(perf_collector=None)
+    astrbot_config = {"Self_Learning_Basic": {}}
+    astrbot_core_config = {"dashboard": {"port": 6185}}
+
+    async def fake_set_plugin_services(**kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr(
+        dependencies_module,
+        "set_plugin_services",
+        fake_set_plugin_services,
+    )
+    monkeypatch.setattr(
+        dependencies_module,
+        "get_container",
+        lambda: webui_container,
+    )
+
+    manager = WebUIManager(
+        plugin_config=SimpleNamespace(data_dir="./data"),
+        context=object(),
+        factory_manager=object(),
+        perf_tracker="perf",
+        group_id_to_unified_origin={},
+        astrbot_config=astrbot_config,
+        astrbot_core_config=astrbot_core_config,
+    )
+
+    await manager._setup_services(astrbot_persona_manager=None)
+
+    assert calls["astrbot_config"] is astrbot_config
+    assert calls["astrbot_core_config"] is astrbot_core_config
 
 
 @pytest.mark.asyncio

--- a/webui/blueprints/integrations.py
+++ b/webui/blueprints/integrations.py
@@ -2,7 +2,7 @@
 
 from html import escape
 
-from quart import Blueprint, Response, jsonify
+from quart import Blueprint, Response, jsonify, redirect
 from astrbot.api import logger
 
 from ..dependencies import get_container
@@ -43,11 +43,40 @@ async def embed_integration_dashboard(plugin_id: str):
         return error_response(f"获取伴随插件嵌入页失败: {str(e)}", 500)
 
 
+@integrations_bp.route(
+    "/plugin/page/content/<plugin_name>/<page_name>/",
+    defaults={"asset_path": ""},
+    methods=["GET"],
+)
+@integrations_bp.route(
+    "/plugin/page/content/<plugin_name>/<page_name>/<path:asset_path>",
+    methods=["GET"],
+)
+@require_auth
+async def redirect_companion_plugin_page(
+    plugin_name: str,
+    page_name: str,
+    asset_path: str,
+):
+    """Redirect known companion plugin Page URLs to AstrBot Dashboard."""
+    try:
+        service = IntegrationService(get_container())
+        target_url = service.get_plugin_page_url(plugin_name, page_name, asset_path)
+        if not target_url:
+            return error_response("该插件页面需要在 AstrBot Dashboard 中打开。", 404)
+        return redirect(target_url)
+    except Exception as e:
+        logger.error(f"获取伴随插件 AstrBot 页面失败: {e}", exc_info=True)
+        return error_response(f"获取伴随插件 AstrBot 页面失败: {str(e)}", 500)
+
+
 def _render_embed_shell(target: dict) -> str:
     title = escape(str(target.get("title") or "伴随插件面板"))
     role = escape(str(target.get("role") or ""))
     target_url = target.get("target_url") or ""
     escaped_url = escape(str(target_url), quote=True)
+    open_url = target.get("open_url") or target_url
+    escaped_open_url = escape(str(open_url), quote=True)
     message = escape(str(target.get("message") or ""))
     active_label = "已加载" if target.get("active") else "未加载"
     delegated = target.get("delegated")
@@ -67,8 +96,8 @@ def _render_embed_shell(target: dict) -> str:
         else f'<div class="empty"><strong>面板不可用</strong><p>{message}</p></div>'
     )
     open_action = (
-        f'<a class="button primary" href="{escaped_url}" target="_blank" rel="noopener noreferrer">新窗口打开</a>'
-        if target_url
+        f'<a class="button primary" href="{escaped_open_url}" target="_blank" rel="noopener noreferrer">新窗口打开</a>'
+        if open_url
         else ""
     )
 

--- a/webui/dependencies.py
+++ b/webui/dependencies.py
@@ -23,6 +23,7 @@ class ServiceContainer:
         # 插件配置
         self.plugin_config: Optional[Any] = None
         self.astrbot_config: Optional[Any] = None
+        self.astrbot_core_config: Optional[Any] = None
         self.plugin_instance: Optional[Any] = None
 
         # 核心服务
@@ -78,6 +79,7 @@ class ServiceContainer:
         group_id_to_unified_origin=None,
         feature_delegation=None,
         astrbot_config=None,
+        astrbot_core_config=None,
         plugin_instance=None,
         database_manager=None,
         database_degraded=False,
@@ -99,6 +101,7 @@ class ServiceContainer:
         """
         self.plugin_config = plugin_config
         self.astrbot_config = astrbot_config
+        self.astrbot_core_config = astrbot_core_config
         self.plugin_instance = plugin_instance
         self.factory_manager = factory_manager
         try:
@@ -233,6 +236,7 @@ async def set_plugin_services(
     group_id_to_unified_origin=None,
     feature_delegation=None,
     astrbot_config=None,
+    astrbot_core_config=None,
     plugin_instance=None,
     database_manager=None,
     database_degraded=False,
@@ -258,10 +262,11 @@ async def set_plugin_services(
         factory_manager=factory_manager,
         llm_client=llm_client,
         astrbot_persona_manager=astrbot_persona_manager,
-        group_id_to_unified_origin=group_id_to_unified_origin,
-        feature_delegation=feature_delegation,
-        astrbot_config=astrbot_config,
-        plugin_instance=plugin_instance,
+            group_id_to_unified_origin=group_id_to_unified_origin,
+            feature_delegation=feature_delegation,
+            astrbot_config=astrbot_config,
+            astrbot_core_config=astrbot_core_config,
+            plugin_instance=plugin_instance,
         database_manager=database_manager,
         database_degraded=database_degraded,
         database_start_error=database_start_error,

--- a/webui/manager.py
+++ b/webui/manager.py
@@ -34,6 +34,7 @@ class WebUIManager:
         group_id_to_unified_origin: Dict[str, str],
         feature_delegation: Any = None,
         astrbot_config: Any = None,
+        astrbot_core_config: Any = None,
         plugin_instance: Any = None,
         v2_integration: Any = None,
     ):
@@ -44,6 +45,7 @@ class WebUIManager:
         self._group_id_to_unified_origin = group_id_to_unified_origin
         self._feature_delegation = feature_delegation
         self._astrbot_config = astrbot_config
+        self._astrbot_core_config = astrbot_core_config
         self._plugin_instance = plugin_instance
         self._v2_integration = v2_integration or getattr(plugin_instance, "v2_integration", None)
         self._database_manager = getattr(plugin_instance, "db_manager", None)
@@ -270,6 +272,7 @@ class WebUIManager:
             group_id_to_unified_origin=self._group_id_to_unified_origin,
             feature_delegation=self._feature_delegation,
             astrbot_config=self._astrbot_config,
+            astrbot_core_config=self._astrbot_core_config,
             plugin_instance=self._plugin_instance,
             database_manager=database_manager,
             database_degraded=self._database_degraded,

--- a/webui/services/integration_service.py
+++ b/webui/services/integration_service.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 LIVINGMEMORY_PAGE_API_BASE = "/astrbot_plugin_livingmemory/page"
-LIVINGMEMORY_PAGE_CONTENT = "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/"
+LIVINGMEMORY_PAGE_NAME = "dashboard"
 LIVINGMEMORY_EMBED_URL = "/api/integrations/embed/livingmemory"
 GROUP_CHAT_PLUS_EMBED_URL = "/api/integrations/embed/group_chat_plus"
+LIVINGMEMORY_PLUGIN_ALIASES = {"livingmemory", "astrbot_plugin_livingmemory"}
 
 SELF_LEARNING_API_ENDPOINTS = [
     "GET /api/integrations/status",
@@ -74,10 +77,68 @@ def _http_url(host: Any, port: Any) -> Optional[str]:
     return f"http://{_local_host(host)}:{port_int}"
 
 
+def _base_url(scheme: str, host: Any, port: Any) -> Optional[str]:
+    if port in (None, ""):
+        return None
+    try:
+        port_int = int(port)
+    except (TypeError, ValueError):
+        return None
+    return f"{scheme}://{_local_host(host)}:{port_int}"
+
+
 def _join_url(base_url: Optional[str], path: str) -> Optional[str]:
     if not base_url:
         return None
     return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _env_first(*names: str) -> Optional[str]:
+    for name in names:
+        value = os.environ.get(name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _bool_value(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _plugin_page_content_path(
+    plugin_name: Any,
+    page_name: str,
+    asset_path: str = "",
+) -> Optional[str]:
+    name = str(plugin_name or "").strip()
+    page = str(page_name or "").strip()
+    if not name or not page or "/" in page or "\\" in page or page.startswith("."):
+        return None
+    encoded_name = quote(name, safe="")
+    encoded_page = quote(page, safe="")
+    path = f"/api/plugin/page/content/{encoded_name}/{encoded_page}/"
+
+    normalized_asset = str(asset_path or "").replace("\\", "/").strip("/")
+    if not normalized_asset:
+        return path
+    asset_parts = [part for part in normalized_asset.split("/") if part]
+    if any(part in {".", ".."} for part in asset_parts):
+        return None
+    return f"{path}{'/'.join(quote(part, safe='') for part in asset_parts)}"
+
+
+def _plugin_page_content_url(
+    base_url: Optional[str],
+    plugin_name: Any,
+    page_name: str,
+    asset_path: str = "",
+) -> Optional[str]:
+    path = _plugin_page_content_path(plugin_name, page_name, asset_path)
+    return _join_url(base_url, path) if path else None
 
 
 class IntegrationService:
@@ -143,13 +204,21 @@ class IntegrationService:
         dashboard = item.get("dashboard") or {}
         external_url = dashboard.get("external_url")
         official_page_url = dashboard.get("official_page_url")
-        target_url = external_url or official_page_url
+        target_url = external_url
+        open_url = external_url or official_page_url
+        if target_url:
+            message = None
+        elif official_page_url:
+            message = "AstrBot 插件页需要在 AstrBot Dashboard 中新窗口打开。"
+        else:
+            message = "该插件面板未开启或尚未检测到可用入口。"
         return {
             "id": item.get("id"),
             "title": item.get("title"),
             "role": item.get("role"),
             "available": bool(dashboard.get("available") and target_url),
             "target_url": target_url,
+            "open_url": open_url,
             "external_url": external_url,
             "official_page_url": official_page_url,
             "label": dashboard.get("label") or "打开面板",
@@ -157,8 +226,31 @@ class IntegrationService:
             "active": bool(item.get("active")),
             "delegated": item.get("delegated"),
             "plugin": item.get("plugin") or {},
-            "message": None if target_url else "该插件面板未开启或尚未检测到可用入口。",
+            "message": message,
         }
+
+    def get_plugin_page_url(
+        self,
+        plugin_name: str,
+        page_name: str,
+        asset_path: str = "",
+    ) -> Optional[str]:
+        """Return an AstrBot Dashboard URL for known companion plugin Pages."""
+        if str(page_name or "").strip() != LIVINGMEMORY_PAGE_NAME:
+            return None
+
+        delegation = self._delegation()
+        star = delegation.memory_plugin() if delegation else None
+        if not self._matches_livingmemory_plugin(plugin_name, star):
+            return None
+
+        runtime_name = getattr(star, "name", None) or "LivingMemory"
+        return _plugin_page_content_url(
+            self._astrbot_dashboard_base_url(),
+            runtime_name,
+            LIVINGMEMORY_PAGE_NAME,
+            asset_path,
+        )
 
     def _delegation(self) -> Optional[Any]:
         delegation = getattr(self.container, "feature_delegation", None)
@@ -227,6 +319,11 @@ class IntegrationService:
 
     def _livingmemory_dashboard(self, star: Any, status: Dict[str, Any]) -> Dict[str, Any]:
         plugin = getattr(star, "star_cls", None)
+        official_page_url = _plugin_page_content_url(
+            self._astrbot_dashboard_base_url(),
+            getattr(star, "name", None),
+            LIVINGMEMORY_PAGE_NAME,
+        ) if plugin else None
         webui_settings = {}
         config_manager = getattr(plugin, "config_manager", None)
         if config_manager:
@@ -250,7 +347,7 @@ class IntegrationService:
                 "available": bool(dashboard_url or plugin),
                 "url": LIVINGMEMORY_EMBED_URL,
                 "external_url": dashboard_url,
-                "official_page_url": LIVINGMEMORY_PAGE_CONTENT if plugin else None,
+                "official_page_url": official_page_url,
                 "route": "#/graphs",
                 "label": "LivingMemory 面板" if dashboard_url else "AstrBot 插件页",
                 "kind": "embedded_external" if dashboard_url else "astrbot_page",
@@ -262,6 +359,61 @@ class IntegrationService:
                 "endpoints": LIVINGMEMORY_API_ENDPOINTS,
             },
             "settings_group": "Integration_Settings",
+        }
+
+    def _astrbot_dashboard_base_url(self) -> Optional[str]:
+        astrbot_config = getattr(self.container, "astrbot_core_config", None)
+        dashboard_config = _safe_get(astrbot_config, "dashboard")
+        if dashboard_config is None:
+            # Backward-compatible test/container fallback. The normal
+            # runtime path uses astrbot_core_config so plugin settings are not
+            # confused with AstrBot's global dashboard config.
+            dashboard_config = _safe_get(
+                getattr(self.container, "astrbot_config", None),
+                "dashboard",
+            )
+        dashboard_config_provided = dashboard_config is not None
+        dashboard_config = dashboard_config or {}
+        env_host = _env_first("DASHBOARD_HOST", "ASTRBOT_DASHBOARD_HOST")
+        env_port = _env_first("DASHBOARD_PORT", "ASTRBOT_DASHBOARD_PORT")
+        if not dashboard_config_provided and env_host is None and env_port is None:
+            return None
+
+        if _safe_get(dashboard_config, "enable", True) is False:
+            return None
+
+        ssl_config = _safe_get(dashboard_config, "ssl", {}) or {}
+        ssl_enabled = _bool_value(
+            _env_first("DASHBOARD_SSL_ENABLE", "ASTRBOT_DASHBOARD_SSL_ENABLE"),
+            bool(_safe_get(ssl_config, "enable", False)),
+        )
+        return _base_url(
+            "https" if ssl_enabled else "http",
+            env_host or _safe_get(dashboard_config, "host", "0.0.0.0"),
+            env_port or _safe_get(dashboard_config, "port", 6185),
+        )
+
+    @staticmethod
+    def _matches_livingmemory_plugin(plugin_name: Any, star: Any) -> bool:
+        requested = str(plugin_name or "").strip().lower()
+        if not requested:
+            return False
+        if requested in LIVINGMEMORY_PLUGIN_ALIASES:
+            return True
+
+        candidates = {
+            getattr(star, "name", None),
+            getattr(star, "display_name", None),
+            getattr(star, "root_dir_name", None),
+            getattr(star, "module_path", None),
+        }
+        module_path = getattr(star, "module_path", None)
+        if isinstance(module_path, str):
+            candidates.update(part for part in module_path.split(".") if part)
+        return requested in {
+            str(candidate).strip().lower()
+            for candidate in candidates
+            if str(candidate or "").strip()
         }
 
     def _group_chat_plus_dashboard(self, star: Any, status: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Route LivingMemory AstrBot Plugin Page URLs through the real AstrBot Dashboard base URL instead of emitting a SelfLearning-relative `/api/plugin/page/content/...` URL.
- Add a narrow compatibility redirect for `/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/` so old SelfLearning WebUI links no longer fall through to the 7833 404 handler after reload.
- Keep AstrBot Plugin Pages out of the iframe target because AstrBot serves them with same-origin frame restrictions; use LivingMemory's external WebUI for iframe embedding when available, and open the AstrBot Page in a new window otherwise.
- Pass AstrBot global dashboard config separately from the plugin config so the integration service reads the correct dashboard host/port.

## Evidence
- User-reported URL on SelfLearning WebUI: `http://localhost:7833/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/` returned `{"message":"资源不存在","success":false}`.
- LivingMemory latest local repo has `pages/dashboard/index.html` and Plugin Page assets, with runtime plugin name `LivingMemory`; AstrBot's route resolves Plugin Pages by runtime plugin name at `/api/plugin/page/content/<plugin_name>/<page_name>/`.
- AstrBot Dashboard source applies `X-Frame-Options: SAMEORIGIN` and `frame-ancestors 'self'`, so cross-port iframe embedding from SelfLearning's 7833 WebUI is not viable.

## Validation
- `python -m pytest tests\unit\test_integration_service.py tests\integration\test_integration_blueprint.py tests\unit\test_webui_dependencies.py tests\integration\test_webui_static_assets.py`
- `python -m py_compile core\plugin_lifecycle.py webui\dependencies.py webui\manager.py webui\services\integration_service.py webui\blueprints\integrations.py`
- `python -m ruff check core\plugin_lifecycle.py webui\dependencies.py webui\manager.py webui\services\integration_service.py webui\blueprints\integrations.py tests\unit\test_integration_service.py tests\integration\test_integration_blueprint.py tests\unit\test_webui_dependencies.py tests\integration\test_webui_static_assets.py`
- `git diff --check`

## Runtime note
The already-running local WebUI on port 7833 still returned the old 404 during smoke testing because it had not reloaded the new code. Reloading the SelfLearning plugin or restarting AstrBot/WebUI should activate the compatibility redirect.

## Summary by Sourcery

Update LivingMemory integration to use AstrBot Dashboard plugin pages correctly and provide a compatibility redirect for legacy URLs.

New Features:
- Expose companion plugin AstrBot Dashboard page URLs via integration status and embed metadata.
- Add a redirect endpoint that forwards SelfLearning plugin page URLs to the AstrBot Dashboard plugin page.

Bug Fixes:
- Fix LivingMemory dashboard routing to use the AstrBot Dashboard host/port and runtime plugin name instead of a SelfLearning-relative path that returned 404s.
- Prevent attempts to iframe AstrBot plugin pages by preferring LivingMemory’s external WebUI for embedding and falling back to opening the AstrBot page in a new window.

Enhancements:
- Derive AstrBot Dashboard base URL from dedicated core config and environment variables, separate from plugin config, with HTTP/HTTPS handling.
- Extend integration embed metadata with explicit open_url and user messages when only the AstrBot page is available.
- Improve plugin name matching for LivingMemory companion pages to handle aliases and runtime names safely.

Documentation:
- Clarify documentation for LivingMemory dashboard URLs, routing behavior, and iframe limitations in the integrations guide.

Tests:
- Add unit and integration tests covering AstrBot core config wiring, LivingMemory plugin page URL generation, redirect behavior, and updated embed target semantics.
- Extend existing integration and static asset tests to assert the new LivingMemory official page URL handling and config propagation.