### PR TITLE
fix: expose cache hit rates in metrics API

### DIFF
--- a/docs/webui-api.md
+++ b/docs/webui-api.md
@@ -224,6 +224,9 @@ $env:ASTRBOT_ENABLE_WEB_DEP_INSTALL="false"
 | GET | `/api/monitoring/functions` | 函数级性能 |
 | GET | `/api/monitoring/profile/backends` | profiling 后端 |
 | POST | `/api/monitoring/profile/start` | 开始 profiling |
+
+`/api/metrics` 会直接返回 `cache_hit_rates` 和 `cache_hit_summary`，数据来自
+`CacheManager.get_hit_rates()`，前端无需从 Prometheus hits/misses 样本自行测算缓存命中率。
 | GET | `/api/monitoring/profile/<session_id>` | 获取 profiling 会话 |
 | DELETE | `/api/monitoring/profile/<session_id>` | 停止 profiling |
 

--- a/tests/integration/test_metrics_blueprint.py
+++ b/tests/integration/test_metrics_blueprint.py
@@ -1,0 +1,88 @@
+"""Integration tests for metrics blueprint routes."""
+
+from types import SimpleNamespace
+
+import pytest
+from quart import Quart
+
+import webui.blueprints.metrics as metrics_module
+from webui.blueprints.metrics import metrics_bp
+
+
+class DummyDatabaseManager:
+    async def get_messages_statistics(self):
+        return {"total_messages": 8, "filtered_messages": 4}
+
+    async def get_style_learning_statistics(self):
+        return {"approved_reviews": 2, "total_reviews": 3}
+
+    async def get_expression_patterns_statistics(self):
+        return {"total_patterns": 5}
+
+    async def get_learning_performance_history(self, group_id):
+        return [
+            {"quality_score": 0.8, "success": True},
+            {"quality_score": 0.4, "success": False},
+        ]
+
+
+class DummyCacheManager:
+    def get_hit_rates(self):
+        return {
+            "general": {"hits": 3, "misses": 1, "hit_rate": 0.75},
+            "memory": {"hits": 0, "misses": 2, "hit_rate": 0.0},
+        }
+
+
+@pytest.fixture
+async def app(monkeypatch):
+    app = Quart(__name__)
+    app.config["TESTING"] = True
+    app.secret_key = "test-secret-key"
+
+    container = SimpleNamespace(
+        database_manager=DummyDatabaseManager(),
+        llm_adapter=None,
+        progressive_learning=SimpleNamespace(learning_active={"g1": True, "g2": False}),
+        perf_collector=None,
+    )
+    monkeypatch.setattr(metrics_module, "get_container", lambda: container)
+    monkeypatch.setattr(metrics_module, "_get_cache_manager_instance", lambda: DummyCacheManager())
+
+    app.register_blueprint(metrics_bp)
+    yield app
+
+
+@pytest.fixture
+async def client(app):
+    return app.test_client()
+
+
+@pytest.mark.asyncio
+async def test_metrics_api_returns_cache_hit_rates_directly(client):
+    response = await client.get("/api/metrics")
+
+    assert response.status_code == 200
+    data = await response.get_json()
+
+    assert data["cache_hit_rates"] == {
+        "general": {
+            "hits": 3,
+            "misses": 1,
+            "total_queries": 4,
+            "hit_rate": 0.75,
+        },
+        "memory": {
+            "hits": 0,
+            "misses": 2,
+            "total_queries": 2,
+            "hit_rate": 0.0,
+        },
+    }
+    assert data["cache_hit_summary"] == {
+        "available": True,
+        "total_hits": 3,
+        "total_misses": 3,
+        "total_queries": 6,
+        "hit_rate": 0.5,
+    }

--- a/webui/blueprints/metrics.py
+++ b/webui/blueprints/metrics.py
@@ -1,6 +1,8 @@
 """
 指标分析蓝图 - 处理指标分析相关路由
 """
+from typing import Any, Dict
+
 from quart import Blueprint, request, jsonify
 from astrbot.api import logger
 
@@ -10,6 +12,96 @@ from ..middleware.auth import require_auth
 from ..utils.response import success_response, error_response
 
 metrics_bp = Blueprint('metrics', __name__, url_prefix='/api')
