### PR TITLE
[codex] Render knowledge graph from LivingMemory backend

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -134,7 +134,9 @@ Dashboard -> 功能融合
 Self Learning 不再调用 LivingMemory 的 Page 图谱 API。Dashboard 的
 `#/graphs` 模块会在 LivingMemory 已加载时直读其
 `initializer.memory_engine.graph_store` 后端对象，并通过本插件接口暴露
-ECharts 图谱 payload:
+ECharts 图谱 payload。记忆图和知识图谱都会优先读取 LivingMemory 后端；
+当后端不可用或快照为空时，仍保留 Self Learning 本地记忆、LightRAG 和
+本地 KG 表回退:
 
 - `GET /api/graphs/memory`
 - `GET /api/graphs/knowledge`

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -136,7 +136,7 @@ Self Learning 不再调用 LivingMemory 的 Page 图谱 API。Dashboard 的
 `initializer.memory_engine.graph_store` 后端对象，并通过本插件接口暴露
 ECharts 图谱 payload。记忆图和知识图谱都会优先读取 LivingMemory 后端；
 当后端不可用或快照为空时，仍保留 Self Learning 本地记忆、LightRAG 和
-本地 KG 表回退:
+本地 KG 表作为回退方案:
 
 - `GET /api/graphs/memory`
 - `GET /api/graphs/knowledge`

--- a/tests/integration/test_graph_blueprint.py
+++ b/tests/integration/test_graph_blueprint.py
@@ -166,3 +166,73 @@ async def test_knowledge_graph_route_returns_echarts_payload(client):
     assert "nodes" in data
     assert "links" in data
     assert "categories" in data
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_route_reads_livingmemory_graph_store(
+    client,
+    monkeypatch,
+):
+    class GraphStore:
+        async def get_graph_snapshot(self, **_kwargs):
+            return {
+                "nodes": [
+                    {
+                        "id": 1,
+                        "type": "person",
+                        "label": "Alice",
+                        "canonical_value": "alice",
+                        "entry_count": 1,
+                    },
+                    {
+                        "id": 2,
+                        "type": "topic",
+                        "label": "Tea",
+                        "canonical_value": "tea",
+                        "entry_count": 1,
+                    },
+                ],
+                "edges": [
+                    {
+                        "source": 1,
+                        "target": 2,
+                        "relation_type": "likes",
+                        "weight": 1,
+                    }
+                ],
+                "entries": [],
+                "memories": [],
+            }
+
+    livingmemory_plugin = SimpleNamespace(
+        initializer=SimpleNamespace(
+            memory_engine=SimpleNamespace(graph_store=GraphStore())
+        )
+    )
+    monkeypatch.setattr(
+        graphs_module,
+        "get_container",
+        lambda: SimpleNamespace(
+            database_manager=None,
+            group_id_to_unified_origin={"group-a": "umo:group-a"},
+            feature_delegation=SimpleNamespace(
+                status=lambda: {
+                    "memory_delegated": True,
+                    "memory_plugin": "LivingMemory",
+                    "reply_delegated": False,
+                    "reply_plugin": None,
+                },
+                memory_plugin=lambda: SimpleNamespace(star_cls=livingmemory_plugin),
+            ),
+        ),
+    )
+
+    response = await client.get("/api/graphs/knowledge?group_id=group-a")
+
+    assert response.status_code == 200
+    data = await response.get_json()
+    assert data["success"] is True
+    assert data["type"] == "knowledge"
+    assert data["data_source"] == "livingmemory_graph_store"
+    assert {node["name"] for node in data["nodes"]} >= {"Alice", "Tea"}
+    assert any(link["label"]["formatter"] == "likes" for link in data["links"])

--- a/tests/unit/test_graph_service.py
+++ b/tests/unit/test_graph_service.py
@@ -57,7 +57,8 @@ async def test_knowledge_graph_reads_lightrag_graphml(tmp_path):
 @pytest.mark.asyncio
 async def test_knowledge_graph_prefers_livingmemory_graph_store(tmp_path):
     class GraphStore:
