### PR TITLE
[codex] Add WebUI persona selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 让 AstrBot 在群聊中持续采集、学习、审查并注入上下文，使 Bot 逐步具备表达风格、群组黑话、社交关系、长期记忆和人格演化能力。
 
-[![Version](https://img.shields.io/badge/version-3.1.3-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
+[![Version](https://img.shields.io/badge/version-3.1.4-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE)
 [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-3.1.3-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+[![Version](https://img.shields.io/badge/version-3.1.4-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 
 [Features](#what-we-can-do) · [Quick Start](#quick-start) · [Web UI](#visual-management-interface) · [Community](#community) · [Contributing](CONTRIBUTING.md)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 # AstrBot 自学习插件
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 
 # Ensure parent namespace packages ("data", "data.plugins") are
 # durably registered in sys.modules.  AstrBot loads plugins via

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: "astrbot_plugin_self_learning"
 author: "NickMo, EterUltimate"
 display_name: "self-learning"
 description: "SELF LEARNING 自主学习插件 — 让 AI 聊天机器人自主学习对话风格、理解群组黑话、管理社交关系与好感度、自适应人格演化，像真人一样自然对话。(使用前必须手动备份人格数据)"
-version: "3.1.3"
+version: "3.1.4"
 repo: "https://github.com/NickCharlie/astrbot_plugin_self_learning"
 tags:
   - "自学习"

--- a/persona_web_manager.py
+++ b/persona_web_manager.py
@@ -140,6 +140,13 @@ class PersonaWebManager:
             logger.error(f"获取人格列表失败: {e}", exc_info=True)
             return []
 
+    async def get_persona_by_id(self, persona_id: str) -> Optional[Dict[str, Any]]:
+        """获取指定人格，格式化为Web界面需要的格式"""
+        for persona in await self.get_all_personas_for_web():
+            if persona.get("persona_id") == persona_id:
+                return persona
+        return None
+
     async def get_default_persona_for_web(self) -> Dict[str, Any]:
         """获取默认人格，格式化为Web界面需要的格式
 

--- a/services/core_learning/progressive_learning.py
+++ b/services/core_learning/progressive_learning.py
@@ -19,6 +19,7 @@ from ...constants import (
 from ...exceptions import LearningError
 
 from ...utils.json_utils import safe_parse_llm_json, clean_llm_json_response
+from ...utils.persona_selection import get_persona_identifier, resolve_target_persona
 
 from ..database import DatabaseManager
 from ..learning.sample_filter import filter_learning_messages, should_ignore_learning_sample
@@ -799,11 +800,17 @@ class ProgressiveLearningService:
             # 如果没有特定群组的人格，尝试从框架获取默认人格
             if hasattr(self.context, 'persona_manager') and self.context.persona_manager:
                 try:
-                    default_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+                    default_persona = await resolve_target_persona(
+                        self.context.persona_manager,
+                        self.config,
+                        self._resolve_umo(group_id),
+                        require_existing=True,
+                        log=logger,
+                    )
                     if default_persona:
                         return {
                             'prompt': default_persona.get('prompt', '默认人格'),
-                            'name': default_persona.get('name', 'default'),
+                            'name': get_persona_identifier(default_persona),
                             'style_parameters': {},
                             'last_updated': datetime.now().isoformat()
                         }
@@ -829,7 +836,13 @@ class ProgressiveLearningService:
                 logger.warning(f"无法获取PersonaManager for group {group_id}")
                 return current_persona
 
-            default_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            default_persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=logger,
+            )
             if not default_persona:
                 logger.warning(f"无法获取当前人格 for group {group_id}")
                 return current_persona

--- a/services/persona/persona_backup_manager.py
+++ b/services/persona/persona_backup_manager.py
@@ -11,6 +11,7 @@ from astrbot.api.star import Context
 
 from ...config import PluginConfig
 from ...exceptions import BackupError
+from ...utils.persona_selection import get_persona_identifier, resolve_target_persona
 from ..database import DatabaseManager
 
 
@@ -72,9 +73,16 @@ class PersonaBackupManager:
             if hasattr(self.context, 'persona_manager') and self.context.persona_manager:
                 try:
                     umo = self._resolve_umo(group_id) if group_id else None
-                    default_persona = await self.context.persona_manager.get_default_persona_v3(umo)
+                    default_persona = await resolve_target_persona(
+                        self.context.persona_manager,
+                        self.config,
+                        umo,
+                        require_existing=True,
+                        log=logger,
+                    )
                     if default_persona:
                         return {
+                            'persona_id': get_persona_identifier(default_persona, 'default'),
                             'name': default_persona.get('name', '默认人格') if isinstance(default_persona, dict) else getattr(default_persona, 'name', '默认人格'),
                             'prompt': default_persona.get('prompt', '') if isinstance(default_persona, dict) else getattr(default_persona, 'prompt', ''),
                             'settings': {},
@@ -154,7 +162,7 @@ class PersonaBackupManager:
             # 使用新版框架API恢复人格数据
             if hasattr(self.context, 'persona_manager') and self.context.persona_manager:
                 try:
-                    persona_name = persona_data.get('name', '恢复的人格')
+                    persona_name = persona_data.get('persona_id') or persona_data.get('name', '恢复的人格')
                     persona_prompt = persona_data.get('prompt', '')
 
                     # 通过PersonaManager更新当前人格

--- a/services/persona/persona_manager.py
+++ b/services/persona/persona_manager.py
@@ -7,6 +7,7 @@ from ...config import PluginConfig
 from ...core.interfaces import IPersonaManager, IPersonaUpdater, IPersonaBackupManager, ServiceLifecycle, MessageData
 
 from ...exceptions import SelfLearningError # 导入 SelfLearningError
+from ...utils.persona_selection import resolve_target_persona
 
 class PersonaManagerService(IPersonaManager):
     """
@@ -115,7 +116,13 @@ class PersonaManagerService(IPersonaManager):
         """获取当前人格的描述"""
         try:
             umo = self._resolve_umo(group_id)
-            persona = await self.context.persona_manager.get_default_persona_v3(umo)
+            persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                umo,
+                require_existing=True,
+                log=self._logger,
+            )
             if persona:
                 return persona.get('prompt', '') if isinstance(persona, dict) else getattr(persona, 'prompt', '')
             return None
@@ -127,7 +134,13 @@ class PersonaManagerService(IPersonaManager):
         """获取当前人格信息"""
         try:
             umo = self._resolve_umo(group_id)
-            persona = await self.context.persona_manager.get_default_persona_v3(umo)
+            persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                umo,
+                require_existing=True,
+                log=self._logger,
+            )
             if persona:
                 return dict(persona) if isinstance(persona, dict) else {'prompt': getattr(persona, 'prompt', '')}
             return None

--- a/services/persona/persona_updater.py
+++ b/services/persona/persona_updater.py
@@ -16,6 +16,7 @@ from .persona_manager_updater import PersonaManagerUpdater
 
 from ...exceptions import PersonaUpdateError, SelfLearningError # 导入 PersonaUpdateError
 from ..database import DatabaseManager # 导入 DatabaseManager
+from ...utils.persona_selection import get_persona_identifier, resolve_target_persona
 
 # MaiBot功能模块导入 - 结合MaiBot的学习功能
 from ..analysis import ExpressionPatternLearner
@@ -72,12 +73,18 @@ class PersonaUpdater(IPersonaUpdater):
                 return False
 
             # 获取当前人格（传递group_id以支持多会话多人格）
-            current_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            current_persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if not current_persona:
                 self._logger.error(f"无法获取群组 {group_id} 的当前人格")
                 return False
 
-            persona_name = current_persona.get('name', 'unknown') if isinstance(current_persona, dict) else current_persona['name']
+            persona_name = get_persona_identifier(current_persona, 'unknown')
             self._logger.info(f"当前人格: {persona_name} for group {group_id}")
             
             # 创建备份（如果启用）
@@ -131,7 +138,7 @@ class PersonaUpdater(IPersonaUpdater):
                 if auto_apply:
                     try:
                         await self.context.persona_manager.update_persona(
-                            persona_id=persona_name,
+                            persona_id=get_persona_identifier(current_persona),
                             system_prompt=enhanced_prompt
                         )
                         self._logger.info(f"[自动应用] 已将批准内容应用到默认人格 [{persona_name}]（群组 {group_id}），内容长度: {len(enhanced_prompt)}")
@@ -249,7 +256,13 @@ class PersonaUpdater(IPersonaUpdater):
                 self._logger.warning("无法获取PersonaManager，跳过备份")
                 return False
 
-            current_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            current_persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if not current_persona:
                 self._logger.warning(f"无法获取群组 {group_id} 的当前人格信息，跳过备份")
                 return False
@@ -419,7 +432,13 @@ class PersonaUpdater(IPersonaUpdater):
                 self._logger.error("无法获取PersonaManager")
                 return None
 
-            persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if persona:
                 if isinstance(persona, dict):
                     return persona.get('prompt', '')
@@ -436,7 +455,13 @@ class PersonaUpdater(IPersonaUpdater):
                 self._logger.error("无法获取PersonaManager")
                 return None
 
-            persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if persona and isinstance(persona, dict):
                 return dict(persona)
             return None
@@ -736,7 +761,13 @@ class PersonaUpdater(IPersonaUpdater):
                 self._logger.warning("无法获取PersonaManager，跳过备份")
                 return False
 
-            current_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            current_persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if not current_persona:
                 self._logger.warning("无法获取当前人格信息，跳过备份")
                 return False
@@ -1136,13 +1167,19 @@ class PersonaAnalyzer:
                 self._logger.error("无法获取PersonaManager")
                 return False
 
-            current_persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+            current_persona = await resolve_target_persona(
+                self.context.persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=self._logger,
+            )
             if not current_persona:
                 self._logger.error("无法获取当前人格")
                 return False
 
             # 获取persona_id用于更新
-            persona_id = current_persona.get('name', 'default')
+            persona_id = get_persona_identifier(current_persona)
 
             # 获取当前prompt
             current_prompt = current_persona.get('prompt', '')

--- a/services/persona/temporary_persona_updater.py
+++ b/services/persona/temporary_persona_updater.py
@@ -23,6 +23,7 @@ from ...statics.temp_persona_messages import TemporaryPersonaMessages
 from ...statics.prompts import MULTIDIMENSIONAL_ANALYZER_FILTER_MESSAGE_PROMPT
 
 from ...exceptions import SelfLearningError
+from ...utils.persona_selection import get_persona_identifier, resolve_target_persona
 
 
 class TemporaryPersonaUpdater:
@@ -80,10 +81,14 @@ class TemporaryPersonaUpdater:
         返回: Personality的字典表示
         """
         try:
-            persona = await self.context.persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
-            if persona:
-                return dict(persona) if isinstance(persona, dict) else persona
-            return None
+            persona_manager = getattr(self.context, "persona_manager", None)
+            return await resolve_target_persona(
+                persona_manager,
+                self.config,
+                self._resolve_umo(group_id),
+                require_existing=True,
+                log=logger,
+            )
         except Exception as e:
             logger.warning(f"获取框架人格失败: {e}")
             return None
@@ -755,7 +760,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，无法直接更新system prompt")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
 
             # 彻底清理所有重复的历史内容
@@ -919,7 +924,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，临时风格更新失败")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
 
             # 检查是否已经有风格示范段落，如果有则替换
@@ -971,7 +976,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，begin_dialogs 风格注入失败")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
             current_begin_dialogs: list = list(persona.get('begin_dialogs', []) or [])
 
@@ -1129,7 +1134,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，无法直接更新system prompt")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
             cleaned_prompt = self._clean_duplicate_content(current_prompt)
 
@@ -1163,7 +1168,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，无法直接更新system prompt")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
             cleaned_prompt = self._clean_duplicate_content(current_prompt)
 
@@ -1199,7 +1204,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，无法直接更新system prompt")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
             cleaned_prompt = self._clean_duplicate_content(current_prompt)
 
@@ -1235,7 +1240,7 @@ class TemporaryPersonaUpdater:
                 logger.warning("无法获取当前人格，无法直接更新system prompt")
                 return False
 
-            persona_name = persona.get('name', 'default')
+            persona_name = get_persona_identifier(persona)
             current_prompt = persona.get('prompt', '')
             cleaned_prompt = self._clean_duplicate_content(current_prompt)
 

--- a/tests/unit/test_persona_review_service.py
+++ b/tests/unit/test_persona_review_service.py
@@ -229,6 +229,46 @@ class TestPersonaReviewService:
         assert payload["system_prompt"] == "Original prompt\n\nUpdated prompt with learning"
 
     @pytest.mark.asyncio
+    async def test_persona_learning_approval_falls_back_to_only_existing_persona(
+        self, mock_container, sample_review_data
+    ):
+        """When AstrBot default is missing, approval should not try to update default."""
+        mock_container.plugin_config.current_persona_name = "default"
+        mock_container.plugin_config.auto_apply_persona_updates = True
+        mock_container.persona_web_manager = Mock()
+        mock_container.persona_web_manager.get_all_personas_for_web = AsyncMock(return_value=[
+            {
+                "persona_id": "suleng",
+                "system_prompt": "Original prompt",
+                "begin_dialogs": [],
+                "tools": [],
+            }
+        ])
+        mock_container.persona_web_manager.get_persona_for_group = AsyncMock(return_value={
+            "persona_id": "default",
+            "system_prompt": "",
+            "begin_dialogs": [],
+            "tools": [],
+        })
+        mock_container.persona_web_manager.get_default_persona_for_web = AsyncMock(return_value={
+            "persona_id": "default",
+            "system_prompt": "You are a helpful assistant.",
+            "begin_dialogs": [],
+            "tools": [],
+        })
+        mock_container.persona_web_manager.update_persona_via_web = AsyncMock(return_value={"success": True})
+        mock_container.database_manager.get_persona_learning_review_by_id.return_value = sample_review_data
+        service = PersonaReviewService(mock_container)
+
+        success, message = await service.review_persona_update("persona_learning_1", "approve")
+
+        assert success is True
+        assert "已追加到人格" in message
+        persona_id, payload = mock_container.persona_web_manager.update_persona_via_web.await_args.args
+        assert persona_id == "suleng"
+        assert payload["system_prompt"] == "Original prompt\n\nUpdated prompt with learning"
+
+    @pytest.mark.asyncio
     async def test_persona_learning_approval_saves_change_snapshot(self, mock_container, sample_review_data):
         """Approved auto-applied persona learning should persist before/after snapshots."""
         mock_container.plugin_config.auto_apply_persona_updates = False

--- a/tests/unit/test_persona_selection.py
+++ b/tests/unit/test_persona_selection.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from utils.persona_selection import get_persona_identifier, resolve_target_persona
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_persona_prefers_plugin_configured_persona():
+    manager = AsyncMock()
+    manager.get_persona.return_value = {
+        "persona_id": "suleng",
+        "name": "Suleng Persona",
+        "system_prompt": "Configured prompt",
+        "begin_dialogs": ["hi", "hello"],
+    }
+    manager.get_default_persona_v3.return_value = {
+        "persona_id": "default",
+        "name": "default",
+        "prompt": "Default prompt",
+    }
+    config = SimpleNamespace(current_persona_name="suleng")
+
+    persona = await resolve_target_persona(manager, config, "aiocqhttp:group:1", require_existing=True)
+
+    assert persona["persona_id"] == "suleng"
+    assert persona["prompt"] == "Configured prompt"
+    manager.get_persona.assert_awaited_once_with("suleng")
+    manager.get_default_persona_v3.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_persona_falls_back_to_single_existing_when_default_missing():
+    manager = AsyncMock()
+    manager.get_persona.side_effect = ValueError("Persona with ID default does not exist.")
+    manager.get_default_persona_v3.return_value = {
+        "persona_id": "default",
+        "name": "default",
+        "prompt": "Default prompt",
+    }
+    manager.get_all_personas.return_value = [
+        {
+            "persona_id": "suleng",
+            "name": "Suleng Persona",
+            "system_prompt": "Only prompt",
+            "begin_dialogs": [],
+        }
+    ]
+    config = SimpleNamespace(current_persona_name="default")
+
+    persona = await resolve_target_persona(manager, config, "aiocqhttp:group:1", require_existing=True)
+
+    assert persona["persona_id"] == "suleng"
+    assert persona["selection_source"] == "single_existing"
+
+
+def test_get_persona_identifier_uses_persona_id_before_display_name():
+    persona = {
+        "persona_id": "suleng",
+        "name": "Suleng Persona",
+        "system_prompt": "Configured prompt",
+    }
+
+    assert get_persona_identifier(persona) == "suleng"

--- a/tests/unit/test_persona_service.py
+++ b/tests/unit/test_persona_service.py
@@ -171,6 +171,27 @@ class TestPersonaService:
         mock_container.persona_web_manager.get_default_persona_for_web.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_get_default_persona_prefers_configured_persona_with_web_manager(self, mock_container):
+        """Current persona preview should honor plugin target persona before AstrBot default."""
+        mock_container.plugin_config.current_persona_name = "suleng"
+        mock_container.persona_web_manager = AsyncMock()
+        mock_container.persona_web_manager.get_all_personas_for_web.return_value = [
+            {
+                "persona_id": "suleng",
+                "system_prompt": "Configured prompt",
+                "begin_dialogs": [],
+                "tools": [],
+            }
+        ]
+        service = PersonaService(mock_container)
+
+        result = await service.get_default_persona("test_group")
+
+        assert result["persona_id"] == "suleng"
+        assert result["prompt"] == "Configured prompt"
+        mock_container.persona_web_manager.get_persona_for_group.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_get_default_persona_fallback(self, mock_container):
         """Test getting default persona with fallback"""
         service = PersonaService(mock_container)

--- a/utils/persona_selection.py
+++ b/utils/persona_selection.py
@@ -1,0 +1,323 @@
+"""Helpers for resolving the AstrBot persona targeted by this plugin."""
+import inspect
+from typing import Any, Dict, Optional
+
+
+def _is_unset_mock(obj: Any, name: str) -> bool:
+    return (
+        obj is not None
+        and obj.__class__.__module__ == "unittest.mock"
+        and name not in getattr(obj, "__dict__", {})
+    )
+
+
+def _explicit_attr(obj: Any, name: str) -> Any:
+    if obj is None:
+        return None
+    if obj.__class__.__module__ == "unittest.mock":
+        children = getattr(obj, "_mock_children", {})
+        if name in children:
+            return children[name]
+        if name in getattr(obj, "__dict__", {}):
+            return getattr(obj, name)
+        return None
+    return getattr(obj, name, None)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def optional_object_attr(obj: Any, name: str, default: Any = None) -> Any:
+    """Read optional attrs without auto-creating unittest.mock children."""
+    if obj is None or _is_unset_mock(obj, name):
+        return default
+    return getattr(obj, name, default)
+
+
+def get_configured_persona_id(config: Any) -> Optional[str]:
+    """Return plugin-configured target persona ID, if explicitly configured."""
+    value = optional_object_attr(config, "current_persona_name")
+    if value is None:
+        return None
+    persona_id = str(value).strip()
+    if not persona_id or persona_id == "[%None]":
+        return None
+    return persona_id
+
+
+def normalize_persona_data(persona: Any) -> Optional[Dict[str, Any]]:
+    """Normalize AstrBot Persona objects and legacy Personality dicts."""
+    if not persona:
+        return None
+
+    if isinstance(persona, dict):
+        raw = dict(persona)
+        persona_id = raw.get("persona_id") or raw.get("name")
+        name = raw.get("name") or persona_id
+        prompt = raw.get("prompt") or raw.get("system_prompt") or ""
+        system_prompt = raw.get("system_prompt") or raw.get("prompt") or ""
+        begin_dialogs = raw.get("begin_dialogs") or []
+        tools = raw.get("tools")
+    else:
+        persona_id = getattr(persona, "persona_id", None)
+        name = getattr(persona, "name", None) or persona_id
+        prompt = getattr(persona, "prompt", None) or getattr(persona, "system_prompt", "") or ""
+        system_prompt = getattr(persona, "system_prompt", None) or getattr(persona, "prompt", "") or ""
+        begin_dialogs = getattr(persona, "begin_dialogs", None) or []
+        tools = getattr(persona, "tools", None)
+        raw = {}
+
+    if persona_id is not None:
+        persona_id = str(persona_id)
+    if name is not None:
+        name = str(name)
+
+    normalized = {
+        **raw,
+        "persona_id": persona_id or name,
+        "name": name or persona_id or "default",
+        "prompt": prompt,
+        "system_prompt": system_prompt,
+        "begin_dialogs": begin_dialogs,
+        "tools": tools,
+    }
+    return normalized
+
+
+def get_persona_identifier(persona: Any, fallback: str = "default") -> str:
+    normalized = normalize_persona_data(persona) or {}
+    return str(normalized.get("persona_id") or normalized.get("name") or fallback)
+
+
+def _warn(log: Any, message: str) -> None:
+    if log and hasattr(log, "warning"):
+        log.warning(message)
+
+
+async def _read_persona_by_id(
+    persona_manager: Any,
+    persona_id: str,
+    log: Any = None,
+) -> Optional[Dict[str, Any]]:
+    get_persona = _explicit_attr(persona_manager, "get_persona")
+    if not get_persona:
+        return None
+    try:
+        persona = await _maybe_await(get_persona(persona_id))
+    except Exception as exc:
+        _warn(log, f"读取人格 {persona_id} 失败: {exc}")
+        return None
+
+    normalized = normalize_persona_data(persona)
+    if normalized:
+        returned_id = normalized.get("persona_id")
+        if returned_id and str(returned_id) != persona_id:
+            _warn(log, f"读取人格 {persona_id} 返回了 {returned_id}，按未命中处理")
+            return None
+        normalized["persona_id"] = returned_id or persona_id
+        normalized.setdefault("name", normalized["persona_id"])
+    return normalized
+
+
+async def read_web_persona_by_id(persona_web_manager: Any, persona_id: str) -> Optional[Dict[str, Any]]:
+    """Read a persona through PersonaWebManager's thread-safe WebUI surface."""
+    if not persona_web_manager:
+        return None
+    get_persona_by_id = _explicit_attr(persona_web_manager, "get_persona_by_id")
+    if get_persona_by_id:
+        try:
+            persona = await _maybe_await(get_persona_by_id(persona_id))
+        except Exception:
+            persona = None
+        normalized = normalize_persona_data(persona)
+        if normalized:
+            return normalized
+    get_all_personas = _explicit_attr(persona_web_manager, "get_all_personas_for_web")
+    if not get_all_personas:
+        return None
+
+    personas = await _maybe_await(get_all_personas())
+    for persona in personas or []:
+        normalized = normalize_persona_data(persona)
+        if normalized and normalized.get("persona_id") == persona_id:
+            return normalized
+    return None
+
+
+async def resolve_target_persona_from_web(
+    persona_web_manager: Any,
+    config: Any = None,
+    group_id: Optional[str] = None,
+    *,
+    log: Any = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve target persona through PersonaWebManager for WebUI threads."""
+    if not persona_web_manager:
+        return None
+
+    configured_id = get_configured_persona_id(config)
+    if configured_id:
+        configured = await read_web_persona_by_id(persona_web_manager, configured_id)
+        if configured:
+            configured["selection_source"] = "plugin_config"
+            return configured
+        _warn(log, f"插件配置的人格 {configured_id} 不存在，将尝试 AstrBot 当前人格")
+
+    get_persona_for_group = _explicit_attr(persona_web_manager, "get_persona_for_group")
+    get_all_personas = _explicit_attr(persona_web_manager, "get_all_personas_for_web")
+    get_default_persona = _explicit_attr(persona_web_manager, "get_default_persona_for_web")
+
+    if get_persona_for_group and group_id:
+        current = await _maybe_await(get_persona_for_group(group_id))
+        normalized = normalize_persona_data(current)
+        if normalized and normalized.get("persona_id"):
+            if get_all_personas or _explicit_attr(persona_web_manager, "get_persona_by_id"):
+                existing = await read_web_persona_by_id(
+                    persona_web_manager,
+                    str(normalized["persona_id"]),
+                )
+                if existing:
+                    existing["selection_source"] = "astrbot_default"
+                    return existing
+                _warn(log, f"AstrBot 当前人格 {normalized['persona_id']} 不存在于 PersonaManager")
+            else:
+                normalized["selection_source"] = "astrbot_default"
+                return normalized
+
+    if get_default_persona:
+        current = await _maybe_await(get_default_persona())
+        normalized = normalize_persona_data(current)
+        if normalized and normalized.get("persona_id"):
+            if get_all_personas or _explicit_attr(persona_web_manager, "get_persona_by_id"):
+                existing = await read_web_persona_by_id(
+                    persona_web_manager,
+                    str(normalized["persona_id"]),
+                )
+                if existing:
+                    existing["selection_source"] = "astrbot_default"
+                    return existing
+                _warn(log, f"AstrBot 全局人格 {normalized['persona_id']} 不存在于 PersonaManager")
+            else:
+                normalized["selection_source"] = "astrbot_default"
+                return normalized
+
+    if get_all_personas:
+        personas = await _maybe_await(get_all_personas())
+        normalized = [
+            persona
+            for persona in (normalize_persona_data(item) for item in (personas or []))
+            if persona and persona.get("persona_id")
+        ]
+        if len(normalized) == 1:
+            _warn(log, f"目标人格不可用，回退到唯一可用人格 {normalized[0]['persona_id']}")
+            normalized[0]["selection_source"] = "single_existing"
+            return normalized[0]
+
+    return None
+
+
+async def _read_single_existing_persona(
+    persona_manager: Any,
+    log: Any = None,
+) -> Optional[Dict[str, Any]]:
+    get_all_personas = _explicit_attr(persona_manager, "get_all_personas")
+    if not persona_manager or not get_all_personas:
+        return None
+    try:
+        personas = await _maybe_await(get_all_personas())
+    except Exception as exc:
+        _warn(log, f"读取人格列表失败: {exc}")
+        return None
+
+    normalized = [
+        persona
+        for persona in (normalize_persona_data(item) for item in (personas or []))
+        if persona and persona.get("persona_id")
+    ]
+    if len(normalized) == 1:
+        _warn(log, f"目标人格不可用，回退到唯一可用人格 {normalized[0]['persona_id']}")
+        return normalized[0]
+    return None
+
+
+async def resolve_target_persona(
+    persona_manager: Any,
+    config: Any = None,
+    umo: Optional[str] = None,
+    *,
+    require_existing: bool = False,
+    log: Any = None,
+) -> Optional[Dict[str, Any]]:
+    """Resolve the persona SelfLearning should read or mutate.
+
+    Plugin config must take precedence over AstrBot's global default; otherwise
+    learning updates can be written to a non-existent ``default`` persona.
+    """
+    if not persona_manager:
+        return None
+
+    configured_id = get_configured_persona_id(config)
+    if configured_id:
+        configured = await _read_persona_by_id(persona_manager, configured_id, log)
+        if configured:
+            configured["selection_source"] = "plugin_config"
+            return configured
+        _warn(log, f"插件配置的人格 {configured_id} 不存在，将尝试 AstrBot 当前人格")
+
+    get_default_persona = _explicit_attr(persona_manager, "get_default_persona_v3")
+    if get_default_persona:
+        try:
+            default_persona = await _maybe_await(get_default_persona(umo))
+        except Exception as exc:
+            _warn(log, f"读取 AstrBot 当前人格失败: {exc}")
+        else:
+            normalized = normalize_persona_data(default_persona)
+            if normalized:
+                if not require_existing:
+                    normalized["selection_source"] = "astrbot_default"
+                    return normalized
+
+                existing_id = normalized.get("persona_id")
+                if existing_id and str(existing_id) != "default":
+                    normalized["selection_source"] = "astrbot_default"
+                    return normalized
+                if existing_id:
+                    existing = await _read_persona_by_id(persona_manager, existing_id, log)
+                    if existing:
+                        normalized["selection_source"] = "astrbot_default"
+                        return normalized
+                    _warn(log, f"AstrBot 当前人格 {existing_id} 不存在于 PersonaManager")
+
+        if umo != "default":
+            try:
+                default_persona = await _maybe_await(get_default_persona("default"))
+            except Exception as exc:
+                _warn(log, f"读取 AstrBot default 人格失败: {exc}")
+            else:
+                normalized = normalize_persona_data(default_persona)
+                if normalized:
+                    if not require_existing:
+                        normalized["selection_source"] = "astrbot_default"
+                        return normalized
+
+                    existing_id = normalized.get("persona_id")
+                    if existing_id and str(existing_id) != "default":
+                        normalized["selection_source"] = "astrbot_default"
+                        return normalized
+                    if existing_id:
+                        existing = await _read_persona_by_id(persona_manager, existing_id, log)
+                        if existing:
+                            normalized["selection_source"] = "astrbot_default"
+                            return normalized
+                        _warn(log, f"AstrBot default 人格 {existing_id} 不存在于 PersonaManager")
+
+    if require_existing:
+        single_persona = await _read_single_existing_persona(persona_manager, log)
+        if single_persona:
+            single_persona["selection_source"] = "single_existing"
+            return single_persona
+
+    return None

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -1920,6 +1920,47 @@
             color: var(--muted);
         }
 
+        .persona-picker {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) auto;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .persona-picker .config-input {
+            min-width: 0;
+        }
+
+        .persona-picker-btn {
+            min-width: 38px;
+            height: 38px;
+            padding: 0 10px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel);
+            color: var(--text);
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: var(--shadow-sm);
+        }
+
+        .persona-picker-btn:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+            background: var(--surface-hover);
+        }
+
+        .persona-picker-btn:disabled {
+            cursor: progress;
+            opacity: 0.6;
+        }
+
+        .persona-picker-btn .material-icons {
+            font-size: 18px;
+        }
+
         .config-status {
             margin-top: 12px;
             padding: 10px 12px;
@@ -2821,6 +2862,11 @@
                     loading: false,
                     saving: false,
                     search: '',
+                },
+                personas: {
+                    items: [],
+                    loading: false,
+                    loaded: false,
                 },
                 dependencyInstall: {
                     busy: false,
@@ -4782,6 +4828,10 @@
                 return null;
             }
 
+            function hasConfigField(key) {
+                return Boolean(getConfigFieldByKey(key));
+            }
+
             function normalizeProviderType(value) {
                 const type = String(value || '').trim().toLowerCase();
                 if (type === 'chat' || type === 'llm') {
@@ -4841,6 +4891,74 @@
                 });
             }
 
+            function extractPersonaItems(payload) {
+                const source = safeArray(
+                    (payload && payload.personas)
+                    || (payload && payload.data && payload.data.personas)
+                    || (payload && payload.data)
+                    || payload
+                );
+
+                return source
+                    .map((item) => {
+                        if (!item || typeof item !== 'object') {
+                            return null;
+                        }
+                        const personaId = String(item.persona_id || item.id || item.name || '').trim();
+                        if (!personaId) {
+                            return null;
+                        }
+                        const name = String(item.name || item.persona_name || personaId).trim() || personaId;
+                        return {
+                            persona_id: personaId,
+                            name,
+                        };
+                    })
+                    .filter(Boolean)
+                    .sort((a, b) => a.persona_id.localeCompare(b.persona_id, 'zh-CN'));
+            }
+
+            async function loadPersonaOptions(options = {}) {
+                const { quiet = false, render = true } = options;
+                if (state.personas.loading) {
+                    return;
+                }
+
+                state.personas.loading = true;
+                let statusMessage = '';
+                let statusTone = '';
+                if (!quiet) {
+                    updateConfigStatus('正在刷新人格列表。');
+                }
+
+                try {
+                    const payload = await safeFetch('/api/persona_management/list');
+                    if (!payload) {
+                        throw new Error('人格列表获取失败');
+                    }
+                    state.personas.items = extractPersonaItems(payload);
+                    state.personas.loaded = true;
+                    if (!quiet) {
+                        statusMessage = `已加载 ${formatCount(state.personas.items.length)} 个人格。`;
+                        statusTone = 'success';
+                    }
+                } catch (error) {
+                    console.error('加载人格列表失败:', error);
+                    if (!quiet) {
+                        statusMessage = `人格列表加载失败: ${error.message}`;
+                        statusTone = 'error';
+                    }
+                } finally {
+                    state.personas.loading = false;
+                    if (render && state.config.schema) {
+                        renderConfigPanel();
+                    }
+                    if (statusMessage) {
+                        updateConfigStatus(statusMessage, statusTone);
+                    }
+                }
+            }
+
             function renderConfigField(field, idPrefix = 'config') {
                 const fieldId = `${idPrefix}-${field.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
                 const value = Object.prototype.hasOwnProperty.call(state.config.draft, field.key)
@@ -4871,7 +4989,50 @@
                 }
 
                 let controlHtml = '';
-                if (field.widget === 'toggle') {
+                if (field.key === 'current_persona_name') {
+                    const personas = safeArray(state.personas.items);
+                    const currentValue = displayValue || '';
+                    const datalistId = `${fieldId}-options`;
+                    const hasCurrent = personas.some((persona) => persona.persona_id === currentValue);
+                    const options = personas.map((persona) => {
+                        const label = persona.name && persona.name !== persona.persona_id
+                            ? `${persona.name} · ${persona.persona_id}`
+                            : persona.persona_id;
+                        return `<option value="${escapeHtml(persona.persona_id)}" label="${escapeHtml(label)}"></option>`;
+                    });
+                    if (currentValue && !hasCurrent) {
+                        options.push(`<option value="${escapeHtml(currentValue)}" label="${escapeHtml(currentValue)}（当前值）"></option>`);
+                    }
+                    controlHtml = `
+                        <div class="persona-picker">
+                            <input
+                                id="${fieldId}"
+                                class="config-input"
+                                type="text"
+                                list="${datalistId}"
+                                value="${escapeHtml(currentValue)}"
+                                placeholder="选择或输入人格 ID"
+                                data-config-key="${escapeHtml(field.key)}"
+                                data-config-type="${escapeHtml(field.type)}"
+                                data-config-widget="persona"
+                                ${field.editable ? '' : 'disabled'}
+                            >
+                            <button
+                                class="persona-picker-btn"
+                                type="button"
+                                title="刷新人格列表"
+                                aria-label="刷新人格列表"
+                                data-persona-refresh="1"
+                                ${field.editable && !state.personas.loading ? '' : 'disabled'}
+                            >
+                                <span class="material-icons">refresh</span>
+                            </button>
+                            <datalist id="${datalistId}">
+                                ${options.join('')}
+                            </datalist>
+                        </div>
+                    `;
+                } else if (field.widget === 'toggle') {
                     controlHtml = `
                         <label class="bool-row" for="${fieldId}">
                             <input
@@ -5332,6 +5493,9 @@
                     updateConfigActionStates();
                     if (!quiet && !state.config.schema) {
                         updateConfigStatus('配置面板尚未加载。', 'error');
+                    }
+                    if (state.config.schema && hasConfigField('current_persona_name') && !state.personas.loaded) {
+                        loadPersonaOptions({ quiet: true });
                     }
                 }
             }
@@ -6607,6 +6771,12 @@
                     const target = event.target;
                     if (target && target.dataset && target.dataset.configKey) {
                         syncConfigDraftFromInput(target);
+                    }
+                });
+                $('configGroups').addEventListener('click', (event) => {
+                    const target = event.target.closest('[data-persona-refresh]');
+                    if (target) {
+                        loadPersonaOptions({ quiet: false });
                     }
                 });
                 $('integrationConfigFields').addEventListener('input', (event) => {

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -186,6 +186,12 @@ _EXTRA_SCHEMA_DEFINITION: Dict[str, Dict[str, Any]] = {
                 "hint": "单个服务停止时的等待超时（秒）",
                 "default": 5,
             },
+            "llm_hook_context_timeout": {
+                "description": "LLM Hook 上下文超时",
+                "type": "float",
+                "hint": "LLM Hook 读取单个上下文源的最大等待时间（秒）",
+                "default": 3.0,
+            },
             "messages_db_path": {
                 "description": "消息数据库路径",
                 "type": "string",

--- a/webui/services/persona_review_service.py
+++ b/webui/services/persona_review_service.py
@@ -11,6 +11,10 @@ STYLE_BEGIN_DIALOG_PREFIX = "[风格示范]"
 
 # Import update type constants
 try:
+    from ...utils.persona_selection import (
+        resolve_target_persona,
+        resolve_target_persona_from_web,
+    )
     from ...utils.logging_utils import get_astrbot_logger
     from ...statics.messages import (
         UPDATE_TYPE_STYLE_LEARNING,
@@ -18,6 +22,10 @@ try:
         get_review_source_from_update_type,
     )
 except ImportError:
+    from utils.persona_selection import (
+        resolve_target_persona,
+        resolve_target_persona_from_web,
+    )
     from utils.logging_utils import get_astrbot_logger
     from statics.messages import (
         UPDATE_TYPE_STYLE_LEARNING,
@@ -242,9 +250,20 @@ class PersonaReviewService:
         try:
             current_persona = None
             if self.persona_web_manager:
-                current_persona = await self.persona_web_manager.get_persona_for_group(group_id)
+                current_persona = await resolve_target_persona_from_web(
+                    self.persona_web_manager,
+                    self.plugin_config,
+                    group_id,
+                    log=logger,
+                )
             elif self.astrbot_persona_manager:
-                current_persona = await self.astrbot_persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+                current_persona = await resolve_target_persona(
+                    self.astrbot_persona_manager,
+                    self.plugin_config,
+                    self._resolve_umo(group_id),
+                    require_existing=True,
+                    log=logger,
+                )
 
             if not isinstance(current_persona, dict):
                 return fallback
@@ -508,7 +527,13 @@ class PersonaReviewService:
                         logger.info(f"数据库中没有原人格文本，实时获取群组 {group_id} 的原人格")
                         try:
                             if self.astrbot_persona_manager:
-                                current_persona = await self.astrbot_persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+                                current_persona = await resolve_target_persona(
+                                    self.astrbot_persona_manager,
+                                    self.plugin_config,
+                                    self._resolve_umo(group_id),
+                                    require_existing=True,
+                                    log=logger,
+                                )
                                 if current_persona and current_persona.get('prompt'):
                                     original_content = current_persona.get('prompt', '')
                                     logger.info(f"成功获取群组 {group_id} 的原人格文本，长度: {len(original_content)}")
@@ -586,7 +611,13 @@ class PersonaReviewService:
                     try:
                         # 通过 persona_manager 获取当前人格
                         if self.astrbot_persona_manager:
-                            current_persona = await self.astrbot_persona_manager.get_default_persona_v3(self._resolve_umo(group_id))
+                            current_persona = await resolve_target_persona(
+                                self.astrbot_persona_manager,
+                                self.plugin_config,
+                                self._resolve_umo(group_id),
+                                require_existing=True,
+                                log=logger,
+                            )
                             if current_persona and current_persona.get('prompt'):
                                 original_persona_text = current_persona.get('prompt', '')
                             else:
@@ -756,8 +787,7 @@ class PersonaReviewService:
                                         persona_name, {"system_prompt": new_prompt}
                                     )
                                     if result.get('success'):
-                                        after_current = await self.persona_web_manager.get_persona_for_group(group_id)
-                                        after = self._persona_snapshot_from_current(after_current)
+                                        after = await self._get_current_persona_snapshot(group_id)
                                         change_payload = self._build_change_payload(
                                             self._persona_snapshot_from_current(before_snapshot),
                                             after,
@@ -899,8 +929,7 @@ class PersonaReviewService:
                     persona_name, {"system_prompt": new_content}
                 )
                 if update_result.get('success'):
-                    after_current = await self.persona_web_manager.get_persona_for_group(group_id)
-                    after = self._persona_snapshot_from_current(after_current)
+                    after = await self._get_current_persona_snapshot(group_id)
                     change_payload = self._build_change_payload(
                         {
                             'persona_id': change_preview.get('applied_persona_id', 'default'),
@@ -983,8 +1012,7 @@ class PersonaReviewService:
                             persona_name, {"begin_dialogs": change_snapshot.get('after_begin_dialogs', [])}
                         )
                         if result.get('success'):
-                            after_current = await self.persona_web_manager.get_persona_for_group(group_id)
-                            after = self._persona_snapshot_from_current(after_current)
+                            after = await self._get_current_persona_snapshot(group_id)
                             change_payload = self._build_change_payload(
                                 self._persona_snapshot_from_current(before_snapshot),
                                 after,

--- a/webui/services/persona_service.py
+++ b/webui/services/persona_service.py
@@ -5,6 +5,19 @@ from typing import Dict, Any, List, Optional, Tuple
 from datetime import datetime
 from astrbot.api import logger
 
+try:
+    from ...utils.persona_selection import (
+        normalize_persona_data,
+        resolve_target_persona,
+        resolve_target_persona_from_web,
+    )
+except ImportError:
+    from utils.persona_selection import (
+        normalize_persona_data,
+        resolve_target_persona,
+        resolve_target_persona_from_web,
+    )
+
 
 def _optional_container_attr(container, name: str, default=None):
     value = getattr(container, name, default)
@@ -47,12 +60,7 @@ class PersonaService:
 
     @staticmethod
     def _normalize_persona_data(data: Dict[str, Any]) -> Dict[str, Any]:
-        normalized = dict(data)
-        if 'system_prompt' not in normalized and 'prompt' in normalized:
-            normalized['system_prompt'] = normalized['prompt']
-        if 'prompt' not in normalized and 'system_prompt' in normalized:
-            normalized['prompt'] = normalized['system_prompt']
-        return normalized
+        return normalize_persona_data(data) or {}
 
     @staticmethod
     def _has_required_persona_fields(data: Dict[str, Any]) -> bool:
@@ -220,20 +228,24 @@ class PersonaService:
 
         try:
             if self.persona_web_mgr:
-                if group_id and group_id != "default":
-                    default_persona = await self.persona_web_mgr.get_persona_for_group(group_id)
-                else:
-                    default_persona = await self.persona_web_mgr.get_default_persona_for_web()
-                return self._normalize_persona_data(default_persona or fallback_persona)
+                persona = await resolve_target_persona_from_web(
+                    self.persona_web_mgr,
+                    _optional_container_attr(self.container, 'plugin_config'),
+                    group_id,
+                    log=logger,
+                )
+                return self._normalize_persona_data(persona or fallback_persona)
 
             if self.astrbot_persona_manager:
-                default_persona = await self.astrbot_persona_manager.get_default_persona_v3(group_id)
-                if default_persona:
-                    return self._normalize_persona_data(default_persona)
-
-                default_persona = await self.astrbot_persona_manager.get_default_persona_v3('default')
-                if default_persona:
-                    return self._normalize_persona_data(default_persona)
+                persona = await resolve_target_persona(
+                    self.astrbot_persona_manager,
+                    _optional_container_attr(self.container, 'plugin_config'),
+                    group_id,
+                    require_existing=True,
+                    log=logger,
+                )
+                if persona:
+                    return self._normalize_persona_data(persona)
 
             return fallback_persona
         except Exception as e:


### PR DESCRIPTION
Closes #164.

## Evidence

- Issue #164 asks for the WebUI target persona field to fetch all personas from the database and use a dropdown-style selector instead of manual-only input.
- The repository already exposes `GET /api/persona_management/list` in `webui/blueprints/personas.py`, so this PR reuses that authenticated API instead of adding a duplicate route.

## Changes

- Adds a refreshable datalist picker for `current_persona_name` in `web_res/static/html/dashboard.html`, with manual input preserved for compatibility and empty-list fallback.
- Adds persona resolution helpers so WebUI previews, review approval, backups, and automatic persona updates honor the configured target persona ID before falling back to AstrBot defaults.
- Adds `PersonaWebManager.get_persona_by_id()` for WebUI thread-safe lookup through the existing persona cache/list surface.
- Adds schema coverage for the existing `llm_hook_context_timeout` config field so the full config-schema test remains consistent.
- Bumps release metadata/docs from `3.1.3` to `3.1.4`.

## Validation

- `python -m pytest tests` with repo-local TEMP/TMP override: `571 passed, 7 warnings`
- `python -m py_compile utils\persona_selection.py webui\services\persona_service.py webui\services\persona_review_service.py webui\services\config_service.py persona_web_manager.py services\persona\persona_updater.py services\persona\temporary_persona_updater.py services\persona\persona_manager.py services\persona\persona_backup_manager.py services\core_learning\progressive_learning.py`
- Dashboard inline script parse: `dashboard scripts parsed: 2`
- `git diff --check`

## Release Readiness Note

- `python C:\Users\zacza\.codex\skills\skill-astrbot-dev\scripts\pre_review_check.py C:\Users\zacza\Desktop\x\self_learning_EterU` still reports existing repo-wide AstrBot publish-rule findings, primarily logger import and `StarTools.get_data_dir()` rules in files such as `config.py`, `main.py`, `persona_web_manager.py`, `services/learning/sample_filter.py`, `services/persona/persona_manager.py`, `services/persona/persona_updater.py`, and others. These findings predate this issue-scoped change and were not expanded here.

Release/tag `3.1.4` should be published after this PR is reviewed and merged into upstream `main`.

## Summary by Sourcery

Add a WebUI persona selector and centralize persona resolution so WebUI previews, reviews, backups, and learning updates respect the configured target persona, while updating config schema and version metadata.

New Features:
- Introduce a refreshable WebUI persona picker for the current_persona_name config field backed by the existing persona list API.
- Add persona resolution helpers and PersonaWebManager.get_persona_by_id to consistently select the plugin-configured target persona across WebUI and backend services.

Enhancements:
- Refactor persona-related services (review, updater, backup, temporary and progressive learning) to use shared persona selection logic and stable persona identifiers.
- Align persona backup and restore metadata to track persona IDs explicitly and prefer configured personas when applying updates.

Build:
- Extend WebUI config schema to cover the llm_hook_context_timeout field.

Deployment:
- Bump plugin version and metadata to 3.1.4 for release.

Documentation:
- Update README badges to reflect release version 3.1.4.

Tests:
- Add unit tests for persona selection helpers and for WebUI persona and learning flows that prefer configured personas and fall back to existing ones when defaults are missing.