### PR TITLE
[codex] Fix persona review generation and filter stats

### DIFF
--- a/services/core_learning/progressive_learning.py
+++ b/services/core_learning/progressive_learning.py
@@ -205,6 +205,85 @@ class ProgressiveLearningService:
             except Exception:
                 pass
 
+    def _build_fallback_style_analysis_data(
+        self,
+        filtered_messages: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Build reviewable persona-learning content when refine analysis is unavailable."""
+        texts = [
+            self._message_text(message).strip()
+            for message in (filtered_messages or [])
+        ]
+        texts = [text for text in texts if text]
+        sample_texts = texts[:5]
+        avg_len = sum(len(text) for text in texts) / max(len(texts), 1)
+
+        expression_features = []
+        if avg_len >= 40:
+            expression_features.append("偏向较完整、信息量较高的表达")
+        elif avg_len > 0:
+            expression_features.append("偏向短句和即时回应")
+        if any("?" in text or "？" in text for text in texts):
+            expression_features.append("常使用提问式互动")
+        if any("!" in text or "！" in text for text in texts):
+            expression_features.append("语气中包含强调和情绪表达")
+        if not expression_features:
+            expression_features.append("保留群聊中的自然表达习惯")
+
+        sample_lines = [
+            f"- {text[:80]}"
+            for text in sample_texts
+        ]
+        learning_insights = [
+            f"基于 {len(texts)} 条通过筛选的群聊消息生成待审人格候选。",
+            "请在人工审查后决定是否将这些表达习惯追加到当前人格。",
+        ]
+        if sample_lines:
+            learning_insights.append("代表性表达：")
+            learning_insights.extend(sample_lines)
+
+        return {
+            "message_count": len(texts),
+            "analysis_timestamp": datetime.now().isoformat(),
+            "learning_insights": "\n".join(learning_insights),
+            "style_analysis": {
+                "text_style": (
+                    "长句详述型" if avg_len >= 40 else "短句互动型"
+                ),
+                "expression_features": expression_features,
+                "tone": "强调型" if any("!" in text or "！" in text for text in texts) else "平和型",
+                "topics": [],
+            },
+        }
+
+    async def _save_filtered_messages_for_stats(
+        self,
+        group_id: str,
+        filtered_messages: List[Dict[str, Any]],
+    ) -> int:
+        """Persist passed learning samples so WebUI filter-rate stats move."""
+        saved_count = 0
+        for msg in filtered_messages or []:
+            try:
+                await self.message_collector.add_filtered_message({
+                    "raw_message_id": msg.get("id"),
+                    "message": msg.get("message", ""),
+                    "sender_id": msg.get("sender_id", ""),
+                    "group_id": msg.get("group_id", group_id),
+                    "timestamp": msg.get("timestamp", int(time.time())),
+                    "confidence": msg.get("relevance_score", 1.0),
+                    "filter_reason": msg.get("filter_reason", "batch_learning"),
+                })
+                saved_count += 1
+            except Exception as exc:
+                logger.debug(f"保存筛选消息统计失败: {exc}")
+
+        if saved_count:
+            logger.debug(
+                f"已保存 {saved_count}/{len(filtered_messages or [])} 条筛选消息到 FilteredMessage 表"
+            )
+        return saved_count
+
     def set_update_system_prompt_callback(self, callback):
         """
         设置增量更新回调函数
@@ -377,42 +456,31 @@ class ProgressiveLearningService:
                 return
 
             # 2.5 将筛选后的消息写入 FilteredMessage 表（供 WebUI 统计）
-            saved_count = 0
-            for msg in filtered_messages:
-                try:
-                    await self.message_collector.add_filtered_message({
-                        "raw_message_id": msg.get("id"),
-                        "message": msg.get("message", ""),
-                        "sender_id": msg.get("sender_id", ""),
-                        "group_id": msg.get("group_id", group_id),
-                        "timestamp": msg.get("timestamp", int(time.time())),
-                        "confidence": msg.get("relevance_score", 1.0),
-                        "filter_reason": msg.get("filter_reason", "batch_learning"),
-                    })
-                    saved_count += 1
-                except Exception:
-                    pass  # best-effort, don't block learning
-            if saved_count:
-                logger.debug(f"已保存 {saved_count}/{len(filtered_messages)} 条筛选消息到 FilteredMessage 表")
+            await self._save_filtered_messages_for_stats(group_id, filtered_messages)
 
             # 3. 获取当前人格设置 (针对特定群组)
             current_persona = await self._get_current_persona(group_id)
             
-            # 4-7. 跳过LLM分析，仅记录消息统计
+            # 4-7. 分析风格并生成候选人格更新；失败时保留统计和风格学习降级记录
             from ...core.interfaces import AnalysisResult
 
-            style_analysis = AnalysisResult(
-                success=True,
-                confidence=0.7,
-                data={
-                    'message_count': len(filtered_messages),
-                    'analysis_timestamp': datetime.now().isoformat(),
-                },
-                timestamp=time.time()
-            )
+            style_analysis = await self._execute_style_analysis_background(group_id, filtered_messages)
+            if not getattr(style_analysis, "success", False):
+                logger.warning(
+                    f"风格分析失败，使用统计摘要继续学习批次: {getattr(style_analysis, 'error', '')}"
+                )
+                style_analysis = AnalysisResult(
+                    success=True,
+                    confidence=0.7,
+                    data=self._build_fallback_style_analysis_data(filtered_messages),
+                    timestamp=time.time()
+                )
 
-            # 不调用LLM生成更新后的人格，保持当前人格不变
-            updated_persona = current_persona.copy() if current_persona else {"prompt": ""}
+            updated_persona = await self._generate_updated_persona_with_refinement(
+                group_id,
+                current_persona or {"prompt": "默认人格"},
+                style_analysis,
+            )
             ml_tuning_info = None
             
             # 8. 质量监控评估
@@ -530,21 +598,29 @@ class ProgressiveLearningService:
                 logger.debug("没有通过筛选的消息")
                 await self._mark_messages_processed(unprocessed_messages)
                 return
-            
-            # 3. 跳过LLM分析，仅记录消息统计
+
+            await self._save_filtered_messages_for_stats(group_id, filtered_messages)
+
+            # 3. 分析风格并生成候选人格更新；失败时保留统计和风格学习降级记录
             from ...core.interfaces import AnalysisResult
 
-            style_analysis = AnalysisResult(
-                success=True,
-                confidence=0.7,
-                data={
-                    'message_count': len(filtered_messages),
-                    'analysis_timestamp': datetime.now().isoformat(),
-                },
-                timestamp=time.time()
-            )
+            style_analysis = await self._execute_style_analysis_background(group_id, filtered_messages)
+            if not getattr(style_analysis, "success", False):
+                logger.warning(
+                    f"风格分析失败，使用统计摘要继续学习批次: {getattr(style_analysis, 'error', '')}"
+                )
+                style_analysis = AnalysisResult(
+                    success=True,
+                    confidence=0.7,
+                    data=self._build_fallback_style_analysis_data(filtered_messages),
+                    timestamp=time.time()
+                )
 
-            updated_persona = current_persona.copy() if current_persona else {"prompt": ""}
+            updated_persona = await self._generate_updated_persona_with_refinement(
+                group_id,
+                current_persona or {"prompt": "默认人格"},
+                style_analysis,
+            )
 
             # 4. 质量评估和应用更新
             await self._finalize_learning_batch(

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -68,6 +68,167 @@ async def test_progressive_learning_fetches_unprocessed_messages_for_current_gro
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_background_learning_persists_filter_stats_and_persona_review():
+    service = ProgressiveLearningService.__new__(ProgressiveLearningService)
+    service.batch_size = 10
+    service.config = SimpleNamespace(max_messages_per_batch=200)
+    service._group_sessions = {}
+    service.update_system_prompt_callback = None
+    service.ml_analyzer = SimpleNamespace()
+    service.message_collector = SimpleNamespace(
+        get_unprocessed_messages=AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "sender_id": "user-a",
+                    "sender_name": "User A",
+                    "message": "这是一条足够长的学习消息，会进入人格审查",
+                    "group_id": "group-a",
+                    "timestamp": time.time(),
+                }
+            ]
+        ),
+        add_filtered_message=AsyncMock(),
+        mark_messages_processed=AsyncMock(),
+    )
+    service._filter_messages_with_context = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "sender_id": "user-a",
+                "message": "这是一条足够长的学习消息，会进入人格审查",
+                "group_id": "group-a",
+                "timestamp": time.time(),
+                "relevance_score": 1.0,
+                "filter_reason": "style_learning_no_filter",
+            }
+        ]
+    )
+    service._get_current_persona = AsyncMock(
+        return_value={"prompt": "原人格", "name": "default"}
+    )
+    service._execute_style_analysis_background = AsyncMock(
+        return_value=AnalysisResult(
+            success=True,
+            confidence=0.8,
+            data={"enhanced_prompt": "新增人格特征"},
+            timestamp=time.time(),
+        )
+    )
+    service._generate_updated_persona_with_refinement = AsyncMock(
+        return_value={"prompt": "原人格\n\n新增人格特征", "name": "default"}
+    )
+    service.quality_monitor = SimpleNamespace(
+        evaluate_learning_batch=AsyncMock(
+            return_value=AnalysisResult(
+                success=True,
+                confidence=0.8,
+                data={},
+                consistency_score=0.8,
+            )
+        )
+    )
+    service.persona_manager = SimpleNamespace(update_persona=AsyncMock(return_value=True))
+    service._save_style_learning_record = AsyncMock()
+    service.db_manager = SimpleNamespace(
+        get_session=lambda: (_ for _ in ()).throw(AssertionError("unused")),
+        save_learning_performance_record=AsyncMock(return_value=True),
+        add_persona_learning_review=AsyncMock(return_value=42),
+    )
+
+    await service._execute_learning_batch_background("group-a")
+
+    service.message_collector.add_filtered_message.assert_awaited_once()
+    filter_payload = service.message_collector.add_filtered_message.await_args.args[0]
+    assert filter_payload["raw_message_id"] == 1
+    assert filter_payload["confidence"] == 1.0
+    service.db_manager.add_persona_learning_review.assert_awaited_once()
+    review_kwargs = service.db_manager.add_persona_learning_review.await_args.kwargs
+    assert review_kwargs["group_id"] == "group-a"
+    assert review_kwargs["proposed_content"] == "新增人格特征"
+    assert review_kwargs["original_content"] == "原人格"
+    assert review_kwargs["new_content"] == "原人格\n\n新增人格特征"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_manual_learning_batch_generates_persona_review():
+    service = ProgressiveLearningService.__new__(ProgressiveLearningService)
+    service.batch_size = 10
+    service.config = SimpleNamespace(max_messages_per_batch=200)
+    service._group_sessions = {}
+    service.update_system_prompt_callback = None
+    service.ml_analyzer = SimpleNamespace()
+    service.message_collector = SimpleNamespace(
+        get_unprocessed_messages=AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "sender_id": "user-a",
+                    "sender_name": "User A",
+                    "message": "手动学习也应该产生人格候选",
+                    "group_id": "group-a",
+                    "timestamp": time.time(),
+                }
+            ]
+        ),
+        add_filtered_message=AsyncMock(),
+        mark_messages_processed=AsyncMock(),
+    )
+    service._filter_messages_with_context = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "sender_id": "user-a",
+                "message": "手动学习也应该产生人格候选",
+                "group_id": "group-a",
+                "timestamp": time.time(),
+                "relevance_score": 1.0,
+                "filter_reason": "style_learning_no_filter",
+            }
+        ]
+    )
+    service._get_current_persona = AsyncMock(
+        return_value={"prompt": "原人格", "name": "default"}
+    )
+    service._execute_style_analysis_background = AsyncMock(
+        return_value=AnalysisResult(
+            success=True,
+            confidence=0.8,
+            data={"enhanced_prompt": "手动学习新增人格特征"},
+            timestamp=time.time(),
+        )
+    )
+    service._generate_updated_persona_with_refinement = AsyncMock(
+        return_value={"prompt": "原人格\n\n手动学习新增人格特征", "name": "default"}
+    )
+    service.quality_monitor = SimpleNamespace(
+        evaluate_learning_batch=AsyncMock(
+            return_value=AnalysisResult(
+                success=True,
+                confidence=0.8,
+                data={},
+                consistency_score=0.8,
+            )
+        )
+    )
+    service.persona_manager = SimpleNamespace(update_persona=AsyncMock(return_value=True))
+    service._save_style_learning_record = AsyncMock()
+    service.db_manager = SimpleNamespace(
+        save_learning_performance_record=AsyncMock(return_value=True),
+        add_persona_learning_review=AsyncMock(return_value=43),
+    )
+
+    await service._execute_learning_batch("group-a", from_force_learning=True)
+
+    service.message_collector.add_filtered_message.assert_awaited_once()
+    service.db_manager.add_persona_learning_review.assert_awaited_once()
+    review_kwargs = service.db_manager.add_persona_learning_review.await_args.kwargs
+    assert review_kwargs["proposed_content"] == "手动学习新增人格特征"
+
+
+@pytest.mark.unit
 def test_progressive_learning_derives_quality_when_monitor_returns_zero():
     service = ProgressiveLearningService.__new__(ProgressiveLearningService)
     service.config = SimpleNamespace(max_messages_per_batch=200)