-        calls = []
+        def __init__(self):
+            self.calls = []
 
         async def get_graph_snapshot(self, **kwargs):
             self.calls.append(kwargs)
@@ -239,7 +240,8 @@ async def test_memory_graph_reads_active_mem0_manager(monkeypatch):
 @pytest.mark.asyncio
 async def test_memory_graph_reads_livingmemory_graph_store_directly():
     class GraphStore:
-        calls = []
+        def __init__(self):
+            self.calls = []
 
         async def get_graph_snapshot(
             self,

--- a/tests/unit/test_graph_service.py
+++ b/tests/unit/test_graph_service.py
@@ -55,6 +55,151 @@ async def test_knowledge_graph_reads_lightrag_graphml(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_knowledge_graph_prefers_livingmemory_graph_store(tmp_path):
+    class GraphStore:
+        calls = []
+
+        async def get_graph_snapshot(self, **kwargs):
+            self.calls.append(kwargs)
+            return {
+                "nodes": [
+                    {
+                        "id": 1,
+                        "type": "person",
+                        "label": "Alice",
+                        "canonical_value": "alice",
+                        "entry_count": 2,
+                    },
+                    {
+                        "id": 2,
+                        "type": "topic",
+                        "label": "Tea",
+                        "canonical_value": "tea",
+                        "entry_count": 1,
+                    },
+                ],
+                "edges": [
+                    {
+                        "source": 1,
+                        "target": 2,
+                        "relation_type": "likes",
+                        "weight": 1.5,
+                    }
+                ],
+                "entries": [],
+                "memories": [],
+            }
+
+    graph_dir = tmp_path / "lightrag" / "group-a"
+    graph_dir.mkdir(parents=True)
+    (graph_dir / "graph_chunk_entity_relation.graphml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <graph edgedefault="undirected">
+    <node id="FallbackOnly"/>
+  </graph>
+</graphml>
+""",
+        encoding="utf-8",
+    )
+
+    graph_store = GraphStore()
+    livingmemory_plugin = SimpleNamespace(
+        initializer=SimpleNamespace(
+            memory_engine=SimpleNamespace(
+                graph_store=graph_store,
+                get_statistics=lambda: {"graph_nodes": 2},
+            )
+        )
+    )
+    container = SimpleNamespace(
+        database_manager=None,
+        plugin_config=SimpleNamespace(data_dir=str(tmp_path)),
+        v2_integration=None,
+        group_id_to_unified_origin={"group-a": "umo:group-a"},
+        feature_delegation=SimpleNamespace(
+            status=lambda: {
+                "memory_delegated": True,
+                "memory_plugin": "LivingMemory",
+            },
+            memory_plugin=lambda: SimpleNamespace(star_cls=livingmemory_plugin),
+        ),
+    )
+
+    payload = await GraphService(container).get_knowledge_graph(
+        group_id="group-a",
+        limit=20,
+    )
+
+    assert graph_store.calls[0]["session_id"] == "umo:group-a"
+    assert payload["type"] == "knowledge"
+    assert payload["data_source"] == "livingmemory_graph_store"
+    assert payload["source_stats"]["graph_nodes"] == 2
+    assert {node["name"] for node in payload["nodes"]} >= {"Alice", "Tea"}
+    assert "FallbackOnly" not in {node["name"] for node in payload["nodes"]}
+    assert any(link["label"]["formatter"] == "likes" for link in payload["links"])
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_falls_back_when_livingmemory_graph_store_empty(tmp_path):
+    class EmptyGraphStore:
+        async def get_graph_snapshot(self, **_kwargs):
+            return {"nodes": [], "edges": [], "entries": [], "memories": []}
+
+    graph_dir = tmp_path / "lightrag" / "group-a"
+    graph_dir.mkdir(parents=True)
+    (graph_dir / "graph_chunk_entity_relation.graphml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <key id="d0" for="node" attr.name="entity_type" attr.type="string"/>
+  <key id="d1" for="edge" attr.name="keywords" attr.type="string"/>
+  <graph edgedefault="undirected">
+    <node id="FallbackAlice"><data key="d0">person</data></node>
+    <node id="FallbackTea"><data key="d0">topic</data></node>
+    <edge source="FallbackAlice" target="FallbackTea"><data key="d1">fallback-likes</data></edge>
+  </graph>
+</graphml>
+""",
+        encoding="utf-8",
+    )
+    livingmemory_plugin = SimpleNamespace(
+        initializer=SimpleNamespace(
+            memory_engine=SimpleNamespace(graph_store=EmptyGraphStore())
+        )
+    )
+    container = SimpleNamespace(
+        database_manager=None,
+        plugin_config=SimpleNamespace(data_dir=str(tmp_path)),
+        v2_integration=None,
+        group_id_to_unified_origin={"group-a": "umo:group-a"},
+        feature_delegation=SimpleNamespace(
+            status=lambda: {
+                "memory_delegated": True,
+                "memory_plugin": "LivingMemory",
+            },
+            memory_plugin=lambda: SimpleNamespace(star_cls=livingmemory_plugin),
+        ),
+    )
+
+    payload = await GraphService(container).get_knowledge_graph(
+        group_id="group-a",
+        limit=20,
+    )
+
+    assert payload["type"] == "knowledge"
+    assert payload["data_source"] == "self_learning"
+    assert payload["groups"] == ["group-a"]
+    assert {node["name"] for node in payload["nodes"]} >= {
+        "FallbackAlice",
+        "FallbackTea",
+    }
+    assert any(
+        link["label"]["formatter"] == "fallback-likes"
+        for link in payload["links"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_memory_graph_reads_active_mem0_manager(monkeypatch):
     monkeypatch.setattr(EnhancedMemoryGraphManager, "_instance", None)
 

--- a/webui/services/graph_service.py
+++ b/webui/services/graph_service.py
@@ -772,7 +772,7 @@ class GraphService:
         group_id: Optional[str] = None,
         limit: int = 120,
     ) -> Dict[str, Any]:
-        """Return knowledge graph nodes and links from KG ORM tables."""
+        """Return knowledge graph nodes and links from LivingMemory or local stores."""
         limit = max(10, min(int(limit or 120), 300))
         nodes: List[Dict[str, Any]] = []
         links: List[Dict[str, Any]] = []
@@ -780,12 +780,29 @@ class GraphService:
         seen_links: Set[Tuple[str, str, str]] = set()
         groups: Set[str] = set()
         categories: Set[str] = set()
+        source_stats: Dict[str, Any] = {}
 
-        await self._append_lightrag_graph(
-            nodes, links, seen_nodes, seen_links, groups, categories, group_id, limit
+        livingmemory_used = await self._append_livingmemory_graph_store(
+            nodes,
+            links,
+            seen_nodes,
+            seen_links,
+            groups,
+            group_id,
+            limit,
+            source_stats,
         )
 
-        if self.database_manager and hasattr(self.database_manager, "get_session"):
+        if not livingmemory_used:
+            await self._append_lightrag_graph(
+                nodes, links, seen_nodes, seen_links, groups, categories, group_id, limit
+            )
+
+        if (
+            not livingmemory_used
+            and self.database_manager
+            and hasattr(self.database_manager, "get_session")
+        ):
             try:
                 from sqlalchemy import desc, select
 
@@ -861,6 +878,9 @@ class GraphService:
         payload = {
             "success": True,
             "type": "knowledge",
+            "data_source": (
+                "livingmemory_graph_store" if livingmemory_used else "self_learning"
+            ),
             "group_id": group_id,
             "groups": sorted(groups),
             "nodes": returned_nodes,
@@ -876,6 +896,8 @@ class GraphService:
                 "groups": len(groups),
             },
         }
+        if source_stats:
+            payload["source_stats"] = source_stats
         return self._maybe_add_delegated_empty_state(payload, "knowledge")
 
     @staticmethod

--- a/webui/services/graph_service.py
+++ b/webui/services/graph_service.py
@@ -13,6 +13,11 @@ from defusedxml import ElementTree as ET
 
 from astrbot.api import logger
 
+GRAPH_DATA_SOURCE_LIVINGMEMORY = "livingmemory_graph_store"
+GRAPH_DATA_SOURCE_SELF_LEARNING = "self_learning"
+GRAPH_DATA_SOURCE_LIVINGMEMORY_EMPTY = "livingmemory_backend_empty"
+GRAPH_EMPTY_REASON_BACKEND_EMPTY = "graph_backend_empty"
+
 
 def _trim_text(value: Any, limit: int = 120) -> str:
     text = "" if value is None else str(value)
@@ -64,8 +69,8 @@ class GraphService:
 
         payload.update(
             {
-                "data_source": "livingmemory_backend_empty",
-                "empty_reason": "graph_backend_empty",
+                "data_source": GRAPH_DATA_SOURCE_LIVINGMEMORY_EMPTY,
+                "empty_reason": GRAPH_EMPTY_REASON_BACKEND_EMPTY,
                 "message": message,
                 "delegation": status,
             }
@@ -200,7 +205,9 @@ class GraphService:
             "success": True,
             "type": "memory",
             "data_source": (
-                "livingmemory_graph_store" if livingmemory_used else "self_learning"
+                GRAPH_DATA_SOURCE_LIVINGMEMORY
+                if livingmemory_used
+                else GRAPH_DATA_SOURCE_SELF_LEARNING
             ),
             "group_id": group_id,
             "groups": sorted(groups),
@@ -879,7 +886,9 @@ class GraphService:
             "success": True,
             "type": "knowledge",
             "data_source": (
-                "livingmemory_graph_store" if livingmemory_used else "self_learning"
+                GRAPH_DATA_SOURCE_LIVINGMEMORY
+                if livingmemory_used
+                else GRAPH_DATA_SOURCE_SELF_LEARNING
             ),
             "group_id": group_id,
             "groups": sorted(groups),


### PR DESCRIPTION
## Summary
- make `/api/graphs/knowledge` prefer the delegated LivingMemory `graph_store` backend, matching the memory graph path
- keep existing local fallbacks: LightRAG graph files and local KG ORM tables are still used when LivingMemory is unavailable or returns an empty snapshot
- document the LivingMemory-first/local-fallback behavior for both memory and knowledge graphs

## Validation
- `python -m pytest --basetemp .tmp\pytest-basetemp tests\unit\test_graph_service.py tests\integration\test_graph_blueprint.py`
- `python -m ruff check webui\services\graph_service.py tests\unit\test_graph_service.py tests\integration\test_graph_blueprint.py`
- `python -m py_compile webui\services\graph_service.py`
- `git diff --check`

## Summary by Sourcery

Prefer the LivingMemory graph_store backend as the primary source for knowledge graphs, with existing local graph and ORM-based fallbacks retained when LivingMemory is unavailable or empty.

Enhancements:
- Expose the knowledge graph API payload source via a new data_source field and optional source_stats metadata.
- Extend the knowledge graph service to read from LivingMemory-backed graph_store before LightRAG files and local KG tables.
- Update integration documentation to describe the LivingMemory-first, local-fallback behavior for memory and knowledge graphs.

Documentation:
- Document the LivingMemory graph_store integration and fallback behavior for memory and knowledge graphs in the integrations guide.

Tests:
- Add unit tests for preferring LivingMemory graph_store and falling back to local knowledge graph sources when it returns an empty snapshot.
- Add integration test to verify the knowledge graph HTTP endpoint uses the LivingMemory graph_store backend when available.