+
+
+def _get_cache_manager_instance():
+    """Return the plugin cache manager, if available."""
+    try:
+        from ...utils.cache_manager import get_cache_manager
+
+        return get_cache_manager()
+    except Exception as e:
+        logger.warning(f"获取缓存管理器失败: {e}")
+        return None
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_float(value: Any) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _get_cache_hit_payload(cache_manager=None) -> Dict[str, Any]:
+    """Build API payload from CacheManager.get_hit_rates()."""
+    manager = cache_manager if cache_manager is not None else _get_cache_manager_instance()
+    if not manager or not hasattr(manager, "get_hit_rates"):
+        return {
+            "cache_hit_rates": {},
+            "cache_hit_summary": {
+                "available": False,
+                "total_hits": 0,
+                "total_misses": 0,
+                "total_queries": 0,
+                "hit_rate": 0.0,
+                "message": "cache manager unavailable",
+            },
+        }
+
+    try:
+        raw_rates = manager.get_hit_rates() or {}
+    except Exception as e:
+        logger.warning(f"获取缓存命中统计失败: {e}")
+        return {
+            "cache_hit_rates": {},
+            "cache_hit_summary": {
+                "available": False,
+                "total_hits": 0,
+                "total_misses": 0,
+                "total_queries": 0,
+                "hit_rate": 0.0,
+                "message": str(e),
+            },
+        }
+
+    rates: Dict[str, Dict[str, Any]] = {}
+    total_hits = 0
+    total_misses = 0
+    for name, stats in raw_rates.items():
+        if not isinstance(stats, dict):
+            continue
+        hits = _safe_int(stats.get("hits"))
+        misses = _safe_int(stats.get("misses"))
+        total = hits + misses
+        api_hit_rate = _safe_float(stats.get("hit_rate"))
+        hit_rate = api_hit_rate if total else 0.0
+        rates[str(name)] = {
+            "hits": hits,
+            "misses": misses,
+            "total_queries": total,
+            "hit_rate": round(hit_rate, 4),
+        }
+        total_hits += hits
+        total_misses += misses
+
+    total_queries = total_hits + total_misses
+    return {
+        "cache_hit_rates": rates,
+        "cache_hit_summary": {
+            "available": True,
+            "total_hits": total_hits,
+            "total_misses": total_misses,
+            "total_queries": total_queries,
+            "hit_rate": round(total_hits / total_queries, 4) if total_queries else 0.0,
+        },
+    }
 
 
 @metrics_bp.route("/intelligence_metrics", methods=["GET"])
@@ -321,6 +413,8 @@ async def get_metrics():
             except Exception as e:
                 logger.warning(f"获取Hook性能数据失败: {e}")
 
+        cache_hit_payload = _get_cache_hit_payload()
+
         import time
         metrics = {
             "llm_calls": llm_stats,
@@ -334,6 +428,7 @@ async def get_metrics():
             "learning_efficiency": round(learning_efficiency, 1),
             "learning_dimensions": learning_dimensions,
             "hook_performance": hook_performance,
+            **cache_hit_payload,
             "last_updated": time.time()
         }
 


### PR DESCRIPTION
## Summary
- Expose `cache_hit_rates` and `cache_hit_summary` directly from `/api/metrics` by calling `CacheManager.get_hit_rates()`.
- Keep cache hit aggregation in the backend API so frontend consumers do not need to infer hit rate from Prometheus hits/misses samples.
- Add an integration test for the metrics route cache-hit response contract and document the fields.

## Validation
- `python -m pytest --basetemp .tmp\pytest-basetemp tests\integration\test_metrics_blueprint.py tests\unit\test_cache_manager.py`
- `python -m ruff check webui\blueprints\metrics.py tests\integration\test_metrics_blueprint.py`
- `python -m py_compile webui\blueprints\metrics.py tests\integration\test_metrics_blueprint.py`
- `git diff --check`

## Summary by Sourcery

Expose cache cache hit statistics via the metrics API and validate the new response contract.

New Features:
- Return aggregated cache hit rates and a cache hit summary from the `/api/metrics` endpoint based on `CacheManager.get_hit_rates()`.

Enhancements:
- Add internal helpers to safely obtain and normalize cache hit data for inclusion in the metrics payload.
- Document the new cache hit fields returned by the `/api/metrics` endpoint in the web UI API docs.

Tests:
- Introduce an integration test ensuring `/api/metrics` returns the expected cache hit rates and summary structure.