### PR TITLE
[codex] Render LivingMemory graph locally

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -71,7 +71,7 @@ Dashboard -> 功能融合
 页面内容:
 
 - Self Learning 当前面板。
-- LivingMemory 状态、面板入口和开发 API 列表。
+- LivingMemory 状态、外部面板入口和本地图谱适配 API 列表。
 - Group Chat Plus 状态、面板入口和开发 API 列表。
 - `Integration_Settings` 快速编辑。
 
@@ -111,7 +111,7 @@ Dashboard -> 功能融合
 | `active` | 是否检测到插件 |
 | `delegated` | 当前能力是否已委托 |
 | `plugin` | AstrBot star 元信息 |
-| `dashboard` | 面板 URL、AstrBot 页面 URL、入口类型 |
+| `dashboard` | 面板 URL、本地图谱路由、入口类型 |
 | `dev_api` | 该插件公开 API 列表 |
 | `settings_group` | 相关配置组 |
 
@@ -131,19 +131,13 @@ Dashboard -> 功能融合
 
 ### LivingMemory
 
-- `GET /astrbot_plugin_livingmemory/page/stats`
-- `GET /astrbot_plugin_livingmemory/page/memories`
-- `POST /astrbot_plugin_livingmemory/page/memories/update`
-- `POST /astrbot_plugin_livingmemory/page/memories/batch-delete`
-- `POST /astrbot_plugin_livingmemory/page/recall/test`
-- `GET /astrbot_plugin_livingmemory/page/graph/overview`
-- `POST /astrbot_plugin_livingmemory/page/graph/query`
+Self Learning 不再调用 LivingMemory 的 Page 图谱 API。Dashboard 的
+`#/graphs` 模块会在 LivingMemory 已加载时直读其
+`initializer.memory_engine.graph_store` 后端对象，并通过本插件接口暴露
+ECharts 图谱 payload:
 
-AstrBot 页面入口:
-
-```text
-/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/
-```
+- `GET /api/graphs/memory`
+- `GET /api/graphs/knowledge`
 
 ### Group Chat Plus
 
@@ -165,7 +159,7 @@ AstrBot 页面入口:
 | Dashboard 显示未委托 | 目标插件是否已加载、启用、名称是否匹配 |
 | LivingMemory 已安装但仍写入本地记忆 | `delegate_memory_to_livingmemory` 和 `disable_local_memory_when_delegated` 是否为 `true` |
 | Group Chat Plus 已安装但仍创建本地回复器 | `delegate_reply_to_group_chat_plus` 和 `disable_local_reply_when_delegated` 是否为 `true` |
-| 面板入口为空 | 目标插件 Web 面板是否开启，或是否只提供 AstrBot Pages 入口 |
+| 面板入口为空 | 目标插件 Web 面板是否开启；图谱模块仍可通过本插件 `/api/graphs/*` 查看 |
 | API 列表不匹配 | 以目标插件当前开发 API 为准，更新 `webui/services/integration_service.py` |
 
 ## 测试

