### PR TITLE
feat: add persona state and backup management

### DIFF
--- a/repositories/persona_backup_repository.py
+++ b/repositories/persona_backup_repository.py
@@ -42,6 +42,7 @@ class PersonaBackupRepository(BaseRepository[PersonaBackup]):
 
     async def list_backups(
         self,
+        group_id: Optional[str] = None,
         limit: int = 50,
         offset: int = 0
     ) -> List[PersonaBackup]:
@@ -56,12 +57,10 @@ class PersonaBackupRepository(BaseRepository[PersonaBackup]):
             List[PersonaBackup]: 备份列表
         """
         try:
-            stmt = (
-                select(PersonaBackup)
-                .order_by(desc(PersonaBackup.timestamp))
-                .offset(offset)
-                .limit(limit)
-            )
+            stmt = select(PersonaBackup)
+            if group_id:
+                stmt = stmt.where(PersonaBackup.group_id == group_id)
+            stmt = stmt.order_by(desc(PersonaBackup.timestamp)).offset(offset).limit(limit)
             result = await self.session.execute(stmt)
             return list(result.scalars().all())
         except Exception as e:

--- a/services/database/facades/persona_facade.py
+++ b/services/database/facades/persona_facade.py
@@ -22,6 +22,37 @@ except ImportError:
 class PersonaFacade(BaseFacade):
     """人格备份管理 Facade"""
 
+    @staticmethod
+    def _json_loads(value: Any, default: Any) -> Any:
+        if not value:
+            return default
+        if isinstance(value, (dict, list)):
+            return value
+        try:
+            return json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            return default
+
+    def _backup_to_dict(self, backup: PersonaBackup, include_content: bool = True) -> Dict[str, Any]:
+        data = {
+            'id': backup.id,
+            'group_id': backup.group_id,
+            'backup_name': backup.backup_name,
+            'timestamp': backup.timestamp,
+            'reason': backup.reason,
+            'backup_reason': backup.backup_reason,
+            'backup_time': backup.backup_time,
+            'created_at': backup.created_at.isoformat() if backup.created_at else None,
+        }
+        if include_content:
+            data.update({
+                'persona_config': self._json_loads(backup.persona_config, {}),
+                'original_persona': self._json_loads(backup.original_persona, {}),
+                'imitation_dialogues': self._json_loads(backup.imitation_dialogues, []),
+                'persona_content': backup.persona_content or '',
+            })
+        return data
+
     async def backup_persona(self, backup_data: Dict[str, Any]) -> bool:
         """创建人格备份"""
         try:
@@ -47,48 +78,63 @@ class PersonaFacade(BaseFacade):
             self._logger.error(f"[PersonaFacade] 备份人格失败: {e}")
             return False
 
-    async def get_persona_backups(self, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_persona_backups(
+        self,
+        group_id: Optional[str] = None,
+        limit: int = 10,
+        include_content: bool = False,
+    ) -> List[Dict[str, Any]]:
         """获取人格备份列表"""
         try:
             async with self.get_session() as session:
                 repo = PersonaBackupRepository(session)
-                backups = await repo.list_backups(limit=limit)
-                return [
-                    {
-                        'id': b.id,
-                        'backup_name': b.backup_name,
-                        'timestamp': b.timestamp,
-                        'reason': b.reason,
-                        'persona_config': json.loads(b.persona_config) if b.persona_config else {},
-                        'original_persona': json.loads(b.original_persona) if b.original_persona else {},
-                        'imitation_dialogues': json.loads(b.imitation_dialogues) if b.imitation_dialogues else [],
-                        'backup_reason': b.backup_reason,
-                    }
-                    for b in backups
-                ]
+                backups = await repo.list_backups(group_id=group_id, limit=limit)
+                return [self._backup_to_dict(b, include_content=include_content) for b in backups]
         except Exception as e:
             self._logger.error(f"[PersonaFacade] 获取备份列表失败: {e}")
             return []
 
-    async def restore_persona_backup(self, backup_id: int) -> Optional[Dict[str, Any]]:
-        """恢复指定备份"""
+    async def get_persona_backup(
+        self,
+        backup_id: int,
+        group_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """获取指定备份详情"""
         try:
             async with self.get_session() as session:
                 repo = PersonaBackupRepository(session)
                 backup = await repo.get_backup(backup_id)
-                if not backup:
+                if not backup or (group_id and backup.group_id != group_id):
                     return None
-                return {
-                    'id': backup.id,
-                    'backup_name': backup.backup_name,
-                    'timestamp': backup.timestamp,
-                    'persona_config': json.loads(backup.persona_config) if backup.persona_config else {},
-                    'original_persona': json.loads(backup.original_persona) if backup.original_persona else {},
-                    'imitation_dialogues': json.loads(backup.imitation_dialogues) if backup.imitation_dialogues else [],
-                }
+                return self._backup_to_dict(backup, include_content=True)
         except Exception as e:
-            self._logger.error(f"[PersonaFacade] 恢复备份失败: {e}")
+            self._logger.error(f"[PersonaFacade] 获取备份详情失败: {e}")
             return None
+
+    async def restore_persona_backup(
+        self,
+        backup_id: int,
+        group_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """返回指定备份内容，供上层执行实际恢复。"""
+        return await self.get_persona_backup(backup_id, group_id=group_id)
+
+    async def delete_persona_backup(
+        self,
+        backup_id: int,
+        group_id: Optional[str] = None,
+    ) -> bool:
+        """删除指定人格备份"""
+        try:
+            async with self.get_session() as session:
+                repo = PersonaBackupRepository(session)
+                backup = await repo.get_backup(backup_id)
+                if not backup or (group_id and backup.group_id != group_id):
+                    return False
+                return await repo.delete_backup(backup_id)
+        except Exception as e:
+            self._logger.error(f"[PersonaFacade] 删除备份失败: {e}")
+            return False
 
     async def get_persona_update_history(
         self, group_id: str = None, limit: int = 50

--- a/services/database/sqlalchemy_database_manager.py
+++ b/services/database/sqlalchemy_database_manager.py
@@ -8,7 +8,7 @@ DomainRouter — 薄路由层，将所有数据库方法委托给领域 Facade
 import os
 import asyncio
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Any
+from typing import Callable, Dict, List, Optional, Any, Union
 from contextlib import asynccontextmanager
 
 from astrbot.api import logger
@@ -1048,15 +1048,77 @@ class SQLAlchemyDatabaseManager:
 
     async def backup_persona(self, group_id: str, backup_data: Dict[str, Any]) -> bool:
         backup_data.setdefault('group_id', group_id)
-        return await self._persona.backup_persona(backup_data)
+        return await self._call_facade(
+            lambda: self._persona,
+            "PersonaFacade",
+            "backup_persona",
+            False,
+            backup_data,
+        )
 
-    async def get_persona_backups(self, limit: int = 10) -> List[Dict[str, Any]]:
-        return await self._persona.get_persona_backups(limit)
+    async def get_persona_backups(
+        self,
+        group_id: str = None,
+        limit: int = 10,
+        include_content: bool = False,
+    ) -> List[Dict[str, Any]]:
+        if isinstance(group_id, int) and limit == 10:
+            limit = group_id
+            group_id = None
+        return await self._call_facade(
+            lambda: self._persona,
+            "PersonaFacade",
+            "get_persona_backups",
+            [],
+            group_id=group_id,
+            limit=limit,
+            include_content=include_content,
+        )
 
     async def restore_persona_backup(
-        self, backup_id: int,
+        self,
+        group_id: Union[str, int],
+        backup_id: int = None,
     ) -> Optional[Dict[str, Any]]:
-        return await self._persona.restore_persona_backup(backup_id)
+        if backup_id is None:
+            backup_id = int(group_id)
+            group_id = None
+        return await self._call_facade(
+            lambda: self._persona,
+            "PersonaFacade",
+            "restore_persona_backup",
+            None,
+            int(backup_id),
+            group_id=group_id,
+        )
+
+    async def get_persona_backup(
+        self,
+        backup_id: int,
+        group_id: str = None,
+    ) -> Optional[Dict[str, Any]]:
+        return await self._call_facade(
+            lambda: self._persona,
+            "PersonaFacade",
+            "get_persona_backup",
+            None,
+            backup_id,
+            group_id=group_id,
+        )
+
+    async def delete_persona_backup(
+        self,
+        backup_id: int,
+        group_id: str = None,
+    ) -> bool:
+        return await self._call_facade(
+            lambda: self._persona,
+            "PersonaFacade",
+            "delete_persona_backup",
+            False,
+            backup_id,
+            group_id=group_id,
+        )
 
     async def get_persona_update_history(
         self, group_id: str = None, limit: int = 50,

--- a/services/sqlalchemy_database_manager.py
+++ b/services/sqlalchemy_database_manager.py
@@ -47,5 +47,38 @@ class SQLAlchemyDatabaseManager(_SQLAlchemyDatabaseManager):
             limit=limit, offset=offset, status_filter=status_filter,
         )
 
+    async def get_persona_backups(
+        self,
+        group_id: str = None,
+        limit: int = 10,
+        include_content: bool = False,
+    ) -> List[Dict[str, Any]]:
+        return await super().get_persona_backups(
+            group_id=group_id,
+            limit=limit,
+            include_content=include_content,
+        )
+
+    async def get_persona_backup(
+        self,
+        backup_id: int,
+        group_id: str = None,
+    ) -> Optional[Dict[str, Any]]:
+        return await super().get_persona_backup(backup_id, group_id=group_id)
+
+    async def restore_persona_backup(
+        self,
+        group_id,
+        backup_id: int = None,
+    ) -> Optional[Dict[str, Any]]:
+        return await super().restore_persona_backup(group_id, backup_id)
+
+    async def delete_persona_backup(
+        self,
+        backup_id: int,
+        group_id: str = None,
+    ) -> bool:
+        return await super().delete_persona_backup(backup_id, group_id=group_id)
+
 
 __all__ = ["SQLAlchemyDatabaseManager"]

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -153,6 +153,20 @@ def test_dashboard_exposes_persona_review_diff_preview():
     assert "review-preview" in text
 
 
+def test_dashboard_exposes_persona_state_and_backup_management():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert "当前人格状态" in text
+    assert "人格备份" in text
+    assert "personaStateStats" in text
+    assert "personaBackupList" in text
+    assert "/api/persona_management/current?group_id=default" in text
+    assert "/api/persona_backups/list?group_id=default&limit=8" in text
+    assert "persona-backup-view" in text
+    assert "persona-backup-restore" in text
+    assert "persona-backup-delete" in text
+
+
 def test_dashboard_filters_provider_selects_by_astrbot_provider_type():
     text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
 

--- a/tests/unit/test_persona_backup_service.py
+++ b/tests/unit/test_persona_backup_service.py
@@ -1,0 +1,92 @@
+"""Unit tests for WebUI persona backup management service."""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from webui.services.persona_backup_service import PersonaBackupService
+
+
+@pytest.mark.asyncio
+async def test_list_backups_returns_summaries(mock_container):
+    mock_container.database_manager.get_persona_backups = AsyncMock(return_value=[
+        {
+            'id': 3,
+            'group_id': 'default',
+            'backup_name': 'before-update',
+            'timestamp': 1710000000,
+            'backup_reason': 'Auto backup before update',
+            'original_persona': {'name': 'Default', 'prompt': 'hello'},
+        }
+    ])
+    service = PersonaBackupService(mock_container)
+
+    result = await service.list_backups(group_id='default', limit='50')
+
+    assert result['available'] is True
+    assert result['total'] == 1
+    assert result['backups'][0]['id'] == 3
+    assert result['backups'][0]['persona_name'] == 'Default'
+    assert result['backups'][0]['prompt_length'] == 5
+    mock_container.database_manager.get_persona_backups.assert_awaited_once_with(
+        group_id='default',
+        limit=50,
+        include_content=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_backup_uses_database_detail(mock_container):
+    mock_container.database_manager.get_persona_backup = AsyncMock(return_value={
+        'id': 7,
+        'group_id': 'default',
+        'backup_name': 'manual',
+        'original_persona': {'name': 'Manual Persona', 'prompt': 'content'},
+        'imitation_dialogues': [],
+    })
+    service = PersonaBackupService(mock_container)
+
+    result = await service.get_backup(7, group_id='default')
+
+    assert result['id'] == 7
+    assert result['summary']['backup_name'] == 'manual'
+    assert result['summary']['prompt_length'] == len('content')
+
+
+@pytest.mark.asyncio
+async def test_restore_backup_falls_back_to_persona_manager(mock_container):
+    mock_container.persona_backup_manager = None
+    mock_container.persona_web_manager = None
+    mock_container.database_manager.get_persona_backup = AsyncMock(return_value={
+        'id': 9,
+        'group_id': 'default',
+        'backup_name': 'restore-me',
+        'original_persona': {
+            'persona_id': 'default',
+            'name': 'Default Persona',
+            'prompt': 'restored prompt',
+        },
+        'imitation_dialogues': [],
+    })
+    mock_container.persona_manager.update_persona = AsyncMock(return_value=True)
+    service = PersonaBackupService(mock_container)
+
+    success, message = await service.restore_backup(9, group_id='default')
+
+    assert success is True
+    assert '恢复成功' in message
+    mock_container.persona_manager.update_persona.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_delete_backup_uses_database_manager(mock_container):
+    mock_container.database_manager.delete_persona_backup = AsyncMock(return_value=True)
+    service = PersonaBackupService(mock_container)
+
+    success, message = await service.delete_backup(11, group_id='default')
+
+    assert success is True
+    assert '已删除' in message
+    mock_container.database_manager.delete_persona_backup.assert_awaited_once_with(
+        11,
+        group_id='default',
+    )

--- a/tests/unit/test_persona_service.py
+++ b/tests/unit/test_persona_service.py
@@ -230,6 +230,31 @@ class TestPersonaService:
         assert result['prompt_length'] > 0
 
     @pytest.mark.asyncio
+    async def test_get_current_persona_state_handles_defensive_edges(self, mock_container):
+        """Current persona state should tolerate sparse config and odd persona fields."""
+        mock_container.plugin_config = Mock()
+        mock_container.persona_web_manager = None
+        mock_container.persona_manager.get_default_persona_v3.return_value = {
+            'persona_id': 'system-only',
+            'name': 'System Only',
+            'system_prompt': 'System prompt only',
+            'begin_dialogs': 'not-a-list',
+            'tools': None,
+        }
+        service = PersonaService(mock_container)
+
+        result = await service.get_current_persona_state('edge_group')
+
+        assert result['degraded'] is False
+        assert result['persona']['prompt'] == 'System prompt only'
+        assert result['prompt_preview'] == 'System prompt only'
+        assert result['prompt_length'] == len('System prompt only')
+        assert result['begin_dialog_count'] == 0
+        assert result['tool_count'] == 0
+        assert result['config']['persona_merge_strategy'] is None
+        assert result['available_services']['persona_manager'] is True
+
+    @pytest.mark.asyncio
     async def test_export_persona_success(self, mock_container, sample_persona_data):
         """Test exporting a persona"""
         service = PersonaService(mock_container)

--- a/tests/unit/test_persona_service.py
+++ b/tests/unit/test_persona_service.py
@@ -188,6 +188,48 @@ class TestPersonaService:
         assert mock_container.persona_manager.get_default_persona_v3.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_get_current_persona_state_returns_preview(self, mock_container, sample_persona_data):
+        """Current persona state should expose a compact WebUI preview."""
+        mock_container.plugin_config.current_persona_name = 'test_persona'
+        mock_container.plugin_config.enable_persona_evolution = True
+        mock_container.plugin_config.persona_merge_strategy = 'smart'
+        mock_container.plugin_config.persona_compatibility_threshold = 0.6
+        mock_container.plugin_config.persona_update_backup_enabled = True
+        mock_container.plugin_config.auto_backup_enabled = True
+        mock_container.plugin_config.backup_interval_hours = 24
+        mock_container.plugin_config.max_backups_per_group = 10
+        mock_container.persona_manager.get_default_persona_v3.return_value = {
+            **sample_persona_data,
+            'begin_dialogs': ['hi'],
+            'tools': ['search'],
+        }
+        service = PersonaService(mock_container)
+
+        result = await service.get_current_persona_state('test_group')
+
+        assert result['group_id'] == 'test_group'
+        assert result['persona']['persona_id'] == 'test_persona'
+        assert result['prompt_length'] == len(sample_persona_data['prompt'])
+        assert result['begin_dialog_count'] == 1
+        assert result['tool_count'] == 1
+        assert result['config']['persona_merge_strategy'] == 'smart'
+        assert result['available_services']['persona_manager'] is True
+
+    @pytest.mark.asyncio
+    async def test_get_current_persona_state_degrades_without_manager(self, mock_container):
+        """Current persona state should not fail when persona services are missing."""
+        mock_container.persona_manager = None
+        mock_container.astrbot_persona_manager = None
+        mock_container.persona_web_manager = None
+        service = PersonaService(mock_container)
+
+        result = await service.get_current_persona_state('test_group')
+
+        assert result['degraded'] is True
+        assert result['persona']['persona_id'] == 'default'
+        assert result['prompt_length'] > 0
+
+    @pytest.mark.asyncio
     async def test_export_persona_success(self, mock_container, sample_persona_data):
         """Test exporting a persona"""
         service = PersonaService(mock_container)

--- a/tests/unit/test_sqlalchemy_db_manager_contract.py
+++ b/tests/unit/test_sqlalchemy_db_manager_contract.py
@@ -40,3 +40,17 @@ def test_reviewed_persona_updates_signature_matches_legacy_call_order():
         "签名顺序必须兼容 legacy 调用: "
         "get_reviewed_persona_update_records(limit, offset, status_filter)"
     )
+
+
+def test_persona_backup_management_methods_exist():
+    source = _read_source()
+
+    required_defs = [
+        "async def get_persona_backups(",
+        "async def get_persona_backup(",
+        "async def restore_persona_backup(",
+        "async def delete_persona_backup(",
+    ]
+
+    for method_def in required_defs:
+        assert method_def in source, f"缺少人格备份管理 ORM 方法定义: {method_def}"

--- a/tests/unit/test_sqlalchemy_db_manager_contract.py
+++ b/tests/unit/test_sqlalchemy_db_manager_contract.py
@@ -1,4 +1,7 @@
+from inspect import signature
 from pathlib import Path
+
+from services.sqlalchemy_database_manager import SQLAlchemyDatabaseManager
 
 
 SQLALCHEMY_DB_MANAGER_PATH = (
@@ -42,15 +45,20 @@ def test_reviewed_persona_updates_signature_matches_legacy_call_order():
     )
 
 
-def test_persona_backup_management_methods_exist():
-    source = _read_source()
+def test_persona_backup_management_signatures_match_legacy_call_order():
+    expected_params_by_method = {
+        "get_persona_backups": ("self", "group_id", "limit", "include_content"),
+        "get_persona_backup": ("self", "backup_id", "group_id"),
+        "restore_persona_backup": ("self", "group_id", "backup_id"),
+        "delete_persona_backup": ("self", "backup_id", "group_id"),
+    }
 
-    required_defs = [
-        "async def get_persona_backups(",
-        "async def get_persona_backup(",
-        "async def restore_persona_backup(",
-        "async def delete_persona_backup(",
-    ]
+    for method_name, expected_params in expected_params_by_method.items():
+        method = getattr(SQLAlchemyDatabaseManager, method_name, None)
+        assert method is not None, f"缺少人格备份管理 ORM 方法定义: {method_name}"
 
-    for method_def in required_defs:
-        assert method_def in source, f"缺少人格备份管理 ORM 方法定义: {method_def}"
+        param_names = tuple(signature(method).parameters.keys())
+        assert param_names[:len(expected_params)] == expected_params, (
+            f"人格备份管理方法 `{method_name}` 的参数签名与 legacy 调用不兼容；"
+            f"期望前 {len(expected_params)} 个参数为 {expected_params}，实际为 {param_names}"
+        )

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -2415,6 +2415,29 @@
 
             <div id="queueStatus" class="config-status queue-status" style="margin-bottom:14px;">审查操作就绪。</div>
 
+            <section class="queue-grid" style="margin-bottom:16px;">
+            <div class="panel">
+                <div class="panel-head">
+                    <h2>当前人格状态</h2>
+                    <span class="hint" id="personaStateHint">--</span>
+                </div>
+                <div class="panel-body">
+                    <div class="stats-row" id="personaStateStats"></div>
+                    <div id="personaStatePreview" class="list" style="margin-top:10px;"></div>
+                </div>
+            </div>
+
+            <div class="panel">
+                <div class="panel-head">
+                    <h2>人格备份</h2>
+                    <span class="hint" id="personaBackupHint">--</span>
+                </div>
+                <div class="panel-body">
+                    <div id="personaBackupList" class="list"></div>
+                </div>
+            </div>
+        </section>
+
             <section class="queue-grid">
             <div class="panel">
                 <div class="panel-head">
@@ -2798,6 +2821,9 @@
                     mirror: localStorage.getItem('sl-pip-mirror') || 'default',
                 },
                 actionBusy: new Set(),
+                personaState: {
+                    groupId: 'default',
+                },
                 graph: {
                     type: 'memory',
                     layout: 'force',
@@ -4184,12 +4210,73 @@
                 return rows.length ? rows.join('') : '<div class="item">暂无已审人格记录。</div>';
             }
 
+            function renderPersonaStatePanel(currentState, backupsPayload) {
+                const statePayload = currentState || {};
+                const persona = statePayload.persona || {};
+                const promptPreview = statePayload.prompt_preview || persona.prompt || persona.system_prompt || '';
+                const config = statePayload.config || {};
+                const services = statePayload.available_services || {};
+                const activeServices = Object.entries(services).filter(([, available]) => available).map(([name]) => name);
+                const backupPayload = backupsPayload || {};
+                const backups = safeArray(backupPayload.backups);
+
+                $('personaStateHint').textContent = statePayload.degraded ? '降级预览' : (persona.name || persona.persona_id || 'default');
+                $('personaStateStats').innerHTML = [
+                    ['Prompt', formatCount(statePayload.prompt_length || 0)],
+                    ['Begin dialogs', formatCount(statePayload.begin_dialog_count || 0)],
+                    ['Tools', formatCount(statePayload.tool_count || 0)],
+                    ['备份策略', config.auto_backup_enabled === false ? '关闭' : '开启'],
+                ].map(([label, value]) => `
+                    <div class="small-stat">
+                        <div class="k">${escapeHtml(label)}</div>
+                        <div class="v">${escapeHtml(value)}</div>
+                    </div>
+                `).join('');
+                $('personaStatePreview').innerHTML = `
+                    <div class="item">
+                        <div class="top">
+                            <div class="title">${escapeHtml(persona.name || persona.persona_id || '默认人格')}</div>
+                            <span class="state ${statePayload.degraded ? 'degraded' : 'healthy'}">${escapeHtml(statePayload.group_id || 'default')}</span>
+                        </div>
+                        <div class="meta">合并 ${escapeHtml(config.persona_merge_strategy || '--')} · 兼容阈值 ${escapeHtml(config.persona_compatibility_threshold ?? '--')} · 服务 ${escapeHtml(activeServices.length ? activeServices.join(', ') : 'fallback')}</div>
+                        <div class="body clamp">${escapeHtml(promptPreview || '暂无人格 Prompt')}</div>
+                    </div>
+                `;
+
+                $('personaBackupHint').textContent = backupPayload.available === false ? '不可用' : `${formatCount(backupPayload.total || backups.length)} 个`;
+                $('personaBackupList').innerHTML = backups.length ? backups.map((item) => {
+                    const backupId = item.id;
+                    const meta = [
+                        item.group_id ? `群组 ${item.group_id}` : null,
+                        item.timestamp ? formatTime(item.timestamp) : (item.created_at ? formatTime(item.created_at) : null),
+                        item.prompt_length !== undefined ? `Prompt ${formatCount(item.prompt_length)}` : null,
+                    ].filter(Boolean).join(' · ');
+                    return `
+                        <div class="item">
+                            <div class="top">
+                                <div class="title">${escapeHtml(item.backup_name || `备份 ${backupId}`)}</div>
+                                <span class="state unknown">${escapeHtml(item.persona_name || 'persona')}</span>
+                            </div>
+                            <div class="meta">${escapeHtml(meta || '暂无元信息')}</div>
+                            <div class="body clamp">${escapeHtml(item.reason_short || item.reason || '暂无备份原因')}</div>
+                            <div class="item-actions">
+                                ${actionButton('persona-backup-view', backupId, 'visibility', '查看')}
+                                ${actionButton('persona-backup-restore', backupId, 'settings_backup_restore', '恢复', 'warning')}
+                                ${actionButton('persona-backup-delete', backupId, 'delete', '删除', 'danger')}
+                            </div>
+                        </div>
+                    `;
+                }).join('') : `<div class="empty-state"><span class="material-icons">inventory_2</span><p>${escapeHtml(backupPayload.message || '暂无人格备份')}</p></div>`;
+            }
+
             function renderSummary(data) {
                 const metrics = data.metrics || {};
                 const trends = data.trends || {};
                 const health = data.health || {};
                 const persona = data.persona || {};
                 const personaReviewed = data.personaReviewed || {};
+                const personaState = data.personaState || {};
+                const personaBackups = data.personaBackups || {};
                 const style = data.style || {};
                 const jargonStats = data.jargonStats || {};
 
@@ -4323,6 +4410,7 @@
                 const styleUpdatesFromPersona = personaUpdates.filter((item) => item && item.review_source === 'style_learning');
                 $('styleList').innerHTML = renderStyleQueue(styleUpdatesFromPersona.length ? styleUpdatesFromPersona : style.reviews);
                 $('reviewedPersonaList').innerHTML = renderReviewedPersonaHistory(personaReviewed.updates);
+                renderPersonaStatePanel(personaState, personaBackups);
 
                 $('trendHint').textContent = `最近 ${Object.keys(trends.daily_messages || {}).length || 7} 天`;
 
@@ -5682,6 +5770,12 @@
                 if (action === 'jargon-delete') {
                     if (!(await showConfirm('删除黑话', '确定删除这条黑话？不可撤销。', '确认删除'))) { showToast('已取消', 'warn'); return; }
                 }
+                if (action === 'persona-backup-restore') {
+                    if (!(await showConfirm('恢复人格备份', '确定恢复这个人格备份？当前人格可能被覆盖。', '确认恢复'))) { showToast('已取消', 'warn'); return; }
+                }
+                if (action === 'persona-backup-delete') {
+                    if (!(await showConfirm('删除人格备份', '确定删除这个人格备份？不可撤销。', '确认删除'))) { showToast('已取消', 'warn'); return; }
+                }
 
                 if (action === 'jargon-edit') {
                     state.jargon.editingId = Number(id);
@@ -5708,6 +5802,20 @@
                         payload = await postJson(`/api/persona_updates/${encodeURIComponent(id)}/review`, { action: 'reject' });
                     } else if (action === 'persona-delete') {
                         payload = await postJson(`/api/persona_updates/${encodeURIComponent(id)}/delete`);
+                    } else if (action === 'persona-backup-view') {
+                        payload = await safeFetch(`/api/persona_backups/${encodeURIComponent(id)}?group_id=default`);
+                        if (!payload) {
+                            throw new Error('人格备份不存在');
+                        }
+                        const summary = payload.summary || {};
+                        const prompt = (payload.original_persona && (payload.original_persona.prompt || payload.original_persona.system_prompt)) || payload.persona_content || '';
+                        setQueueStatus(`备份 ${summary.backup_name || id} · ${summary.persona_name || 'persona'} · Prompt ${formatCount(prompt.length)} 字`, 'success');
+                        showToast('人格备份详情已读取', 'ok');
+                        return;
+                    } else if (action === 'persona-backup-restore') {
+                        payload = await postJson(`/api/persona_backups/${encodeURIComponent(id)}/restore`, { group_id: 'default' });
+                    } else if (action === 'persona-backup-delete') {
+                        payload = await deleteJson(`/api/persona_backups/${encodeURIComponent(id)}?group_id=default`);
                     } else if (action === 'jargon-approve') {
                         if (!(await showConfirm('审批确认', '确定确认这条黑话？', '确认'))) { showToast('已取消', 'warn'); state.actionBusy.delete(busyKey); renderAll(state.data || {}); return; }
                         payload = await postJson(`/api/jargon/${encodeURIComponent(id)}/review`, { action: 'approve' });
@@ -6192,6 +6300,8 @@
                     functionsData,
                     persona,
                     personaReviewed,
+                    personaState,
+                    personaBackups,
                     style,
                     jargonStats,
                     jargonList,
@@ -6202,6 +6312,8 @@
                     safeFetch('/api/monitoring/functions'),
                     safeFetch('/api/persona_updates?limit=10'),
                     safeFetch('/api/persona_updates/reviewed?limit=5'),
+                    safeFetch('/api/persona_management/current?group_id=default'),
+                    safeFetch('/api/persona_backups/list?group_id=default&limit=8'),
                     safeFetch('/api/style_learning/reviews?limit=5'),
                     safeFetch('/api/jargon/stats'),
                     safeFetch('/api/jargon/list?page_size=5&confirmed=false&pending=true'),
@@ -6222,6 +6334,8 @@
                     functions: safeArray(functionsData && functionsData.functions).slice(0, 5),
                     persona: persona || { updates: [], total: 0 },
                     personaReviewed: personaReviewed || { updates: [], total: 0 },
+                    personaState: personaState || {},
+                    personaBackups: personaBackups || { backups: [], total: 0, available: false },
                     style: style || { reviews: [], total: 0 },
                     jargonStats: extractJargonStats(jargonStats),
                     jargonList: extractJargonItems(jargonList),

--- a/webui/blueprints/personas.py
+++ b/webui/blueprints/personas.py
@@ -13,6 +13,21 @@ from ..utils.response import success_response, error_response
 personas_bp = Blueprint('personas', __name__, url_prefix='/api')
 
 
+def _parse_backup_limit(raw_limit, default: int = 20) -> int:
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as e:
+        raise ValueError("limit 必须是整数") from e
+    return max(1, min(limit, 100))
+
+
+def _backup_error_status(message: str) -> int:
+    service_unavailable_markers = ("未初始化", "不支持", "不可用")
+    if any(marker in message for marker in service_unavailable_markers):
+        return 503
+    return 404
+
+
 @personas_bp.route("/persona_management/list", methods=["GET"])
 @require_auth
 async def get_personas_list():
@@ -166,8 +181,8 @@ async def get_current_persona_state():
 async def list_persona_backups():
     """获取人格备份列表"""
     group_id = request.args.get("group_id", "default")
-    limit = request.args.get("limit", 20)
     try:
+        limit = _parse_backup_limit(request.args.get("limit", 20))
         container = get_container()
         backup_service = PersonaBackupService(container)
         result = await backup_service.list_backups(group_id=group_id, limit=limit)
@@ -198,7 +213,7 @@ async def get_persona_backup(backup_id: int):
         return jsonify(backup), 200
 
     except ValueError as e:
-        return error_response(str(e), 404)
+        return error_response(str(e), _backup_error_status(str(e)))
     except Exception as e:
         logger.error(f"获取人格备份详情失败: {e}", exc_info=True)
         return error_response(f"获取人格备份详情失败: {str(e)}", 500)
@@ -221,7 +236,7 @@ async def restore_persona_backup(backup_id: int):
         return error_response(message, 400)
 
     except ValueError as e:
-        return error_response(str(e), 404)
+        return error_response(str(e), _backup_error_status(str(e)))
     except Exception as e:
         logger.error(f"恢复人格备份失败: {e}", exc_info=True)
         return error_response(f"恢复人格备份失败: {str(e)}", 500)
@@ -242,7 +257,7 @@ async def delete_persona_backup(backup_id: int):
         return error_response(message, 404)
 
     except ValueError as e:
-        return error_response(str(e), 503)
+        return error_response(str(e), _backup_error_status(str(e)))
     except Exception as e:
         logger.error(f"删除人格备份失败: {e}", exc_info=True)
         return error_response(f"删除人格备份失败: {str(e)}", 500)

--- a/webui/blueprints/personas.py
+++ b/webui/blueprints/personas.py
@@ -6,6 +6,7 @@ from astrbot.api import logger
 
 from ..dependencies import get_container
 from ..services.persona_service import PersonaService
+from ..services.persona_backup_service import PersonaBackupService
 from ..middleware.auth import require_auth
 from ..utils.response import success_response, error_response
 
@@ -141,6 +142,110 @@ async def get_default_persona():
             "begin_dialogs": [],
             "tools": []
         }), 200
+
+
+@personas_bp.route("/persona_management/current", methods=["GET"])
+@require_auth
+async def get_current_persona_state():
+    """获取当前生效人格状态预览"""
+    try:
+        container = get_container()
+        persona_service = PersonaService(container)
+        group_id = request.args.get("group_id", "default")
+        current_state = await persona_service.get_current_persona_state(group_id)
+
+        return jsonify(current_state), 200
+
+    except Exception as e:
+        logger.error(f"获取当前人格状态失败: {e}", exc_info=True)
+        return error_response(f"获取当前人格状态失败: {str(e)}", 500)
+
+
+@personas_bp.route("/persona_backups/list", methods=["GET"])
+@require_auth
+async def list_persona_backups():
+    """获取人格备份列表"""
+    group_id = request.args.get("group_id", "default")
+    limit = request.args.get("limit", 20)
+    try:
+        container = get_container()
+        backup_service = PersonaBackupService(container)
+        result = await backup_service.list_backups(group_id=group_id, limit=limit)
+        return jsonify(result), 200
+
+    except ValueError as e:
+        return jsonify({
+            "group_id": group_id,
+            "backups": [],
+            "total": 0,
+            "available": False,
+            "message": str(e),
+        }), 200
+    except Exception as e:
+        logger.error(f"获取人格备份列表失败: {e}", exc_info=True)
+        return error_response(f"获取人格备份列表失败: {str(e)}", 500)
+
+
+@personas_bp.route("/persona_backups/<int:backup_id>", methods=["GET"])
+@require_auth
+async def get_persona_backup(backup_id: int):
+    """获取人格备份详情"""
+    try:
+        container = get_container()
+        backup_service = PersonaBackupService(container)
+        group_id = request.args.get("group_id", "default")
+        backup = await backup_service.get_backup(backup_id, group_id=group_id)
+        return jsonify(backup), 200
+
+    except ValueError as e:
+        return error_response(str(e), 404)
+    except Exception as e:
+        logger.error(f"获取人格备份详情失败: {e}", exc_info=True)
+        return error_response(f"获取人格备份详情失败: {str(e)}", 500)
+
+
+@personas_bp.route("/persona_backups/<int:backup_id>/restore", methods=["POST"])
+@require_auth
+async def restore_persona_backup(backup_id: int):
+    """恢复人格备份"""
+    try:
+        data = await request.get_json(silent=True) or {}
+        group_id = data.get("group_id") or request.args.get("group_id", "default")
+
+        container = get_container()
+        backup_service = PersonaBackupService(container)
+        success, message = await backup_service.restore_backup(backup_id, group_id=group_id)
+
+        if success:
+            return jsonify({"message": message}), 200
+        return error_response(message, 400)
+
+    except ValueError as e:
+        return error_response(str(e), 404)
+    except Exception as e:
+        logger.error(f"恢复人格备份失败: {e}", exc_info=True)
+        return error_response(f"恢复人格备份失败: {str(e)}", 500)
+
+
+@personas_bp.route("/persona_backups/<int:backup_id>", methods=["DELETE"])
+@require_auth
+async def delete_persona_backup(backup_id: int):
+    """删除人格备份"""
+    try:
+        container = get_container()
+        backup_service = PersonaBackupService(container)
+        group_id = request.args.get("group_id", "default")
+        success, message = await backup_service.delete_backup(backup_id, group_id=group_id)
+
+        if success:
+            return jsonify({"message": message}), 200
+        return error_response(message, 404)
+
+    except ValueError as e:
+        return error_response(str(e), 503)
+    except Exception as e:
+        logger.error(f"删除人格备份失败: {e}", exc_info=True)
+        return error_response(f"删除人格备份失败: {str(e)}", 500)
 
 
 @personas_bp.route("/persona_management/export/<persona_id>", methods=["GET"])

--- a/webui/dependencies.py
+++ b/webui/dependencies.py
@@ -27,6 +27,7 @@ class ServiceContainer:
 
         # 核心服务
         self.persona_manager: Optional[Any] = None
+        self.persona_backup_manager: Optional[Any] = None
         self.persona_updater: Optional[Any] = None
         self.database_manager: Optional[Any] = None
         self.database_degraded: bool = False
@@ -119,6 +120,11 @@ class ServiceContainer:
         # 从工厂获取服务
         service_factory = factory_manager.get_service_factory()
         self.persona_manager = service_factory.create_persona_manager()
+        try:
+            self.persona_backup_manager = service_factory.create_persona_backup_manager()
+        except Exception as e:
+            logger.warning(f"获取 persona_backup_manager 失败: {e}")
+            self.persona_backup_manager = None
         self.database_manager = (
             database_manager
             if database_manager is not None

--- a/webui/services/persona_backup_service.py
+++ b/webui/services/persona_backup_service.py
@@ -1,0 +1,181 @@
+"""
+人格备份 WebUI 服务 - 封装备份列表、详情、恢复与删除。
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+from astrbot.api import logger
+
+from .persona_service import _optional_container_attr
+
+
+class PersonaBackupService:
+    """人格备份管理服务。"""
+
+    def __init__(self, container):
+        self.container = container
+        self.database_manager = _optional_container_attr(container, 'database_manager')
+        self.persona_backup_manager = _optional_container_attr(container, 'persona_backup_manager')
+        self.persona_manager = _optional_container_attr(container, 'persona_manager')
+        self.persona_web_mgr = _optional_container_attr(container, 'persona_web_manager')
+
+    @staticmethod
+    def _normalize_limit(limit: Any, default: int = 20, maximum: int = 100) -> int:
+        try:
+            value = int(limit)
+        except (TypeError, ValueError):
+            value = default
+        return max(1, min(value, maximum))
+
+    @staticmethod
+    def _backup_summary(backup: Dict[str, Any]) -> Dict[str, Any]:
+        reason = backup.get('backup_reason') or backup.get('reason') or ''
+        original_persona = backup.get('original_persona') or {}
+        prompt = (
+            original_persona.get('prompt')
+            or original_persona.get('system_prompt')
+            or backup.get('persona_content')
+            or ''
+        )
+        return {
+            'id': backup.get('id'),
+            'group_id': backup.get('group_id'),
+            'backup_name': backup.get('backup_name'),
+            'timestamp': backup.get('timestamp') or backup.get('backup_time'),
+            'created_at': backup.get('created_at'),
+            'reason': reason,
+            'reason_short': reason[:80],
+            'persona_name': original_persona.get('name') or original_persona.get('persona_id') or '',
+            'prompt_length': len(prompt),
+        }
+
+    @staticmethod
+    def _persona_from_backup(backup: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        original = dict(backup.get('original_persona') or {})
+        config = dict(backup.get('persona_config') or {})
+        persona = {**config, **original}
+
+        persona_content = backup.get('persona_content')
+        if persona_content and not persona.get('prompt') and not persona.get('system_prompt'):
+            persona['prompt'] = persona_content
+        if 'system_prompt' not in persona and persona.get('prompt'):
+            persona['system_prompt'] = persona['prompt']
+        if 'prompt' not in persona and persona.get('system_prompt'):
+            persona['prompt'] = persona['system_prompt']
+        if not persona.get('persona_id'):
+            persona['persona_id'] = persona.get('name') or backup.get('backup_name') or 'default'
+
+        if not (persona.get('prompt') or persona.get('system_prompt')):
+            return None
+        persona.setdefault('name', persona.get('persona_id', '恢复的人格'))
+        persona.setdefault('begin_dialogs', backup.get('imitation_dialogues') or [])
+        persona.setdefault('tools', [])
+        return persona
+
+    def _ensure_database(self):
+        if not self.database_manager:
+            raise ValueError('数据库服务未初始化，无法管理人格备份')
+
+    async def list_backups(self, group_id: str = 'default', limit: Any = 20) -> Dict[str, Any]:
+        """获取人格备份列表。"""
+        self._ensure_database()
+        normalized_limit = self._normalize_limit(limit)
+
+        if not hasattr(self.database_manager, 'get_persona_backups'):
+            return {
+                'group_id': group_id,
+                'backups': [],
+                'total': 0,
+                'available': False,
+                'message': '当前数据库实现不支持人格备份列表',
+            }
+
+        try:
+            backups = await self.database_manager.get_persona_backups(
+                group_id=group_id,
+                limit=normalized_limit,
+                include_content=True,
+            )
+        except TypeError:
+            try:
+                backups = await self.database_manager.get_persona_backups(group_id, normalized_limit)
+            except TypeError:
+                backups = await self.database_manager.get_persona_backups(normalized_limit)
+        summaries = [self._backup_summary(backup) for backup in backups]
+        return {
+            'group_id': group_id,
+            'backups': summaries,
+            'total': len(summaries),
+            'available': True,
+        }
+
+    async def get_backup(self, backup_id: int, group_id: str = 'default') -> Dict[str, Any]:
+        """获取人格备份详情。"""
+        self._ensure_database()
+        if hasattr(self.database_manager, 'get_persona_backup'):
+            backup = await self.database_manager.get_persona_backup(backup_id, group_id=group_id)
+        elif hasattr(self.database_manager, 'restore_persona_backup'):
+            backup = await self.database_manager.restore_persona_backup(group_id, backup_id)
+        else:
+            backup = None
+
+        if not backup:
+            raise ValueError('人格备份不存在')
+
+        detail = dict(backup)
+        detail['summary'] = self._backup_summary(detail)
+        return detail
+
+    async def restore_backup(self, backup_id: int, group_id: str = 'default') -> Tuple[bool, str]:
+        """恢复人格备份。"""
+        if self.persona_backup_manager and hasattr(self.persona_backup_manager, 'restore_backup'):
+            try:
+                success = await self.persona_backup_manager.restore_backup(group_id, backup_id)
+                if success:
+                    return True, '人格备份恢复成功'
+            except Exception as e:
+                logger.warning(f"正式备份管理器恢复失败，尝试 WebUI fallback: {e}")
+
+        backup = await self.get_backup(backup_id, group_id=group_id)
+        persona = self._persona_from_backup(backup)
+        if not persona:
+            return False, '备份中没有可恢复的人格内容'
+
+        persona_id = persona['persona_id']
+        if self.persona_web_mgr and hasattr(self.persona_web_mgr, 'update_persona_via_web'):
+            result = await self.persona_web_mgr.update_persona_via_web(persona_id, persona)
+            if result.get('success'):
+                return True, '人格备份恢复成功'
+            if hasattr(self.persona_web_mgr, 'create_persona_via_web'):
+                result = await self.persona_web_mgr.create_persona_via_web(persona)
+                if result.get('success'):
+                    return True, '人格备份恢复成功'
+            return False, result.get('error', '人格备份恢复失败')
+
+        if self.persona_manager and hasattr(self.persona_manager, 'update_persona'):
+            try:
+                success = await self.persona_manager.update_persona(persona_id, persona)
+            except TypeError:
+                success = await self.persona_manager.update_persona(
+                    persona_id=persona_id,
+                    system_prompt=persona.get('system_prompt') or persona.get('prompt', ''),
+                    begin_dialogs=persona.get('begin_dialogs', []),
+                    tools=persona.get('tools'),
+                )
+            if success:
+                return True, '人格备份恢复成功'
+
+            if hasattr(self.persona_manager, 'create_persona'):
+                success = await self.persona_manager.create_persona(persona)
+                if success:
+                    return True, '人格备份恢复成功'
+
+        return False, 'PersonaManager 未初始化，无法恢复备份'
+
+    async def delete_backup(self, backup_id: int, group_id: str = 'default') -> Tuple[bool, str]:
+        """删除人格备份。"""
+        self._ensure_database()
+        if not hasattr(self.database_manager, 'delete_persona_backup'):
+            return False, '当前数据库实现不支持删除人格备份'
+
+        success = await self.database_manager.delete_persona_backup(backup_id, group_id=group_id)
+        return (True, '人格备份已删除') if success else (False, '人格备份不存在或删除失败')

--- a/webui/services/persona_service.py
+++ b/webui/services/persona_service.py
@@ -15,6 +15,14 @@ def _optional_container_attr(container, name: str, default=None):
     return value
 
 
+def _optional_object_attr(obj, name: str, default=None):
+    if obj is None:
+        return default
+    if obj.__class__.__module__ == 'unittest.mock' and name not in getattr(obj, '__dict__', {}):
+        return default
+    return getattr(obj, name, default)
+
+
 class PersonaService:
     """人格管理服务"""
 
@@ -49,6 +57,19 @@ class PersonaService:
     @staticmethod
     def _has_required_persona_fields(data: Dict[str, Any]) -> bool:
         return bool(data.get('persona_id') and (data.get('prompt') or data.get('system_prompt')))
+
+    @staticmethod
+    def _compact_persona(persona: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = PersonaService._normalize_persona_data(persona or {})
+        return {
+            "persona_id": normalized.get("persona_id") or normalized.get("id") or normalized.get("name") or "default",
+            "name": normalized.get("name") or normalized.get("persona_id") or "默认人格",
+            "prompt": normalized.get("prompt", ""),
+            "system_prompt": normalized.get("system_prompt", ""),
+            "begin_dialogs": normalized.get("begin_dialogs") or [],
+            "tools": normalized.get("tools") or [],
+            "metadata": normalized.get("metadata") or {},
+        }
 
     async def get_all_personas(self) -> List[Dict[str, Any]]:
         """
@@ -218,6 +239,45 @@ class PersonaService:
         except Exception as e:
             logger.error(f"获取默认人格失败: {e}", exc_info=True)
             return fallback_persona
+
+    async def get_current_persona_state(self, group_id: str = "default") -> Dict[str, Any]:
+        """获取当前生效人格的 WebUI 预览状态。"""
+        config = _optional_container_attr(self.container, 'plugin_config')
+        persona = await self.get_default_persona(group_id)
+        compact = self._compact_persona(persona)
+        prompt = compact.get("prompt") or compact.get("system_prompt") or ""
+        begin_dialogs = compact.get("begin_dialogs") if isinstance(compact.get("begin_dialogs"), list) else []
+        tools = compact.get("tools") if isinstance(compact.get("tools"), list) else []
+
+        config_snapshot = {
+            "current_persona_name": _optional_object_attr(config, "current_persona_name"),
+            "enable_persona_evolution": _optional_object_attr(config, "enable_persona_evolution"),
+            "persona_merge_strategy": _optional_object_attr(config, "persona_merge_strategy"),
+            "persona_compatibility_threshold": _optional_object_attr(config, "persona_compatibility_threshold"),
+            "persona_update_backup_enabled": _optional_object_attr(config, "persona_update_backup_enabled"),
+            "auto_backup_enabled": _optional_object_attr(config, "auto_backup_enabled"),
+            "backup_interval_hours": _optional_object_attr(config, "backup_interval_hours"),
+            "max_backups_per_group": _optional_object_attr(config, "max_backups_per_group"),
+        }
+
+        available_services = {
+            "persona_manager": bool(self.persona_manager),
+            "persona_web_manager": bool(self.persona_web_mgr),
+            "astrbot_persona_manager": bool(self.astrbot_persona_manager),
+        }
+
+        return {
+            "group_id": group_id or "default",
+            "persona": compact,
+            "prompt_preview": prompt[:240],
+            "prompt_length": len(prompt),
+            "begin_dialog_count": len(begin_dialogs),
+            "tool_count": len(tools),
+            "config": config_snapshot,
+            "available_services": available_services,
+            "generated_at": datetime.now().isoformat(),
+            "degraded": not any(available_services.values()),
+        }
 
     async def export_persona(self, persona_id: str) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- Add an authenticated current persona state API for WebUI previews.
- Add authenticated persona backup list/detail/restore/delete APIs with database-manager fallbacks.
- Add dashboard panels for current persona status and persona backup management.
- Fix persona backup database delegation to support group filtering and ready-state fallback.

Closes #153

## Tests
- `python -m pytest tests\unit\test_persona_backup_service.py tests\unit\test_persona_service.py tests\unit\test_sqlalchemy_db_manager_contract.py tests\integration\test_webui_static_assets.py -q`
- `python -m ruff check webui\services\persona_backup_service.py webui\services\persona_service.py webui\blueprints\personas.py webui\dependencies.py services\database\facades\persona_facade.py services\database\sqlalchemy_database_manager.py services\sqlalchemy_database_manager.py repositories\persona_backup_repository.py tests\unit\test_persona_backup_service.py tests\unit\test_persona_service.py tests\unit\test_sqlalchemy_db_manager_contract.py tests\integration\test_webui_static_assets.py`
- `python -m py_compile webui\services\persona_backup_service.py webui\services\persona_service.py webui\blueprints\personas.py services\database\facades\persona_facade.py services\database\sqlalchemy_database_manager.py services\sqlalchemy_database_manager.py repositories\persona_backup_repository.py webui\dependencies.py`
- `git diff --check`

## Summary by Sourcery

Add authenticated WebUI support for viewing current persona state and managing persona backups, including database-backed list/detail/restore/delete flows with fallbacks.

New Features:
- Expose an authenticated API and dashboard panel to preview the current effective persona state for a group.
- Expose authenticated APIs and dashboard UI for listing, viewing, restoring, and deleting persona backups from the WebUI.

Bug Fixes:
- Align persona backup database access with group-aware lookups and add fallbacks for legacy method signatures and unsupported operations.

Enhancements:
- Extend persona backup database facade and SQLAlchemy manager to support grouped backup listing, detail retrieval, restore, and delete operations while remaining backward compatible.
- Add a dedicated WebUI persona backup service to orchestrate backup listing, detail, restore, and delete logic across database and persona managers.
- Update dependency wiring to initialize an optional persona backup manager service used during backup restores.

Tests:
- Add unit tests for the persona backup WebUI service and current persona state preview, and update integration and contract tests to cover the new dashboard panels and database manager API surface.