@@ -90,6 +251,23 @@ def test_progressive_learning_derives_quality_when_monitor_returns_zero():
 
     assert 0 < quality_score <= 1
     assert metrics.consistency_score == quality_score
+
+
+@pytest.mark.unit
+def test_progressive_learning_fallback_style_analysis_is_reviewable():
+    service = ProgressiveLearningService.__new__(ProgressiveLearningService)
+
+    data = service._build_fallback_style_analysis_data(
+        [
+            {"message": "今天这个功能真的很好用！继续保持这种表达"},
+            {"message": "能不能再解释一下为什么会这样？"},
+        ]
+    )
+
+    assert data["message_count"] == 2
+    assert "learning_insights" in data
+    assert "代表性表达" in data["learning_insights"]
+    assert data["style_analysis"]["expression_features"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Persist passed learning-batch samples into `filtered_messages` so WebUI filter-rate metrics can increase.
- Restore persona-candidate generation in manual/background progressive learning batches so changed prompts enter the existing persona review queue.
- Add regression coverage for background batches, manual batches, and reviewable fallback style-analysis data.

Fixes #166.

## Evidence
Issue #166 reports that pending persona reviews stay at 0 and the filter pass rate stays at 0 despite collected messages. The batch paths previously kept `updated_persona` equal to `current_persona`, so `_apply_learning_updates()` skipped `add_persona_learning_review()`. The background batch path also did not persist filtered samples to the `FilteredMessage` table used by metrics.

## Validation
- `python -m pytest --basetemp .tmp\pytest-basetemp tests/unit/test_learning_chain_regressions.py -q`
- `python -m py_compile services\core_learning\progressive_learning.py tests\unit\test_learning_chain_regressions.py`
- `python -m ruff check services\core_learning\progressive_learning.py tests\unit\test_learning_chain_regressions.py`
- `git diff --check`

## Summary by Sourcery

Ensure progressive learning batches persist filter stats and generate reviewable persona updates for both manual and background flows.

New Features:
- Generate fallback style-analysis data that remains reviewable when background analysis is unavailable.
- Produce refined persona candidates from style analysis results in background and manual learning batches so they can enter the review queue.

Bug Fixes:
- Persist filtered learning messages to the metrics store so WebUI filter-rate statistics reflect processed batches.
- Restore persona review creation for background and manual learning batches by ensuring updated personas are generated instead of reusing the current persona.

Enhancements:
- Refactor filtered-message persistence into a reusable helper shared by manual and background batch execution.

Tests:
- Add regression tests covering background learning batches, manual learning-triggered persona reviews, and fallback style-analysis data being reviewable.