--- a/tests/integration/test_graph_blueprint.py
+++ b/tests/integration/test_graph_blueprint.py
@@ -77,6 +77,85 @@ async def test_memory_graph_route_explains_livingmemory_delegation(
 
 
 @pytest.mark.asyncio
+async def test_memory_graph_route_reads_livingmemory_graph_store(
+    client,
+    monkeypatch,
+):
+    class GraphStore:
+        async def get_graph_snapshot(self, **_kwargs):
+            return {
+                "nodes": [
+                    {
+                        "id": 1,
+                        "type": "person",
+                        "label": "Alice",
+                        "canonical_value": "alice",
+                        "entry_count": 1,
+                    },
+                    {
+                        "id": 2,
+                        "type": "topic",
+                        "label": "Tea",
+                        "canonical_value": "tea",
+                        "entry_count": 1,
+                    },
+                ],
+                "edges": [
+                    {
+                        "source": 1,
+                        "target": 2,
+                        "relation_type": "likes",
+                        "weight": 1,
+                    }
+                ],
+                "entries": [],
+                "memories": [
+                    {
+                        "memory_id": 42,
+                        "summary": "Alice likes tea",
+                        "session_id": "umo:group-a",
+                    }
+                ],
+            }
+
+    livingmemory_plugin = SimpleNamespace(
+        initializer=SimpleNamespace(
+            memory_engine=SimpleNamespace(
+                graph_store=GraphStore(),
+                get_statistics=lambda: (_ for _ in ()).throw(RuntimeError("stats down")),
+            )
+        )
+    )
+    monkeypatch.setattr(
+        graphs_module,
+        "get_container",
+        lambda: SimpleNamespace(
+            database_manager=None,
+            group_id_to_unified_origin={"group-a": "umo:group-a"},
+            feature_delegation=SimpleNamespace(
+                status=lambda: {
+                    "memory_delegated": True,
+                    "memory_plugin": "LivingMemory",
+                    "reply_delegated": False,
+                    "reply_plugin": None,
+                },
+                memory_plugin=lambda: SimpleNamespace(star_cls=livingmemory_plugin),
+            ),
+        ),
+    )
+
+    response = await client.get("/api/graphs/memory?group_id=group-a")
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["success"] is True
+    assert data["data_source"] == "livingmemory_graph_store"
+    assert "empty_reason" not in data
+    assert {node["name"] for node in data["nodes"]} >= {"Alice", "Tea"}
+    assert any(link["label"]["formatter"] == "likes" for link in data["links"])
+
+
+@pytest.mark.asyncio
 async def test_knowledge_graph_route_returns_echarts_payload(client):
     response = await client.get("/api/graphs/knowledge")
 

--- a/tests/integration/test_graph_blueprint.py
+++ b/tests/integration/test_graph_blueprint.py
@@ -71,8 +71,8 @@ async def test_memory_graph_route_explains_livingmemory_delegation(
     data = await response.get_json()
     assert data["success"] is True
     assert data["type"] == "memory"
-    assert data["empty_reason"] == "memory_delegated"
-    assert data["data_source"] == "livingmemory_delegated"
+    assert data["empty_reason"] == "graph_backend_empty"
+    assert data["data_source"] == "livingmemory_backend_empty"
     assert "LivingMemory" in data["message"]
 
 

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -120,8 +120,9 @@ def test_dashboard_exposes_companion_plugin_api_hub():
     assert "/api/integrations/embed/livingmemory" in text + service
     assert "/api/integrations/embed/group_chat_plus" in text + service
     assert "reply-strategy" in text + service
-    assert "astrbot_plugin_livingmemory/page" in service
-    assert "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/" in service
+    assert "self_learning_graph_store_adapter" in service
+    assert "astrbot_plugin_livingmemory/page" not in service
+    assert "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/" not in service
     assert "Group Chat Plus" in service
     assert "POST /api/auth/login" in service
     assert "GET /api/data/overview" in service

--- a/tests/unit/test_graph_service.py
+++ b/tests/unit/test_graph_service.py
@@ -91,6 +91,125 @@ async def test_memory_graph_reads_active_mem0_manager(monkeypatch):
     assert payload["stats"]["nodes"] > 0
 
 
+@pytest.mark.asyncio
+async def test_memory_graph_reads_livingmemory_graph_store_directly():
+    class GraphStore:
+        calls = []
+
+        async def get_graph_snapshot(
+            self,
+            *,
+            session_id,
+            persona_id,
+            limit_memories,
+            limit_entries,
+            limit_nodes,
+            limit_edges,
+        ):
+            self.calls.append(
+                {
+                    "session_id": session_id,
+                    "persona_id": persona_id,
+                    "limit_memories": limit_memories,
+                    "limit_entries": limit_entries,
+                    "limit_nodes": limit_nodes,
+                    "limit_edges": limit_edges,
+                }
+            )
+            return {
+                "nodes": [
+                    {
+                        "id": 1,
+                        "type": "person",
+                        "label": "Alice",
+                        "canonical_value": "alice",
+                        "entry_count": 2,
+                        "memory_count": 1,
+                        "degree": 1,
+                    },
+                    {
+                        "id": 2,
+                        "type": "topic",
+                        "label": "Tea",
+                        "canonical_value": "tea",
+                        "entry_count": 1,
+                        "memory_count": 1,
+                        "degree": 1,
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": 7,
+                        "source": 1,
+                        "target": 2,
+                        "relation_type": "likes",
+                        "memory_id": 42,
+                        "weight": 1.5,
+                    }
+                ],
+                "entries": [
+                    {
+                        "id": 9,
+                        "memory_id": 42,
+                        "entry_type": "fact",
+                        "relation_type": "likes",
+                        "content": "Alice likes tea",
+                        "session_id": "umo:group-a",
+                        "node_ids": [1, 2],
+                    }
+                ],
+                "memories": [
+                    {
+                        "memory_id": 42,
+                        "summary": "Alice likes tea",
+                        "session_id": "umo:group-a",
+                        "importance": 0.8,
+                    }
+                ],
+            }
+
+    graph_store = GraphStore()
+    livingmemory_plugin = SimpleNamespace(
+        initializer=SimpleNamespace(
+            memory_engine=SimpleNamespace(
+                graph_store=graph_store,
+                get_statistics=lambda: {
+                    "graph_nodes": 2,
+                    "graph_edges": 1,
+                    "graph_entries": 1,
+                },
+            )
+        )
+    )
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": True,
+            "memory_plugin": "LivingMemory",
+        },
+        memory_plugin=lambda: SimpleNamespace(star_cls=livingmemory_plugin),
+    )
+    container = SimpleNamespace(
+        database_manager=None,
+        plugin_config=SimpleNamespace(),
+        v2_integration=None,
+        group_id_to_unified_origin={"group-a": "umo:group-a"},
+        feature_delegation=delegation,
+    )
+
+    payload = await GraphService(container).get_memory_graph(group_id="group-a", limit=30)
+
+    assert graph_store.calls[0]["session_id"] == "umo:group-a"
+    assert payload["data_source"] == "livingmemory_graph_store"
+    assert payload["source_stats"]["graph_nodes"] == 2
+    assert payload["groups"] == ["umo:group-a"]
+    assert {node["name"] for node in payload["nodes"]} >= {
+        "Alice",
+        "Tea",
+        "Alice likes tea",
+    }
+    assert any(link["label"]["formatter"] == "likes" for link in payload["links"])
+
+
 def test_memory_graph_singleton_accepts_late_dependencies(monkeypatch):
     monkeypatch.setattr(EnhancedMemoryGraphManager, "_instance", None)
     first = EnhancedMemoryGraphManager.get_instance()

--- a/tests/unit/test_integration_service.py
+++ b/tests/unit/test_integration_service.py
@@ -75,8 +75,10 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
     assert dashboards["livingmemory"]["dashboard"]["url"] == "/api/integrations/embed/livingmemory"
     assert dashboards["livingmemory"]["dashboard"]["external_url"] == "http://127.0.0.1:8888"
     assert dashboards["livingmemory"]["dashboard"]["route"] == "#/graphs"
-    assert dashboards["livingmemory"]["dev_api"]["base"] == "/astrbot_plugin_livingmemory/page"
-    assert "POST /astrbot_plugin_livingmemory/page/graph/query" in dashboards["livingmemory"]["dev_api"]["endpoints"]
+    assert dashboards["livingmemory"]["dev_api"]["base"] == "/api/graphs"
+    assert dashboards["livingmemory"]["dev_api"]["mode"] == "self_learning_graph_store_adapter"
+    assert "GET /api/graphs/memory" in dashboards["livingmemory"]["dev_api"]["endpoints"]
+    assert "POST /astrbot_plugin_livingmemory/page/graph/query" not in dashboards["livingmemory"]["dev_api"]["endpoints"]
     assert dashboards["group_chat_plus"]["dashboard"]["url"] == "/api/integrations/embed/group_chat_plus"
     assert dashboards["group_chat_plus"]["dashboard"]["external_url"] == "http://127.0.0.1:8787/panel?embed=1"
     assert dashboards["group_chat_plus"]["dashboard"]["route"] == "#/reply-strategy"

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -2172,7 +2172,7 @@
                     <div class="module-card-top">
                         <div class="module-title">
                             <strong>记忆 / 知识图谱</strong>
-                            <span>LivingMemory 面板</span>
+                            <span>本地图谱</span>
                         </div>
                         <span class="module-icon"><span class="material-icons">hub</span></span>
                     </div>
@@ -2599,39 +2599,45 @@
             <div class="page-titlebar">
                 <div class="page-title">
                     <h2>记忆 / 知识图谱</h2>
-                    <p>嵌入 LivingMemory WebUI，统一管理长期记忆、召回测试和知识图谱。</p>
+                    <p>直接读取本插件和 LivingMemory 后端图谱存储，构建本地图谱视图。</p>
                 </div>
                 <a class="back-home" href="#/home"><span class="material-icons" style="font-size:18px;">apps</span>模块</a>
             </div>
 
-            <section class="companion-band">
-            <div class="panel">
-                <div class="panel-head">
-                    <div>
-                        <h2>LivingMemory</h2>
-                        <span class="hint">长期记忆和知识图谱由 LivingMemory 接管。</span>
+            <section class="graphs-band">
+                <div class="panel">
+                    <div class="panel-head">
+                        <div>
+                            <h2>图谱视图</h2>
+                            <span class="hint" id="graphHint">等待加载图谱</span>
+                        </div>
+                        <div class="panel-tools graph-toolbar">
+                            <div class="graph-tabs" aria-label="图谱类型">
+                                <button class="seg-btn active" type="button" data-graph-type="memory">
+                                    <span class="material-icons" style="font-size:16px;">psychology</span>
+                                    记忆图
+                                </button>
+                                <button class="seg-btn" type="button" data-graph-type="knowledge">
+                                    <span class="material-icons" style="font-size:16px;">account_tree</span>
+                                    知识图谱
+                                </button>
+                            </div>
+                            <input class="graph-input" id="graphGroupInput" type="search" placeholder="群组 / 会话 ID" autocomplete="off">
+                            <button class="icon-btn" id="graphLayoutBtn" type="button" aria-label="切换图谱布局" title="切换图谱布局">
+                                <span class="material-icons">device_hub</span>
+                            </button>
+                            <button class="icon-btn" id="graphReloadBtn" type="button" aria-label="刷新图谱" title="刷新图谱">
+                                <span class="material-icons">sync</span>
+                            </button>
+                        </div>
                     </div>
-                    <div class="panel-tools">
-                        <a class="action-btn" id="livingMemoryExternalBtn" href="/api/integrations/embed/livingmemory" target="_blank" rel="noopener noreferrer">
-                            <span class="material-icons" style="font-size:16px;">open_in_new</span>
-                            新窗口
-                        </a>
-                        <button class="icon-btn" id="livingMemoryReloadBtn" type="button" aria-label="刷新 LivingMemory 面板" title="刷新 LivingMemory 面板">
-                            <span class="material-icons">sync</span>
-                        </button>
+                    <div class="panel-body">
+                        <div class="graph-summary" id="graphSummary"></div>
+                        <div id="graphChart" class="graph-chart"></div>
+                        <div class="graph-detail" id="graphDetail">选择节点查看详情。</div>
                     </div>
                 </div>
-                <div class="panel-body">
-                    <div class="companion-status" id="livingMemoryStatus">
-                        <span class="chip">LivingMemory 子页面</span>
-                        <span>正在准备嵌入面板。</span>
-                    </div>
-                    <div class="companion-frame-shell" style="margin-top:10px;">
-                        <iframe id="livingMemoryFrame" title="LivingMemory 面板" data-companion-frame="livingmemory"></iframe>
-                    </div>
-                </div>
-            </div>
-        </section>
+            </section>
         </section>
 
         <section class="page" id="page-reply-strategy" data-page="reply-strategy">
@@ -3293,7 +3299,9 @@
 
             function graphDataSourceLabel(value) {
                 return {
-                    livingmemory_delegated: 'LivingMemory 委托',
+                    livingmemory_graph_store: 'LivingMemory 后端',
+                    livingmemory_backend_empty: 'LivingMemory 后端',
+                    self_learning: 'Self Learning',
                 }[value] || value;
             }
 
@@ -3336,7 +3344,11 @@
             function loadPageData(page, options = {}) {
                 const force = Boolean(options.force);
                 if (page === 'graphs') {
-                    loadCompanionFrame('livingmemory', { force });
+                    if (force || !state.graph.loaded) {
+                        loadGraphPanel({ quiet: true });
+                    } else {
+                        renderGraphPanel(state.graph.data);
+                    }
                 } else if (page === 'reply-strategy') {
                     loadCompanionFrame('group_chat_plus', { force });
                 } else if (page === 'content' && (force || !state.content.loaded)) {
@@ -3405,12 +3417,12 @@
                 $('homeReplyNote').textContent = groupChatPlusDashboard
                     ? (groupChatPlusDashboard.delegated ? '回复已委托' : (groupChatPlusDashboard.active ? '插件已加载' : '插件未加载'))
                     : '检查 Group Chat Plus';
-                $('homeGraphValue').textContent = livingMemoryDashboard
-                    ? (livingMemoryDashboard.delegated ? 'ON' : (livingMemoryDashboard.active ? '本地' : '--'))
-                    : (graphNodes ? formatCount(graphNodes) : '--');
-                $('homeGraphNote').textContent = livingMemoryDashboard
-                    ? (livingMemoryDashboard.delegated ? '记忆已委托' : (livingMemoryDashboard.active ? '插件已加载' : '插件未加载'))
-                    : '检查 LivingMemory';
+                $('homeGraphValue').textContent = graphNodes
+                    ? formatCount(graphNodes)
+                    : (livingMemoryDashboard && livingMemoryDashboard.active ? '后端' : '--');
+                $('homeGraphNote').textContent = graphNodes
+                    ? '本地图谱节点'
+                    : (livingMemoryDashboard && livingMemoryDashboard.delegated ? '直读 LivingMemory 后端' : '本地图谱');
                 $('homeIntegrationValue').textContent = integrationDashboards.length
                     ? `${formatCount(activeIntegrations)}/${formatCount(integrationDashboards.length)}`
                     : '--';
@@ -6724,10 +6736,20 @@
                     }
                 });
 
-                const livingMemoryReloadBtn = $('livingMemoryReloadBtn');
-                if (livingMemoryReloadBtn) {
-                    livingMemoryReloadBtn.addEventListener('click', () => loadCompanionFrame('livingmemory', { force: true }));
-                }
+                $('graphReloadBtn').addEventListener('click', () => loadGraphPanel());
+                $('graphLayoutBtn').addEventListener('click', () => {
+                    state.graph.layout = state.graph.layout === 'force' ? 'circular' : 'force';
+                    renderGraphPanel(state.graph.data);
+                });
+                let graphGroupTimer = null;
+                $('graphGroupInput').addEventListener('input', (event) => {
+                    clearTimeout(graphGroupTimer);
+                    graphGroupTimer = setTimeout(() => {
+                        state.graph.groupId = (event.target.value || '').trim();
+                        state.graph.loaded = false;
+                        loadGraphPanel({ quiet: true });
+                    }, 360);
+                });
                 const groupChatPlusReloadBtn = $('groupChatPlusReloadBtn');
                 if (groupChatPlusReloadBtn) {
                     groupChatPlusReloadBtn.addEventListener('click', () => loadCompanionFrame('group_chat_plus', { force: true }));

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -6736,20 +6736,29 @@
                     }
                 });
 
-                $('graphReloadBtn').addEventListener('click', () => loadGraphPanel());
-                $('graphLayoutBtn').addEventListener('click', () => {
-                    state.graph.layout = state.graph.layout === 'force' ? 'circular' : 'force';
-                    renderGraphPanel(state.graph.data);
-                });
+                const graphReloadBtn = $('graphReloadBtn');
+                if (graphReloadBtn) {
+                    graphReloadBtn.addEventListener('click', () => loadGraphPanel());
+                }
+                const graphLayoutBtn = $('graphLayoutBtn');
+                if (graphLayoutBtn) {
+                    graphLayoutBtn.addEventListener('click', () => {
+                        state.graph.layout = state.graph.layout === 'force' ? 'circular' : 'force';
+                        renderGraphPanel(state.graph.data);
+                    });
+                }
                 let graphGroupTimer = null;
-                $('graphGroupInput').addEventListener('input', (event) => {
-                    clearTimeout(graphGroupTimer);
-                    graphGroupTimer = setTimeout(() => {
-                        state.graph.groupId = (event.target.value || '').trim();
-                        state.graph.loaded = false;
-                        loadGraphPanel({ quiet: true });
-                    }, 360);
-                });
+                const graphGroupInput = $('graphGroupInput');
+                if (graphGroupInput) {
+                    graphGroupInput.addEventListener('input', (event) => {
+                        clearTimeout(graphGroupTimer);
+                        graphGroupTimer = setTimeout(() => {
+                            state.graph.groupId = (event.target.value || '').trim();
+                            state.graph.loaded = false;
+                            loadGraphPanel({ quiet: true });
+                        }, 360);
+                    });
+                }
                 const groupChatPlusReloadBtn = $('groupChatPlusReloadBtn');
                 if (groupChatPlusReloadBtn) {
                     groupChatPlusReloadBtn.addEventListener('click', () => loadCompanionFrame('group_chat_plus', { force: true }));

--- a/webui/services/graph_service.py
+++ b/webui/services/graph_service.py
@@ -238,14 +238,7 @@ class GraphService:
             return False
 
         try:
-            stats_getter = getattr(memory_engine, "get_statistics", None)
-            if callable(stats_getter):
-                stats = stats_getter()
-                if inspect.isawaitable(stats):
-                    stats = await stats
-                if isinstance(stats, dict):
-                    source_stats.update(stats)
-
+            await self._append_livingmemory_stats(memory_engine, source_stats)
             snapshot = await self._read_livingmemory_snapshot(
                 graph_store,
                 group_id=group_id,
@@ -267,6 +260,24 @@ class GraphService:
         except Exception as e:
             logger.warning(f"读取 LivingMemory 后端图谱失败: {e}", exc_info=True)
             return False
+
+    async def _append_livingmemory_stats(
+        self,
+        memory_engine: Any,
+        source_stats: Dict[str, Any],
+    ) -> None:
+        stats_getter = getattr(memory_engine, "get_statistics", None)
+        if not callable(stats_getter):
+            return
+
+        try:
+            stats = stats_getter()
+            if inspect.isawaitable(stats):
+                stats = await stats
+            if isinstance(stats, dict):
+                source_stats.update(stats)
+        except Exception as exc:
+            logger.debug(f"读取 LivingMemory 图谱统计失败，继续加载图谱快照: {exc}")
 
     def _livingmemory_graph_backend(self) -> Tuple[Any, Any]:
         delegation = self._delegation()
@@ -388,6 +399,11 @@ class GraphService:
         raw_entries = self._safe_items(snapshot.get("entries"))
         raw_memories = self._safe_items(snapshot.get("memories"))
         raw_id_to_node_id: Dict[str, str] = {}
+        initial_link_count = len(links)
+        max_new_links = max(1, int(limit or 1) * 3)
+
+        def link_budget_exhausted() -> bool:
+            return len(links) - initial_link_count >= max_new_links
 
         for item in raw_nodes:
             if len(nodes) >= limit:
@@ -453,6 +469,8 @@ class GraphService:
             )
 
         for edge in raw_edges:
+            if link_budget_exhausted():
+                break
             source = raw_id_to_node_id.get(str(edge.get("source")))
             target = raw_id_to_node_id.get(str(edge.get("target")))
             if not source or not target:
@@ -480,6 +498,8 @@ class GraphService:
                 or "提及"
             )
             for raw_node_id in self._safe_items(entry.get("node_ids"))[:6]:
+                if link_budget_exhausted():
+                    break
                 target = raw_id_to_node_id.get(str(raw_node_id))
                 if target:
                     self._add_link(links, seen_links, memory_node_id, target, label, 1)

--- a/webui/services/graph_service.py
+++ b/webui/services/graph_service.py
@@ -4,6 +4,7 @@ Dashboard graph data service.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import re
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -57,20 +58,14 @@ class GraphService:
 
         plugin_name = status.get("memory_plugin") or "LivingMemory"
         if graph_type == "memory":
-            message = (
-                f"记忆已委托给 {plugin_name}，本插件不再维护本地长期记忆图。"
-                f"请在 {plugin_name} 面板查看记忆与图谱数据。"
-            )
+            message = f"{plugin_name} 后端图谱暂无可展示节点。"
         else:
-            message = (
-                f"长期记忆已委托给 {plugin_name}。当前本地知识图谱为空，"
-                f"如需查看委托侧记忆图谱，请打开 {plugin_name} 面板。"
-            )
+            message = f"长期记忆已委托给 {plugin_name}，当前本地知识图谱为空。"
 
         payload.update(
             {
-                "data_source": "livingmemory_delegated",
-                "empty_reason": "memory_delegated",
+                "data_source": "livingmemory_backend_empty",
+                "empty_reason": "graph_backend_empty",
                 "message": message,
                 "delegation": status,
             }
@@ -166,17 +161,30 @@ class GraphService:
         seen_nodes: Set[str] = set()
         seen_links: Set[Tuple[str, str, str]] = set()
         groups: Set[str] = set()
+        source_stats: Dict[str, Any] = {}
 
-        await self._append_live_memory_graph(
-            nodes, links, seen_nodes, seen_links, groups, group_id, limit
+        livingmemory_used = await self._append_livingmemory_graph_store(
+            nodes,
+            links,
+            seen_nodes,
+            seen_links,
+            groups,
+            group_id,
+            limit,
+            source_stats,
         )
 
-        if len(nodes) < limit:
+        if not livingmemory_used:
+            await self._append_live_memory_graph(
+                nodes, links, seen_nodes, seen_links, groups, group_id, limit
+            )
+
+        if not livingmemory_used and len(nodes) < limit:
             await self._append_v2_mem0_memories(
                 nodes, links, seen_nodes, seen_links, groups, group_id, limit
             )
 
-        if len(nodes) < 2:
+        if not livingmemory_used and len(nodes) < 2:
             await self._append_memory_rows(
                 nodes, links, seen_nodes, seen_links, groups, group_id, limit
             )
@@ -191,6 +199,9 @@ class GraphService:
         payload = {
             "success": True,
             "type": "memory",
+            "data_source": (
+                "livingmemory_graph_store" if livingmemory_used else "self_learning"
+            ),
             "group_id": group_id,
             "groups": sorted(groups),
             "nodes": returned_nodes,
@@ -206,7 +217,301 @@ class GraphService:
                 "groups": len(groups),
             },
         }
+        if source_stats:
+            payload["source_stats"] = source_stats
         return self._maybe_add_delegated_empty_state(payload, "memory")
+
+    async def _append_livingmemory_graph_store(
+        self,
+        nodes: List[Dict[str, Any]],
+        links: List[Dict[str, Any]],
+        seen_nodes: Set[str],
+        seen_links: Set[Tuple[str, str, str]],
+        groups: Set[str],
+        group_id: Optional[str],
+        limit: int,
+        source_stats: Dict[str, Any],
+    ) -> bool:
+        """Append graph data directly from LivingMemory's backend graph store."""
+        graph_store, memory_engine = self._livingmemory_graph_backend()
+        if graph_store is None:
+            return False
+
+        try:
+            stats_getter = getattr(memory_engine, "get_statistics", None)
+            if callable(stats_getter):
+                stats = stats_getter()
+                if inspect.isawaitable(stats):
+                    stats = await stats
+                if isinstance(stats, dict):
+                    source_stats.update(stats)
+
+            snapshot = await self._read_livingmemory_snapshot(
+                graph_store,
+                group_id=group_id,
+                limit=limit,
+            )
+            if not self._livingmemory_snapshot_has_data(snapshot):
+                return False
+
+            self._append_livingmemory_snapshot(
+                snapshot,
+                nodes,
+                links,
+                seen_nodes,
+                seen_links,
+                groups,
+                limit,
+            )
+            return bool(nodes)
+        except Exception as e:
+            logger.warning(f"读取 LivingMemory 后端图谱失败: {e}", exc_info=True)
+            return False
+
+    def _livingmemory_graph_backend(self) -> Tuple[Any, Any]:
+        delegation = self._delegation()
+        star = None
+        if delegation:
+            memory_plugin = getattr(delegation, "memory_plugin", None)
+            if callable(memory_plugin):
+                try:
+                    star = memory_plugin()
+                except Exception:
+                    star = None
+
+        plugin = getattr(star, "star_cls", None)
+        if plugin is None:
+            return None, None
+
+        initializer = getattr(plugin, "initializer", None)
+        memory_engine = (
+            getattr(initializer, "memory_engine", None)
+            or getattr(plugin, "memory_engine", None)
+        )
+        graph_store = getattr(memory_engine, "graph_store", None)
+        return graph_store, memory_engine
+
+    def _delegation(self) -> Optional[Any]:
+        delegation = getattr(self.container, "feature_delegation", None)
+        if delegation:
+            return delegation
+
+        config = getattr(self.container, "plugin_config", None)
+        factory_manager = getattr(self.container, "factory_manager", None)
+        if not config or not factory_manager:
+            return None
+
+        try:
+            service_factory = factory_manager.get_service_factory()
+            context = getattr(service_factory, "context", None)
+            if not context:
+                return None
+            try:
+                from ...core.feature_delegation import FeatureDelegation
+            except ImportError:
+                from core.feature_delegation import FeatureDelegation
+
+            delegation = FeatureDelegation(config, context)
+            self.container.feature_delegation = delegation
+            return delegation
+        except Exception:
+            return None
+
+    async def _read_livingmemory_snapshot(
+        self,
+        graph_store: Any,
+        group_id: Optional[str],
+        limit: int,
+    ) -> Dict[str, Any]:
+        snapshot_getter = getattr(graph_store, "get_graph_snapshot", None)
+        if not callable(snapshot_getter):
+            return {}
+
+        limit_memories = max(1, min(max(limit // 8, 12), 24))
+        limit_entries = max(12, min(limit, 80))
+        limit_nodes = max(12, min(limit, 80))
+        limit_edges = max(12, min(limit * 2, 120))
+
+        session_candidates = self._livingmemory_session_candidates(group_id)
+        last_snapshot: Dict[str, Any] = {}
+        for session_id in session_candidates:
+            snapshot = snapshot_getter(
+                session_id=session_id,
+                persona_id=None,
+                limit_memories=limit_memories,
+                limit_entries=limit_entries,
+                limit_nodes=limit_nodes,
+                limit_edges=limit_edges,
+            )
+            if inspect.isawaitable(snapshot):
+                snapshot = await snapshot
+            if isinstance(snapshot, dict):
+                last_snapshot = snapshot
+                if self._livingmemory_snapshot_has_data(snapshot):
+                    return snapshot
+        return last_snapshot
+
+    def _livingmemory_session_candidates(self, group_id: Optional[str]) -> List[Optional[str]]:
+        if not group_id:
+            return [None]
+
+        candidates: List[Optional[str]] = []
+        mapping = getattr(self.container, "group_id_to_unified_origin", None)
+        if isinstance(mapping, dict):
+            mapped = mapping.get(str(group_id))
+            if mapped:
+                candidates.append(str(mapped))
+        candidates.append(str(group_id))
+        return list(dict.fromkeys(candidates))
+
+    @staticmethod
+    def _livingmemory_snapshot_has_data(snapshot: Any) -> bool:
+        if not isinstance(snapshot, dict):
+            return False
+        return any(
+            bool(snapshot.get(key))
+            for key in ("nodes", "edges", "entries", "memories")
+        )
+
+    def _append_livingmemory_snapshot(
+        self,
+        snapshot: Dict[str, Any],
+        nodes: List[Dict[str, Any]],
+        links: List[Dict[str, Any]],
+        seen_nodes: Set[str],
+        seen_links: Set[Tuple[str, str, str]],
+        groups: Set[str],
+        limit: int,
+    ) -> None:
+        raw_nodes = self._safe_items(snapshot.get("nodes"))
+        raw_edges = self._safe_items(snapshot.get("edges"))
+        raw_entries = self._safe_items(snapshot.get("entries"))
+        raw_memories = self._safe_items(snapshot.get("memories"))
+        raw_id_to_node_id: Dict[str, str] = {}
+
+        for item in raw_nodes:
+            if len(nodes) >= limit:
+                break
+            raw_id = item.get("id")
+            if raw_id is None:
+                continue
+            node_id = f"livingmemory-node:{raw_id}"
+            raw_id_to_node_id[str(raw_id)] = node_id
+            category = self._livingmemory_node_category(item)
+            label = (
+                item.get("label")
+                or item.get("canonical_value")
+                or item.get("value")
+                or item.get("key")
+                or str(raw_id)
+            )
+            detail = self._livingmemory_node_detail(item)
+            self._add_node(
+                nodes,
+                seen_nodes,
+                node_id,
+                str(label),
+                category,
+                self._to_float(
+                    item.get("weight")
+                    or item.get("entry_count")
+                    or item.get("memory_count"),
+                    1,
+                ),
+                detail=detail,
+                source="livingmemory",
+                raw_id=raw_id,
+            )
+
+        memory_node_ids: Dict[str, str] = {}
+        for item in raw_memories:
+            session_id = item.get("session_id")
+            if session_id:
+                groups.add(str(session_id))
+            if len(nodes) >= limit:
+                continue
+            memory_id = item.get("memory_id")
+            if memory_id is None:
+                continue
+            node_id = f"livingmemory-memory:{memory_id}"
+            memory_node_ids[str(memory_id)] = node_id
+            summary = item.get("summary") or f"记忆 {memory_id}"
+            self._add_node(
+                nodes,
+                seen_nodes,
+                node_id,
+                str(summary),
+                "记忆",
+                self._to_float(
+                    item.get("importance") or item.get("entry_count"),
+                    1,
+                ),
+                detail=_trim_text(summary, 240),
+                group_id=str(session_id) if session_id else None,
+                source="livingmemory",
+                raw_id=memory_id,
+            )
+
+        for edge in raw_edges:
+            source = raw_id_to_node_id.get(str(edge.get("source")))
+            target = raw_id_to_node_id.get(str(edge.get("target")))
+            if not source or not target:
+                continue
+            self._add_link(
+                links,
+                seen_links,
+                source,
+                target,
+                str(edge.get("relation_type") or "关联"),
+                self._to_float(edge.get("weight") or edge.get("confidence"), 1),
+            )
+
+        for entry in raw_entries:
+            session_id = entry.get("session_id")
+            if session_id:
+                groups.add(str(session_id))
+            memory_id = entry.get("memory_id")
+            memory_node_id = memory_node_ids.get(str(memory_id))
+            if not memory_node_id:
+                continue
+            label = str(
+                entry.get("relation_type")
+                or entry.get("entry_type")
+                or "提及"
+            )
+            for raw_node_id in self._safe_items(entry.get("node_ids"))[:6]:
+                target = raw_id_to_node_id.get(str(raw_node_id))
+                if target:
+                    self._add_link(links, seen_links, memory_node_id, target, label, 1)
+
+        if not groups and raw_memories:
+            groups.add("LivingMemory")
+
+    @staticmethod
+    def _safe_items(value: Any) -> List[Any]:
+        return value if isinstance(value, list) else []
+
+    @staticmethod
+    def _livingmemory_node_category(item: Dict[str, Any]) -> str:
+        node_type = str(item.get("type") or item.get("node_type") or "实体")
+        return {
+            "person": "人物",
+            "topic": "主题",
+            "fact": "事实",
+            "summary": "摘要",
+            "entity": "实体",
+            "other": "实体",
+        }.get(node_type.lower(), node_type or "实体")
+
+    @staticmethod
+    def _livingmemory_node_detail(item: Dict[str, Any]) -> str:
+        parts = [
+            item.get("canonical_value"),
+            f"条目 {item.get('entry_count')}" if item.get("entry_count") is not None else None,
+            f"记忆 {item.get('memory_count')}" if item.get("memory_count") is not None else None,
+            f"度 {item.get('degree')}" if item.get("degree") is not None else None,
+        ]
+        return _trim_text(" · ".join(str(part) for part in parts if part), 240)
 
     async def _append_live_memory_graph(
         self,

--- a/webui/services/integration_service.py
+++ b/webui/services/integration_service.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
-LIVINGMEMORY_PAGE_API_BASE = "/astrbot_plugin_livingmemory/page"
-LIVINGMEMORY_PAGE_CONTENT = "/api/plugin/page/content/astrbot_plugin_livingmemory/dashboard/"
 LIVINGMEMORY_EMBED_URL = "/api/integrations/embed/livingmemory"
 GROUP_CHAT_PLUS_EMBED_URL = "/api/integrations/embed/group_chat_plus"
 
@@ -22,13 +20,8 @@ SELF_LEARNING_API_ENDPOINTS = [
 ]
 
 LIVINGMEMORY_API_ENDPOINTS = [
-    f"GET {LIVINGMEMORY_PAGE_API_BASE}/stats",
-    f"GET {LIVINGMEMORY_PAGE_API_BASE}/memories",
-    f"POST {LIVINGMEMORY_PAGE_API_BASE}/memories/update",
-    f"POST {LIVINGMEMORY_PAGE_API_BASE}/memories/batch-delete",
-    f"POST {LIVINGMEMORY_PAGE_API_BASE}/recall/test",
-    f"GET {LIVINGMEMORY_PAGE_API_BASE}/graph/overview",
-    f"POST {LIVINGMEMORY_PAGE_API_BASE}/graph/query",
+    "GET /api/graphs/memory",
+    "GET /api/graphs/knowledge",
 ]
 
 GROUP_CHAT_PLUS_API_ENDPOINTS = [
@@ -250,15 +243,15 @@ class IntegrationService:
                 "available": bool(dashboard_url or plugin),
                 "url": LIVINGMEMORY_EMBED_URL,
                 "external_url": dashboard_url,
-                "official_page_url": LIVINGMEMORY_PAGE_CONTENT if plugin else None,
+                "official_page_url": None,
                 "route": "#/graphs",
-                "label": "LivingMemory 面板" if dashboard_url else "AstrBot 插件页",
-                "kind": "embedded_external" if dashboard_url else "astrbot_page",
-                "astrbot_page": "插件 -> LivingMemory -> Pages -> dashboard",
+                "label": "本地图谱",
+                "kind": "embedded_external" if dashboard_url else "local_graph",
+                "graph_source": "Self Learning 直读 LivingMemory graph_store 后端对象",
             },
             "dev_api": {
-                "base": LIVINGMEMORY_PAGE_API_BASE,
-                "mode": "astrbot_register_web_api",
+                "base": "/api/graphs",
+                "mode": "self_learning_graph_store_adapter",
                 "endpoints": LIVINGMEMORY_API_ENDPOINTS,
             },
             "settings_group": "Integration_Settings",


### PR DESCRIPTION
## Summary
- read LivingMemory graph data from its backend `initializer.memory_engine.graph_store` when memory is delegated
- restore Self Learning's `#/graphs` page as a local ECharts graph view instead of embedding the LivingMemory dashboard
- remove deprecated LivingMemory Page graph API entries from the integration hub/docs

## Validation
- `python -m pytest --basetemp .tmp\\pytest-basetemp tests\\unit\\test_graph_service.py tests\\unit\\test_integration_service.py tests\\integration\\test_graph_blueprint.py tests\\integration\\test_webui_static_assets.py`
- `python -m pytest --basetemp .tmp\\pytest-basetemp tests\\unit\\test_integration_service.py`
- `python -m ruff check webui\\services\\graph_service.py webui\\services\\integration_service.py tests\\unit\\test_graph_service.py tests\\unit\\test_integration_service.py tests\\integration\\test_graph_blueprint.py tests\\integration\\test_webui_static_assets.py`
- `python -m py_compile webui\\services\\graph_service.py webui\\services\\integration_service.py`
- `node -e "...parse dashboard inline scripts..."`
- `git diff --check`

## Summary by Sourcery

Render the Self Learning graphs page as a local ECharts view that can read graph data directly from a delegated LivingMemory backend instead of embedding the LivingMemory dashboard, and update integration metadata and docs accordingly.

New Features:
- Support reading memory graph snapshots directly from LivingMemory's backend graph_store when memory is delegated, exposing a unified graph API payload.
- Provide a local graphs dashboard with interactive controls for graph type, layout, and group/session selection using the existing /api/graphs endpoints.

Enhancements:
- Refine empty-state handling and data_source reporting for delegated LivingMemory graphs to distinguish backend emptiness from delegation state.
- Expose LivingMemory backend graph statistics and source information in the memory graph API response for better diagnostics.
- Update integration metadata to describe the local graph adapter instead of LivingMemory Page APIs and adjust dashboard home tiles to reflect local/remote graph status.

Documentation:
- Revise integration documentation to remove deprecated LivingMemory Page graph APIs and document the Self Learning graph store adapter via /api/graphs routes.

Tests:
- Add unit and integration tests covering direct graph_store access, updated integration service metadata, new dashboard behavior, and revised graph empty-state semantics.