### PR TITLE
refactor:优化Dashboard 审查页与设置页，并支持 AstrBot 插件内嵌页面

### DIFF
--- a/.astrbot-plugin/i18n/en-US.json
+++ b/.astrbot-plugin/i18n/en-US.json
@@ -1,0 +1,7 @@
+{
+  "pages": {
+    "dashboard": {
+      "title": "Dashboard"
+    }
+  }
+}

--- a/.astrbot-plugin/i18n/zh-CN.json
+++ b/.astrbot-plugin/i18n/zh-CN.json
@@ -1,0 +1,7 @@
+{
+  "pages": {
+    "dashboard": {
+      "title": "Dashboard"
+    }
+  }
+}

--- a/pages/dashboard/index.html
+++ b/pages/dashboard/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Self Learning Dashboard</title>
+    <script src="/api/plugin/page/bridge-sdk.js"></script>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #eef3f8;
+            --panel: #ffffff;
+            --text: #102033;
+            --muted: #64748b;
+            --border: #d8e1ec;
+            --accent: #2563eb;
+            --accent-soft: rgba(37, 99, 235, 0.12);
+            --danger: #dc2626;
+            --shadow: 0 16px 40px rgba(15, 23, 42, 0.10);
+        }
+
+        [data-theme="dark"] {
+            color-scheme: dark;
+            --bg: #0b111c;
+            --panel: #121c2b;
+            --text: #e5edf7;
+            --muted: #9aa8bc;
+            --border: #273449;
+            --accent: #60a5fa;
+            --accent-soft: rgba(96, 165, 250, 0.16);
+            --danger: #f87171;
+            --shadow: 0 16px 40px rgba(0, 0, 0, 0.36);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            margin: 0;
+            width: 100%;
+            height: 100%;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Microsoft YaHei", sans-serif;
+        }
+
+        body {
+            overflow: hidden;
+        }
+
+        .shell {
+            width: 100%;
+            height: 100%;
+            min-height: 100vh;
+        }
+
+        .frame-wrap {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            min-height: 0;
+        }
+
+        iframe {
+            display: block;
+            width: 100%;
+            height: 100%;
+            border: 0;
+            background: var(--bg);
+        }
+
+        .status {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            padding: 20px;
+            background: var(--bg);
+        }
+
+        .status-card {
+            width: min(520px, 100%);
+            padding: 24px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel);
+            box-shadow: var(--shadow);
+        }
+
+        .status-title {
+            margin: 0;
+            font-size: 20px;
+            letter-spacing: 0;
+            line-height: 1.3;
+        }
+
+        .status-text {
+            margin: 10px 0 0;
+            color: var(--muted);
+            font-size: 14px;
+            line-height: 1.7;
+        }
+
+        .status.error .status-title {
+            color: var(--danger);
+        }
+
+        .hidden {
+            display: none;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="shell">
+        <main class="frame-wrap">
+            <iframe id="dashboardFrame" title="Self Learning Dashboard"></iframe>
+            <section class="status" id="status">
+                <div class="status-card">
+                    <h2 class="status-title" id="statusTitle">正在加载 Dashboard</h2>
+                    <p class="status-text" id="statusText">正在通过 AstrBot Plugin Page bridge 读取 Self Learning WebUI 地址。</p>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script>
+        (function () {
+            const statusEl = document.getElementById('status');
+            const statusTitleEl = document.getElementById('statusTitle');
+            const statusTextEl = document.getElementById('statusText');
+            const frameEl = document.getElementById('dashboardFrame');
+
+            function fallbackDashboardUrl() {
+                const host = window.location.hostname || '127.0.0.1';
+                const safeHost = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+                return `http://${safeHost}:7833/static/html/dashboard.html`;
+            }
+
+            function setStatus(title, message, tone) {
+                statusTitleEl.textContent = title;
+                statusTextEl.textContent = message;
+                statusEl.className = `status${tone ? ` ${tone}` : ''}`;
+            }
+
+            function hideStatus() {
+                statusEl.classList.add('hidden');
+            }
+
+            function setDashboardUrl(url) {
+                frameEl.src = url;
+            }
+
+            frameEl.addEventListener('load', hideStatus);
+
+            if (!window.AstrBotPluginPage) {
+                setDashboardUrl(fallbackDashboardUrl());
+                return;
+            }
+
+            window.AstrBotPluginPage.ready().then(async () => {
+                try {
+                    const payload = await window.AstrBotPluginPage.apiGet('dashboard_url');
+                    if (!payload || !payload.url) {
+                        throw new Error('dashboard_url 未返回 url');
+                    }
+                    setDashboardUrl(payload.url);
+                } catch (error) {
+                    setStatus(
+                        '无法加载 Dashboard',
+                        `已进入插件 Page，但读取独立 WebUI 地址失败：${error.message || error}`,
+                        'error',
+                    );
+                }
+            }).catch((error) => {
+                setStatus(
+                    '插件页面上下文读取失败',
+                    error.message || String(error),
+                    'error',
+                );
+            });
+        })();
+    </script>
+</body>
+</html>

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -87,6 +87,69 @@ def test_dashboard_review_queue_uses_sidebar_categories():
     assert "updateReviewNavCounts" in text
 
 
+def test_dashboard_settings_uses_sidebar_categories():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert "settings-sidebar" in text
+    assert "settings-workspace" in text
+    assert "settingsSidebarSummary" in text
+    assert "settingsNav" in text
+    assert 'data-config-group="all"' in text
+    assert "dependencyInstallPanel" in text
+    assert "renderSettingsNav" in text
+    assert "setConfigGroup" in text
+    assert "configGroupIcon" in text
+    assert "SETTINGS_NAV_SECTIONS" in text
+    assert "常用入口" in text
+    assert "学习链路" in text
+    assert "人格与关系" in text
+    assert "数据与运行" in text
+    assert "settings-nav::-webkit-scrollbar" in text
+    assert "scrollbar-width: thin" in text
+    assert "Dependency_Install_Guide: 'extension'" in text
+    assert "deployed_code" not in text
+
+
+def test_dashboard_settings_right_pane_uses_dense_controls():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert "grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));" in text
+    assert "function configFieldLayoutClasses" in text
+    assert "is-bool" in text
+    assert "is-list" in text
+    assert "is-wide" in text
+    assert "function renderConfigSwitch" in text
+    assert 'class="config-switch-input"' in text
+    assert "switch-track" in text
+    assert "switch-thumb" in text
+    assert "bool-state" in text
+    assert "field.type === 'bool'" in text
+    assert "renderConfigSwitch(field, fieldId, Boolean(displayValue))" in text
+    assert "function syncConfigSwitchState" in text
+
+
+def test_dashboard_global_header_uses_compact_brand_copy():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert '<div class="app-brand">Self Learning</div>' in text
+    assert "SELF LEARNING / DASHBOARD" not in text
+    assert '<div class="brand">' not in text
+    assert 'id="summaryText"' not in text
+    assert 'id="refreshBtn"' in text
+    assert 'id="settingsJumpBtn"' in text
+    assert 'id="themeBtn"' in text
+
+
+def test_dashboard_jargon_sort_does_not_expose_misleading_occurrences_order():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert 'value="occurrences"' not in text
+    assert "按出现次数" not in text
+    assert "sort === 'occurrences'" not in text
+    assert "样本 ${formatCount(item.occurrences)}" in text
+    assert "['样本', jargonStats.total_occurrences]" in text
+
+
 def test_dashboard_review_deletes_use_inline_confirmation():
     text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
 

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -72,6 +72,21 @@ def test_dashboard_review_details_use_backend_structured_fields():
     assert "renderContextExamples(item)" in text
 
 
+def test_dashboard_review_queue_uses_sidebar_categories():
+    text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
+
+    assert "review-sidebar" in text
+    assert "review-workspace" in text
+    assert 'data-review-tab="persona"' in text
+    assert 'data-review-tab="style"' in text
+    assert 'data-review-tab="jargon"' in text
+    assert 'data-review-tab="persona-state"' in text
+    assert 'data-review-tab="reviewed"' in text
+    assert 'data-review-tab="batches"' in text
+    assert "setReviewTab" in text
+    assert "updateReviewNavCounts" in text
+
+
 def test_dashboard_review_deletes_use_inline_confirmation():
     text = (PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html").read_text(encoding="utf-8")
 

--- a/tests/integration/test_webui_static_assets.py
+++ b/tests/integration/test_webui_static_assets.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[2]
 HTML_FILES = [
+    PLUGIN_ROOT / "pages" / "dashboard" / "index.html",
     PLUGIN_ROOT / "web_res" / "static" / "html" / "change_password.html",
     PLUGIN_ROOT / "web_res" / "static" / "html" / "dashboard.html",
     PLUGIN_ROOT / "web_res" / "static" / "html" / "graph_share.html",
@@ -39,6 +40,26 @@ def test_webui_frontend_vendor_assets_exist():
 
     for path in expected_paths:
         assert path.exists(), f"Missing vendored frontend asset: {path}"
+
+
+def test_astrbot_plugin_pages_dashboard_entry_exists():
+    text = (PLUGIN_ROOT / "pages" / "dashboard" / "index.html").read_text(encoding="utf-8")
+    zh_i18n = (PLUGIN_ROOT / ".astrbot-plugin" / "i18n" / "zh-CN.json").read_text(encoding="utf-8")
+    en_i18n = (PLUGIN_ROOT / ".astrbot-plugin" / "i18n" / "en-US.json").read_text(encoding="utf-8")
+
+    assert "AstrBotPluginPage" in text
+    assert "/api/plugin/page/bridge-sdk.js" in text
+    assert "apiGet('dashboard_url')" in text
+    assert 'id="dashboardFrame"' in text
+    assert "setDashboardUrl(payload.url)" in text
+    assert "toolbar" not in text
+    assert "brand-title" not in text
+    assert "brand-meta" not in text
+    assert "pageLabel" not in text
+    assert "openDashboard" not in text
+    assert "reloadDashboard" not in text
+    assert '"dashboard"' in zh_i18n
+    assert '"dashboard"' in en_i18n
 
 
 def test_dashboard_exposes_learning_content_browser():

--- a/tests/unit/test_webui_manager.py
+++ b/tests/unit/test_webui_manager.py
@@ -67,3 +67,46 @@ async def test_webui_manager_continues_when_database_start_raises():
     assert database_manager.start_calls == 1
     assert manager._database_degraded is True
     assert manager._database_start_error == "connection was closed in the middle of operation"
+
+
+def test_webui_manager_registers_astrbot_plugin_page_dashboard_url_api():
+    calls = []
+    context = SimpleNamespace(
+        register_web_api=lambda route, handler, methods, desc: calls.append(
+            (route, handler, methods, desc)
+        )
+    )
+    config = SimpleNamespace(
+        enable_web_interface=True,
+        web_interface_host="0.0.0.0",
+        web_interface_port=7833,
+    )
+
+    WebUIManager(
+        plugin_config=config,
+        context=context,
+        factory_manager=object(),
+        perf_tracker="perf",
+        group_id_to_unified_origin={},
+        plugin_instance=SimpleNamespace(name="astrbot_plugin_self_learning"),
+    )
+
+    routes = {item[0] for item in calls}
+    assert "astrbot_plugin_self_learning/dashboard_url" in routes
+    assert any(item[2] == ["GET"] for item in calls)
+
+
+def test_webui_manager_public_webui_url_uses_configured_host():
+    manager = WebUIManager(
+        plugin_config=SimpleNamespace(
+            enable_web_interface=True,
+            web_interface_host="192.168.114.2",
+            web_interface_port=7833,
+        ),
+        context=SimpleNamespace(),
+        factory_manager=object(),
+        perf_tracker="perf",
+        group_id_to_unified_origin={},
+    )
+
+    assert manager._public_webui_base_url() == "http://192.168.114.2:7833"

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -191,40 +191,19 @@
         .topbar {
             display: flex;
             justify-content: space-between;
-            align-items: flex-start;
+            align-items: center;
             gap: 16px;
-            padding: 8px 0 20px;
-            border-bottom: 1px solid var(--border);
-            margin-bottom: 20px;
+            padding: 0 0 14px;
+            margin-bottom: 14px;
         }
 
-        .brand {
+        .app-brand {
             min-width: 0;
-        }
-
-        .eyebrow {
-            color: var(--muted);
-            font-size: 12px;
+            color: var(--text);
+            font-size: 30px;
+            line-height: 1.1;
             letter-spacing: 0;
-            text-transform: uppercase;
-        }
-
-        .brand h1 {
-            margin: 4px 0 0;
-            font-size: var(--text-2xl);
-            line-height: 1.15;
-            letter-spacing: -0.02em;
             font-weight: 800;
-            background: var(--grad-primary);
-            -webkit-background-clip: text;
-            -webkit-text-fill-color: transparent;
-            background-clip: text;
-        }
-
-        .brand p {
-            margin: 8px 0 0;
-            color: var(--muted);
-            max-width: 880px;
         }
 
         .toolbar {
@@ -1691,6 +1670,172 @@
             margin-top: 18px;
         }
 
+        .settings-workspace {
+            display: grid;
+            grid-template-columns: 280px minmax(0, 1fr);
+            gap: 16px;
+            align-items: start;
+        }
+
+        .settings-sidebar {
+            position: sticky;
+            top: 16px;
+            padding: 14px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            background: var(--panel);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .settings-sidebar-head {
+            padding: 2px 4px 12px;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 12px;
+        }
+
+        .settings-sidebar-head h3 {
+            margin: 4px 0 2px;
+            font-size: var(--text-lg);
+            line-height: 1.25;
+        }
+
+        .settings-sidebar-head p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .settings-nav {
+            display: grid;
+            gap: 8px;
+            max-height: calc(100dvh - 220px);
+            overflow: auto;
+            padding-right: 4px;
+            scrollbar-gutter: stable;
+            scrollbar-width: thin;
+            scrollbar-color: rgba(99, 102, 241, 0.42) transparent;
+        }
+
+        .settings-nav::-webkit-scrollbar {
+            width: 8px;
+        }
+
+        .settings-nav::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        .settings-nav::-webkit-scrollbar-thumb {
+            border: 2px solid transparent;
+            border-radius: 999px;
+            background: rgba(99, 102, 241, 0.34);
+            background-clip: content-box;
+        }
+
+        .settings-nav::-webkit-scrollbar-thumb:hover {
+            background: rgba(99, 102, 241, 0.56);
+            background-clip: content-box;
+        }
+
+        .settings-nav-group {
+            margin: 14px 4px 8px;
+            color: var(--muted);
+            font-size: 11px;
+            font-weight: 700;
+        }
+
+        .settings-nav-btn {
+            width: 100%;
+            min-height: 56px;
+            display: grid;
+            grid-template-columns: 32px minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 10px;
+            padding: 10px;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            background: transparent;
+            color: var(--text);
+            cursor: pointer;
+            text-align: left;
+        }
+
+        .settings-nav-btn:hover {
+            border-color: var(--border);
+            background: var(--surface-hover);
+        }
+
+        .settings-nav-btn.active {
+            border-color: var(--accent);
+            background: var(--selection);
+            box-shadow: inset 3px 0 0 var(--accent);
+        }
+
+        .settings-nav-icon {
+            width: 32px;
+            height: 32px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel-soft);
+            color: var(--accent);
+            overflow: hidden;
+            flex: none;
+        }
+
+        .settings-nav-icon .material-icons {
+            font-size: 18px;
+            line-height: 1;
+        }
+
+        .settings-nav-text {
+            min-width: 0;
+        }
+
+        .settings-nav-title {
+            display: block;
+            font-size: 13px;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .settings-nav-desc {
+            display: block;
+            margin-top: 3px;
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.25;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .settings-nav-badge {
+            min-width: 28px;
+            height: 24px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0 8px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-full);
+            background: var(--panel-soft);
+            color: var(--muted);
+            font-size: 12px;
+            font-weight: 700;
+        }
+
+        .settings-nav-btn.active .settings-nav-badge {
+            border-color: transparent;
+            background: var(--accent);
+            color: #fff;
+        }
+
+        .settings-main {
+            min-width: 0;
+        }
+
         .settings-head {
             display: flex;
             justify-content: space-between;
@@ -1927,7 +2072,7 @@
 
         .settings-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            grid-template-columns: minmax(0, 1fr);
             gap: 12px;
         }
 
@@ -1983,20 +2128,38 @@
 
         .config-fields {
             display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
             gap: 12px;
             padding: 0 16px 16px;
+            align-items: stretch;
         }
 
         .config-field {
             display: grid;
+            grid-template-rows: auto auto 1fr;
             gap: 8px;
-            padding-top: 12px;
-            border-top: 1px solid var(--border);
+            min-width: 0;
+            padding: 12px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel-soft);
+            box-sizing: border-box;
         }
 
-        .config-field:first-child {
-            padding-top: 0;
-            border-top: 0;
+        .config-field:hover {
+            border-color: var(--border-strong);
+            background: var(--panel);
+        }
+
+        .config-field.is-wide,
+        .config-field.is-list,
+        .config-field.is-longtext {
+            grid-column: 1 / -1;
+        }
+
+        .config-field.is-bool {
+            grid-template-rows: auto 1fr auto;
+            min-height: 132px;
         }
 
         .field-head {
@@ -2004,6 +2167,7 @@
             justify-content: space-between;
             gap: 10px;
             align-items: flex-start;
+            min-width: 0;
         }
 
         .field-label {
@@ -2011,6 +2175,8 @@
             font-size: 13px;
             line-height: 1.35;
             font-weight: 600;
+            min-width: 0;
+            overflow-wrap: anywhere;
         }
 
         .field-meta {
@@ -2018,6 +2184,7 @@
             flex-wrap: wrap;
             gap: 6px;
             justify-content: flex-end;
+            flex: none;
         }
 
         .field-pill {
@@ -2048,34 +2215,108 @@
             background: var(--input-bg);
             color: var(--text);
             padding: 10px 12px;
+            min-height: 40px;
             box-sizing: border-box;
             box-shadow: none;
-        }
-
-        .config-control textarea {
-            min-height: 92px;
-            resize: vertical;
-        }
-
-        .config-control input[type="checkbox"] {
-            width: 18px;
-            height: 18px;
-            margin: 0;
-            padding: 0;
-            accent-color: var(--accent);
-        }
-
-        .config-control .bool-row {
-            display: inline-flex;
-            align-items: center;
-            gap: 10px;
-            min-height: 36px;
-            color: var(--text);
             font-size: 13px;
         }
 
-        .config-control .bool-row span {
+        .config-control textarea {
+            min-height: 112px;
+            resize: vertical;
+        }
+
+        .config-control .bool-row {
+            position: relative;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            min-height: 48px;
+            padding: 8px 10px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--input-bg);
+            color: var(--text);
+            font-size: 13px;
+            box-sizing: border-box;
+            cursor: pointer;
+        }
+
+        .config-control .bool-row.disabled {
+            cursor: not-allowed;
+            opacity: .72;
+        }
+
+        .config-control .config-switch-input {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            min-height: 0;
+            margin: -1px;
+            padding: 0;
+            border: 0;
+            background: transparent;
+            box-shadow: none;
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .switch-track {
+            position: relative;
+            width: 44px;
+            height: 24px;
+            flex: none;
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            background: var(--panel);
+            transition: background .18s ease, border-color .18s ease;
+        }
+
+        .switch-thumb {
+            position: absolute;
+            top: 3px;
+            left: 3px;
+            width: 16px;
+            height: 16px;
+            border-radius: 999px;
+            background: var(--muted);
+            box-shadow: var(--shadow-sm);
+            transition: transform .18s ease, background .18s ease;
+        }
+
+        .config-control .config-switch-input:checked + .switch-track {
+            border-color: var(--accent);
+            background: var(--accent);
+        }
+
+        .config-control .config-switch-input:checked + .switch-track .switch-thumb {
+            transform: translateX(20px);
+            background: #fff;
+        }
+
+        .config-control .config-switch-input:focus-visible + .switch-track {
+            outline: 2px solid var(--accent);
+            outline-offset: 2px;
+        }
+
+        .config-control .config-switch-input:disabled + .switch-track {
+            filter: grayscale(.45);
+        }
+
+        .bool-state {
             color: var(--muted);
+            font-weight: 700;
+            white-space: nowrap;
+        }
+
+        .config-field.is-bool .config-control {
+            align-self: center;
+        }
+
+        .config-field.is-bool .field-hint {
+            align-self: end;
         }
 
         .persona-picker {
@@ -2166,11 +2407,13 @@
             }
 
             .review-workspace,
+            .settings-workspace,
             .review-split-grid {
                 grid-template-columns: 1fr;
             }
 
-            .review-sidebar {
+            .review-sidebar,
+            .settings-sidebar {
                 position: static;
             }
 
@@ -2198,7 +2441,18 @@
             }
 
             .topbar {
+                align-items: flex-start;
                 flex-direction: column;
+                gap: 10px;
+            }
+
+            .topbar .toolbar {
+                width: 100%;
+                justify-content: flex-start;
+            }
+
+            .app-brand {
+                font-size: 24px;
             }
 
             .page-titlebar {
@@ -2213,20 +2467,18 @@
                 grid-template-columns: 1fr;
             }
 
-            .review-sidebar {
+            .review-sidebar,
+            .settings-sidebar {
                 padding: 12px;
             }
 
-            .review-nav-btn {
+            .review-nav-btn,
+            .settings-nav-btn {
                 min-height: 54px;
             }
 
             .panel-head {
                 flex-direction: column;
-            }
-
-            .brand h1 {
-                font-size: 24px;
             }
 
             .settings-grid {
@@ -2280,12 +2532,8 @@
 </head>
 <body data-theme="light">
     <div class="shell">
-        <header class="topbar">
-            <div class="brand">
-                <div class="eyebrow">SELF LEARNING / DASHBOARD</div>
-                <h1>监控板</h1>
-                <p id="summaryText">正在连接学习链路。</p>
-            </div>
+        <header class="topbar" aria-label="仪表盘操作">
+            <div class="app-brand">Self Learning</div>
             <div class="toolbar">
                 <span class="pill">
                     <span class="material-icons" style="font-size:18px;">schedule</span>
@@ -3056,37 +3304,60 @@
                     </button>
                 </div>
             </div>
-            <div class="dependency-install-panel" aria-label="依赖安装">
-                <div class="dependency-install-copy">
-                    <div class="subhead">DEPENDENCIES</div>
-                    <h3>手动安装依赖</h3>
-                    <p>基础能力依赖覆盖人格审查、黑话学习、表达方式学习与 WebUI。全能力依赖包含图谱、监控、外部数据库、LightRAG 与 Mem0。</p>
-                </div>
-                <div class="dependency-install-controls">
-                    <select id="pipMirrorSelect" class="dependency-mirror-select" aria-label="pip 镜像源">
-                        <option value="default">PyPI 默认源</option>
-                        <option value="tsinghua">清华大学 TUNA</option>
-                        <option value="aliyun">阿里云</option>
-                        <option value="tencent">腾讯云</option>
-                        <option value="ustc">中国科大 USTC</option>
-                        <option value="douban">豆瓣</option>
-                    </select>
-                    <div class="dependency-tier-actions">
-                        <button class="dependency-tier-btn" type="button" data-dependency-tier="basic">
-                            <span class="material-icons">bolt</span>
-                            基础能力依赖
-                        </button>
-                        <button class="dependency-tier-btn primary" type="button" data-dependency-tier="full">
-                            <span class="material-icons">deployed_code</span>
-                            全能力依赖
-                        </button>
+            <div class="settings-workspace">
+                <aside class="settings-sidebar" aria-label="设置分类菜单">
+                    <div class="settings-sidebar-head">
+                        <div class="subhead">SETTINGS</div>
+                        <h3>配置分类</h3>
+                        <p id="settingsSidebarSummary">等待配置 schema</p>
                     </div>
+                    <div class="settings-nav-group">分类</div>
+                    <nav class="settings-nav" id="settingsNav" aria-label="设置分类">
+                        <button class="settings-nav-btn active" type="button" data-config-group="all" aria-selected="true">
+                            <span class="settings-nav-icon"><span class="material-icons">tune</span></span>
+                            <span class="settings-nav-text">
+                                <span class="settings-nav-title">全部设置</span>
+                                <span class="settings-nav-desc">显示所有配置组</span>
+                            </span>
+                            <span class="settings-nav-badge">--</span>
+                        </button>
+                    </nav>
+                </aside>
+
+                <div class="settings-main">
+                    <div class="dependency-install-panel" id="dependencyInstallPanel" aria-label="依赖安装">
+                        <div class="dependency-install-copy">
+                            <div class="subhead">DEPENDENCIES</div>
+                            <h3>手动安装依赖</h3>
+                            <p>基础能力依赖覆盖人格审查、黑话学习、表达方式学习与 WebUI。全能力依赖包含图谱、监控、外部数据库、LightRAG 与 Mem0。</p>
+                        </div>
+                        <div class="dependency-install-controls">
+                            <select id="pipMirrorSelect" class="dependency-mirror-select" aria-label="pip 镜像源">
+                                <option value="default">PyPI 默认源</option>
+                                <option value="tsinghua">清华大学 TUNA</option>
+                                <option value="aliyun">阿里云</option>
+                                <option value="tencent">腾讯云</option>
+                                <option value="ustc">中国科大 USTC</option>
+                                <option value="douban">豆瓣</option>
+                            </select>
+                            <div class="dependency-tier-actions">
+                                <button class="dependency-tier-btn" type="button" data-dependency-tier="basic">
+                                    <span class="material-icons">bolt</span>
+                                    基础能力依赖
+                                </button>
+                                <button class="dependency-tier-btn primary" type="button" data-dependency-tier="full">
+                                    <span class="material-icons">extension</span>
+                                    全能力依赖
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="dependencyStatus" class="config-status dependency-status">依赖安装需手动确认，不会在插件安装或启动时自动执行。</div>
+                    <div class="settings-summary" id="configSummary"></div>
+                    <div id="configGroups" class="settings-grid"></div>
+                    <div id="configStatus" class="config-status">正在加载配置中。</div>
                 </div>
             </div>
-            <div id="dependencyStatus" class="config-status dependency-status">依赖安装需手动确认，不会在插件安装或启动时自动执行。</div>
-            <div class="settings-summary" id="configSummary"></div>
-            <div id="configGroups" class="settings-grid"></div>
-            <div id="configStatus" class="config-status">正在加载配置中。</div>
         </section>
         </section>
         </main>
@@ -3112,6 +3383,7 @@
                     loading: false,
                     saving: false,
                     search: '',
+                    activeGroup: 'all',
                 },
                 personas: {
                     items: [],
@@ -4699,13 +4971,16 @@
 
                 $('heroHeadline').textContent = '自学习监控板';
                 $('heroSubline').textContent = `总消息 ${formatCount(totalMessages)} · 筛选率 ${formatPercent(filterRate)} · 待办 ${formatCount(backlog)} 条`;
-                $('summaryText').textContent = buildSummaryText({
-                    overallHealth: health.overall || 'unknown',
-                    learningEfficiency,
-                    backlog,
-                    filteredMessages,
-                    totalMessages,
-                });
+                const summaryText = $('summaryText');
+                if (summaryText) {
+                    summaryText.textContent = buildSummaryText({
+                        overallHealth: health.overall || 'unknown',
+                        learningEfficiency,
+                        backlog,
+                        filteredMessages,
+                        totalMessages,
+                    });
+                }
 
                 $('overallHealth').textContent = overallHealth;
                 $('overallEfficiency').textContent = formatPercent(learningEfficiency);
@@ -4866,13 +5141,16 @@
                 const backlog = safeNumber(data.backlog);
                 const filteredMessages = safeNumber(data.metrics && data.metrics.filtered_messages);
                 const totalMessages = safeNumber(data.metrics && data.metrics.total_messages_collected);
-                $('summaryText').textContent = buildSummaryText({
-                    overallHealth,
-                    learningEfficiency,
-                    backlog,
-                    filteredMessages,
-                    totalMessages,
-                });
+                const summaryText = $('summaryText');
+                if (summaryText) {
+                    summaryText.textContent = buildSummaryText({
+                        overallHealth,
+                        learningEfficiency,
+                        backlog,
+                        filteredMessages,
+                        totalMessages,
+                    });
+                }
             }
 
             function renderTrendChart(trends) {
@@ -5166,6 +5444,202 @@
                     .map((field) => field.key);
             }
 
+            function configGroupIcon(groupKey) {
+                const icons = {
+                    Dependency_Install_Guide: 'extension',
+                    Self_Learning_Basic: 'psychology',
+                    Target_Settings: 'gps_fixed',
+                    Model_Configuration: 'smart_toy',
+                    Learning_Parameters: 'school',
+                    Filter_Parameters: 'filter_alt',
+                    Style_Analysis: 'style',
+                    Advanced_Settings: 'tune',
+                    Machine_Learning_Settings: 'model_training',
+                    Persona_Backup_Settings: 'backup',
+                    Goal_Driven_Chat_Settings: 'flag',
+                    Affection_System_Settings: 'favorite',
+                    Mood_System_Settings: 'mood',
+                    Social_Context_Settings: 'groups',
+                    Storage_Settings: 'folder',
+                    Database_Settings: 'storage',
+                    API_Settings: 'api',
+                    Repository_Settings: 'source',
+                    Integration_Settings: 'hub',
+                    V2_Architecture_Settings: 'account_tree',
+                };
+                return icons[groupKey] || 'settings';
+            }
+
+            const SETTINGS_NAV_SECTIONS = [
+                {
+                    title: '常用入口',
+                    keys: [
+                        'Dependency_Install_Guide',
+                        'Self_Learning_Basic',
+                        'Target_Settings',
+                        'Model_Configuration',
+                        'Integration_Settings',
+                    ],
+                },
+                {
+                    title: '学习链路',
+                    keys: [
+                        'Learning_Parameters',
+                        'Filter_Parameters',
+                        'Style_Analysis',
+                        'Machine_Learning_Settings',
+                        'Goal_Driven_Chat_Settings',
+                        'Persona_Evolution_Settings',
+                    ],
+                },
+                {
+                    title: '人格与关系',
+                    keys: [
+                        'Persona_Backup_Settings',
+                        'Affection_System_Settings',
+                        'Mood_System_Settings',
+                        'Social_Context_Settings',
+                    ],
+                },
+                {
+                    title: '数据与运行',
+                    keys: [
+                        'Storage_Settings',
+                        'Database_Settings',
+                        'API_Settings',
+                        'Repository_Settings',
+                        'V2_Architecture_Settings',
+                        'Advanced_Settings',
+                        'Runtime_Internal_Settings',
+                    ],
+                },
+            ];
+
+            function settingsNavGroupMeta(group) {
+                const key = group && group.key ? group.key : '';
+                if (key === 'Dependency_Install_Guide') {
+                    return {
+                        title: '依赖安装',
+                        desc: '基础 / 全能力依赖',
+                    };
+                }
+                return {
+                    title: (group && group.title) || key || '未命名分组',
+                    desc: (group && group.hint) || '',
+                };
+            }
+
+            function ensureValidConfigGroup(groups = safeArray(getConfigSchemaPayload().groups)) {
+                const active = state.config.activeGroup || 'all';
+                if (active === 'all') {
+                    return 'all';
+                }
+                if (groups.some((group) => group && group.key === active)) {
+                    return active;
+                }
+                state.config.activeGroup = 'all';
+                return 'all';
+            }
+
+            function renderSettingsNav(groups = safeArray(getConfigSchemaPayload().groups)) {
+                const nav = $('settingsNav');
+                if (!nav) {
+                    return;
+                }
+
+                const active = ensureValidConfigGroup(groups);
+                const dirtyKeys = state.config.dirtyKeys || new Set();
+                const totalFields = groups.reduce((sum, group) => sum + safeArray(group && group.fields).length, 0);
+                const buttonMarkup = [];
+
+                const allDirtyCount = dirtyKeys.size;
+                buttonMarkup.push('<div class="settings-nav-group">总览</div>');
+                buttonMarkup.push(`
+                    <button class="settings-nav-btn${active === 'all' ? ' active' : ''}" type="button" data-config-group="all" aria-selected="${active === 'all' ? 'true' : 'false'}">
+                        <span class="settings-nav-icon"><span class="material-icons">tune</span></span>
+                        <span class="settings-nav-text">
+                            <span class="settings-nav-title">全部设置</span>
+                            <span class="settings-nav-desc">${allDirtyCount ? `${formatCount(allDirtyCount)} 项已改` : '显示所有配置组'}</span>
+                        </span>
+                        <span class="settings-nav-badge">${formatCount(totalFields)}</span>
+                    </button>
+                `);
+
+                const groupsByKey = new Map(groups.filter((group) => group && group.key).map((group) => [group.key, group]));
+                const renderedKeys = new Set();
+
+                SETTINGS_NAV_SECTIONS.forEach((section) => {
+                    const sectionGroups = section.keys
+                        .map((key) => groupsByKey.get(key))
+                        .filter(Boolean);
+                    if (!sectionGroups.length) {
+                        return;
+                    }
+
+                    buttonMarkup.push(`<div class="settings-nav-group">${escapeHtml(section.title)}</div>`);
+                    sectionGroups.forEach((group) => {
+                        renderedKeys.add(group.key);
+                        buttonMarkup.push(renderSettingsNavButton(group, active, dirtyKeys));
+                    });
+                });
+
+                const otherGroups = groups.filter((group) => group && group.key && !renderedKeys.has(group.key));
+                if (otherGroups.length) {
+                    buttonMarkup.push('<div class="settings-nav-group">其他</div>');
+                    otherGroups.forEach((group) => {
+                        buttonMarkup.push(renderSettingsNavButton(group, active, dirtyKeys));
+                    });
+                }
+
+                nav.innerHTML = buttonMarkup.join('');
+
+                const summary = $('settingsSidebarSummary');
+                if (summary) {
+                    summary.textContent = allDirtyCount
+                        ? `${formatCount(groups.length)} 类 · ${formatCount(allDirtyCount)} 项未保存`
+                        : `${formatCount(groups.length)} 类 · ${formatCount(totalFields)} 项配置`;
+                }
+            }
+
+            function renderSettingsNavButton(group, active, dirtyKeys) {
+                if (!group || !group.key) {
+                    return '';
+                }
+                const fields = safeArray(group.fields);
+                const editableCount = fields.filter((field) => field && field.editable).length;
+                const dirtyCount = fields.filter((field) => dirtyKeys.has(field.key)).length;
+                const isActive = active === group.key;
+                const meta = settingsNavGroupMeta(group);
+                const desc = dirtyCount
+                    ? `${formatCount(dirtyCount)} 项已改`
+                    : (meta.desc || `${formatCount(editableCount)} 项可改`);
+                return `
+                    <button class="settings-nav-btn${isActive ? ' active' : ''}" type="button" data-config-group="${escapeHtml(group.key)}" aria-selected="${isActive ? 'true' : 'false'}">
+                        <span class="settings-nav-icon"><span class="material-icons">${escapeHtml(configGroupIcon(group.key))}</span></span>
+                        <span class="settings-nav-text">
+                            <span class="settings-nav-title">${escapeHtml(meta.title)}</span>
+                            <span class="settings-nav-desc">${escapeHtml(desc)}</span>
+                        </span>
+                        <span class="settings-nav-badge">${dirtyCount ? `${formatCount(dirtyCount)}/${formatCount(fields.length)}` : formatCount(fields.length)}</span>
+                    </button>
+                `;
+            }
+
+            function setConfigGroup(groupKey, options = {}) {
+                const { scroll = false } = options;
+                state.config.activeGroup = groupKey || 'all';
+                ensureValidConfigGroup();
+                renderSettingsNav();
+                applyConfigSearch();
+
+                if (scroll) {
+                    const target = state.config.activeGroup === 'Dependency_Install_Guide'
+                        ? $('dependencyInstallPanel')
+                        : document.querySelector(`[data-group-key="${state.config.activeGroup}"]`);
+                    (target || $('settingsSection'))?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            }
+
             function getConfigFieldByKey(key) {
                 const payload = getConfigSchemaPayload();
                 for (const group of safeArray(payload.groups)) {
@@ -5309,6 +5783,68 @@
                 }
             }
 
+            function configFieldLayoutClasses(field) {
+                const type = String(field && field.type ? field.type : 'text').toLowerCase();
+                const widget = String(field && field.widget ? field.widget : 'text').toLowerCase();
+                const key = String(field && field.key ? field.key : '').toLowerCase();
+                const classes = ['config-field'];
+                const safeType = type.replace(/[^a-z0-9_-]/g, '') || 'text';
+                const safeWidget = widget.replace(/[^a-z0-9_-]/g, '') || 'text';
+
+                classes.push(`is-${safeType}`);
+                classes.push(`widget-${safeWidget}`);
+                if (type === 'bool') {
+                    classes.push('is-bool');
+                }
+                if (type === 'list') {
+                    classes.push('is-list', 'is-wide');
+                }
+                if (
+                    widget === 'textarea'
+                    || key === 'current_persona_name'
+                    || key.includes('path')
+                    || key.includes('dir')
+                    || key.includes('api_key')
+                    || key.includes('password')
+                    || key.includes('prompt')
+                    || key.includes('template')
+                ) {
+                    classes.push('is-wide');
+                }
+
+                return Array.from(new Set(classes)).join(' ');
+            }
+
+            function renderConfigSwitch(field, fieldId, checked) {
+                const stateText = checked ? '已启用' : '已关闭';
+                return `
+                    <label class="bool-row${field.editable ? '' : ' disabled'}" for="${fieldId}">
+                        <span class="bool-state">${stateText}</span>
+                        <input
+                            id="${fieldId}"
+                            class="config-switch-input"
+                            type="checkbox"
+                            data-config-key="${escapeHtml(field.key)}"
+                            data-config-type="${escapeHtml(field.type)}"
+                            data-config-widget="${escapeHtml(field.widget || 'toggle')}"
+                            ${checked ? 'checked' : ''}
+                            ${field.editable ? '' : 'disabled'}
+                        >
+                        <span class="switch-track" aria-hidden="true"><span class="switch-thumb"></span></span>
+                    </label>
+                `;
+            }
+
+            function syncConfigSwitchState(target) {
+                if (!target || target.type !== 'checkbox') {
+                    return;
+                }
+                const stateEl = target.closest('.bool-row')?.querySelector('.bool-state');
+                if (stateEl) {
+                    stateEl.textContent = target.checked ? '已启用' : '已关闭';
+                }
+            }
+
             function renderConfigField(field, idPrefix = 'config') {
                 const fieldId = `${idPrefix}-${field.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
                 const value = Object.prototype.hasOwnProperty.call(state.config.draft, field.key)
@@ -5382,21 +5918,8 @@
                             </datalist>
                         </div>
                     `;
-                } else if (field.widget === 'toggle') {
-                    controlHtml = `
-                        <label class="bool-row" for="${fieldId}">
-                            <input
-                                id="${fieldId}"
-                                type="checkbox"
-                                data-config-key="${escapeHtml(field.key)}"
-                                data-config-type="${escapeHtml(field.type)}"
-                                data-config-widget="${escapeHtml(field.widget)}"
-                                ${displayValue ? 'checked' : ''}
-                                ${field.editable ? '' : 'disabled'}
-                            >
-                            <span>${displayValue ? '已启用' : '已关闭'}</span>
-                        </label>
-                    `;
+                } else if (field.type === 'bool') {
+                    controlHtml = renderConfigSwitch(field, fieldId, Boolean(displayValue));
                 } else if (field.widget === 'select') {
                     const options = safeArray(field.options || []);
                     const currentValue = displayValue || '';
@@ -5520,7 +6043,7 @@
 
                 return `
                     <div
-                        class="config-field"
+                        class="${escapeHtml(configFieldLayoutClasses(field))}"
                         data-config-key="${escapeHtml(field.key)}"
                         data-search="${escapeHtml(searchParts)}"
                     >
@@ -5539,10 +6062,13 @@
             function renderConfigPanel() {
                 const payload = getConfigSchemaPayload();
                 const groups = safeArray(payload.groups);
-                const groupsMarkup = groups.map((group) => {
+                const activeGroup = ensureValidConfigGroup(groups);
+                const visibleGroups = groups.filter((group) => group && group.key !== 'Dependency_Install_Guide');
+                const groupsMarkup = visibleGroups.map((group) => {
                     const fields = safeArray(group.fields);
                     const editableCount = fields.filter((field) => field && field.editable).length;
                     const readonlyCount = fields.length - editableCount;
+                    const shouldOpen = activeGroup === 'all' || activeGroup === group.key;
                     const searchText = [
                         group.key,
                         group.title,
@@ -5551,7 +6077,7 @@
                     ].filter(Boolean).join(' ').toLowerCase();
 
                     return `
-                        <details class="config-group" data-group-key="${escapeHtml(group.key)}" data-search="${escapeHtml(searchText)}" open>
+                        <details class="config-group" data-group-key="${escapeHtml(group.key)}" data-search="${escapeHtml(searchText)}" ${shouldOpen ? 'open' : ''}>
                             <summary>
                                 <div class="group-title">
                                     <strong>${escapeHtml(group.title)}</strong>
@@ -5716,6 +6242,7 @@
                 if (configSummary) {
                     configSummary.innerHTML = summaryItems.join('');
                 }
+                renderSettingsNav(groups);
                 if (state.data) {
                     renderHomeModules(state.data);
                 }
@@ -5761,6 +6288,7 @@
                 let nextValue = null;
                 if (field.type === 'bool') {
                     nextValue = Boolean(target.checked);
+                    syncConfigSwitchState(target);
                 } else if (field.type === 'int' || field.type === 'float') {
                     nextValue = normalizeFieldValue(field, target.value);
                     if (nextValue === null && !field.nullable) {
@@ -5790,22 +6318,36 @@
 
             function applyConfigSearch() {
                 const query = String(state.config.search || '').trim().toLowerCase();
+                const activeGroup = ensureValidConfigGroup();
                 const groups = document.querySelectorAll('.config-group');
+                const dependencyPanel = $('dependencyInstallPanel');
+                const dependencyStatus = $('dependencyStatus');
+                const dependencyVisible = Boolean(query) || activeGroup === 'all' || activeGroup === 'Dependency_Install_Guide';
+                const dependencyMatches = !query || 'Dependency_Install_Guide 依赖安装 手动安装依赖 dependencies'.toLowerCase().includes(query);
+
+                if (dependencyPanel) {
+                    dependencyPanel.hidden = !(dependencyVisible && dependencyMatches);
+                }
+                if (dependencyStatus) {
+                    dependencyStatus.hidden = !(dependencyVisible && dependencyMatches);
+                }
 
                 groups.forEach((groupEl) => {
+                    const groupKey = groupEl.dataset.groupKey || '';
+                    const activeMatch = Boolean(query) || activeGroup === 'all' || groupKey === activeGroup;
                     const groupMatch = !query || (groupEl.dataset.search || '').includes(query);
                     const fields = groupEl.querySelectorAll('.config-field');
                     let fieldMatch = false;
 
                     fields.forEach((fieldEl) => {
-                        const match = !query || groupMatch || (fieldEl.dataset.search || '').includes(query);
+                        const match = activeMatch && (!query || groupMatch || (fieldEl.dataset.search || '').includes(query));
                         fieldEl.hidden = !match;
                         if (match) {
                             fieldMatch = true;
                         }
                     });
 
-                    const visible = !query || groupMatch || fieldMatch;
+                    const visible = activeMatch && (!query || groupMatch || fieldMatch);
                     groupEl.hidden = !visible;
                     if (visible) {
                         groupEl.open = true;
@@ -6146,10 +6688,10 @@
                 navigateToPage('settings');
                 const searchInput = $('configSearch');
                 if (searchInput) {
-                    state.config.search = 'Integration_Settings';
+                    state.config.search = '';
                     searchInput.value = state.config.search;
-                    applyConfigSearch();
                 }
+                setConfigGroup('Integration_Settings');
                 const groupEl = document.querySelector('[data-group-key="Integration_Settings"]');
                 if (groupEl) {
                     groupEl.open = true;
@@ -7106,7 +7648,10 @@
             }
 
             async function loadDashboard() {
-                $('summaryText').innerHTML = '<span class="spinner" style="margin-right:6px;"></span>正在刷新监控数据。';
+                const summaryText = $('summaryText');
+                if (summaryText) {
+                    summaryText.innerHTML = '<span class="spinner" style="margin-right:6px;"></span>正在刷新监控数据。';
+                }
 
                 const [
                     metrics,
@@ -7254,7 +7799,7 @@
                     ['候选', jargonStats.total_candidates],
                     ['确认', jargonStats.confirmed_jargon],
                     ['完成', jargonStats.completed_inference],
-                    ['命中', jargonStats.total_occurrences],
+                    ['样本', jargonStats.total_occurrences],
                 ].map(([label, value]) => `
                     <div class="small-stat">
                         <div class="k">${label}</div>
@@ -7272,7 +7817,7 @@
                     const meta = [
                         item.group_id ? `群组 ${item.group_id}` : null,
                         item.is_confirmed !== undefined ? (item.is_confirmed ? '已确认' : '待确认') : null,
-                        item.occurrences !== undefined ? `命中 ${formatCount(item.occurrences)}` : null,
+                        item.occurrences !== undefined ? `样本 ${formatCount(item.occurrences)}` : null,
                         item.created_at ? `创建 ${formatTime(item.created_at)}` : null,
                         item.updated_at ? `更新 ${formatTime(item.updated_at)}` : null,
                     ].filter(Boolean).join(' · ');
@@ -7405,6 +7950,12 @@
                 $('configSearch').addEventListener('input', (event) => {
                     state.config.search = event.target.value || '';
                     applyConfigSearch();
+                });
+                $('settingsNav').addEventListener('click', (event) => {
+                    const target = event.target.closest('[data-config-group]');
+                    if (target) {
+                        setConfigGroup(target.dataset.configGroup || 'all', { scroll: true });
+                    }
                 });
                 $('configGroups').addEventListener('input', (event) => {
                     const target = event.target;

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -769,6 +769,164 @@
             gap: 16px;
         }
 
+        .review-workspace {
+            display: grid;
+            grid-template-columns: 280px minmax(0, 1fr);
+            gap: 16px;
+            align-items: start;
+        }
+
+        .review-sidebar {
+            position: sticky;
+            top: 16px;
+            padding: 14px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            background: var(--panel);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .review-sidebar-head {
+            padding: 2px 4px 12px;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 12px;
+        }
+
+        .review-sidebar-kicker {
+            color: var(--muted);
+            font-size: 11px;
+            font-weight: 700;
+        }
+
+        .review-sidebar-head h3 {
+            margin: 4px 0 2px;
+            font-size: var(--text-lg);
+            line-height: 1.25;
+        }
+
+        .review-sidebar-head p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .review-nav {
+            display: grid;
+            gap: 8px;
+        }
+
+        .review-nav-group {
+            margin: 14px 4px 8px;
+            color: var(--muted);
+            font-size: 11px;
+            font-weight: 700;
+        }
+
+        .review-nav-btn {
+            width: 100%;
+            min-height: 58px;
+            display: grid;
+            grid-template-columns: 32px minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 10px;
+            padding: 10px;
+            border: 1px solid transparent;
+            border-radius: 8px;
+            background: transparent;
+            color: var(--text);
+            cursor: pointer;
+            text-align: left;
+        }
+
+        .review-nav-btn:hover {
+            border-color: var(--border);
+            background: var(--surface-hover);
+        }
+
+        .review-nav-btn.active {
+            border-color: var(--accent);
+            background: var(--selection);
+            box-shadow: inset 3px 0 0 var(--accent);
+        }
+
+        .review-nav-icon {
+            width: 32px;
+            height: 32px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: var(--panel-soft);
+            color: var(--accent);
+        }
+
+        .review-nav-icon .material-icons {
+            font-size: 18px;
+        }
+
+        .review-nav-text {
+            min-width: 0;
+        }
+
+        .review-nav-title {
+            display: block;
+            font-size: 13px;
+            font-weight: 700;
+            line-height: 1.2;
+        }
+
+        .review-nav-desc {
+            display: block;
+            margin-top: 3px;
+            color: var(--muted);
+            font-size: 12px;
+            line-height: 1.25;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .review-nav-badge {
+            min-width: 28px;
+            height: 24px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0 8px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-full);
+            background: var(--panel-soft);
+            color: var(--muted);
+            font-size: 12px;
+            font-weight: 700;
+        }
+
+        .review-nav-btn.active .review-nav-badge {
+            border-color: transparent;
+            background: var(--accent);
+            color: #fff;
+        }
+
+        .review-main {
+            min-width: 0;
+        }
+
+        .review-tab-panel {
+            display: none;
+            gap: 16px;
+        }
+
+        .review-tab-panel.active {
+            display: grid;
+        }
+
+        .review-split-grid {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(300px, 0.85fr);
+            gap: 16px;
+        }
+
         .panel {
             background: var(--panel);
             border: 1px solid var(--border);
@@ -2007,6 +2165,15 @@
                 grid-template-columns: 1fr;
             }
 
+            .review-workspace,
+            .review-split-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .review-sidebar {
+                position: static;
+            }
+
             .settings-head {
                 flex-direction: column;
                 align-items: stretch;
@@ -2044,6 +2211,14 @@
 
             .stats-row {
                 grid-template-columns: 1fr;
+            }
+
+            .review-sidebar {
+                padding: 12px;
+            }
+
+            .review-nav-btn {
+                min-height: 54px;
             }
 
             .panel-head {
@@ -2456,134 +2631,210 @@
 
             <div id="queueStatus" class="config-status queue-status" style="margin-bottom:14px;">审查操作就绪。</div>
 
-            <section class="queue-grid" style="margin-bottom:16px;">
-            <div class="panel">
-                <div class="panel-head">
-                    <h2>当前人格状态</h2>
-                    <span class="hint" id="personaStateHint">--</span>
-                </div>
-                <div class="panel-body">
-                    <div class="stats-row" id="personaStateStats"></div>
-                    <div id="personaStatePreview" class="list" style="margin-top:10px;"></div>
-                </div>
-            </div>
-
-            <div class="panel">
-                <div class="panel-head">
-                    <h2>人格备份</h2>
-                    <span class="hint" id="personaBackupHint">--</span>
-                </div>
-                <div class="panel-body">
-                    <div id="personaBackupList" class="list"></div>
-                </div>
-            </div>
-        </section>
-
-            <section class="queue-grid">
-            <div class="panel">
-                <div class="panel-head">
-                    <h2>待审人格</h2>
-                    <span class="hint" id="personaCount">0</span>
-                </div>
-                <div class="panel-body">
-                    <div id="personaList" class="list"></div>
-                </div>
-            </div>
-
-            <div class="panel">
-                <div class="panel-head">
-                    <h2>风格审查</h2>
-                    <span class="hint" id="styleCount">0</span>
-                </div>
-                <div class="panel-body">
-                    <div id="styleList" class="list"></div>
-                </div>
-            </div>
-        </section>
-
-        <section class="queue-grid" style="margin-top:16px;">
-            <div class="panel">
-                <div class="panel-head">
-                    <h2>最近已审人格</h2>
-                    <span class="hint" id="reviewedPersonaCount">0</span>
-                </div>
-                <div class="panel-body">
-                    <div id="reviewedPersonaList" class="list"></div>
-                </div>
-            </div>
-
-            <div class="panel">
-                <div class="panel-head">
-                    <div>
-                        <h2>黑话与批次</h2>
-                        <span class="hint" id="jargonHint">--</span>
-                    </div>
-                    <div class="panel-tools">
-                        <select id="jargonFilterSelect" class="content-search" style="width:120px;height:32px;font-size:12px;">
-                            <option value="all">全部</option>
-                            <option value="pending">待确认</option>
-                            <option value="confirmed">已确认</option>
-                            <option value="global">全局</option>
-                            <option value="local">本地</option>
-                        </select>
-                        <select id="jargonSortSelect" class="content-search" style="width:120px;height:32px;font-size:12px;">
-                            <option value="newest">最新优先</option>
-                            <option value="oldest">最早优先</option>
-                            <option value="name">按名称</option>
-                        </select>
-                        <input id="jargonSearchInput" class="content-search" style="width:160px;height:32px;font-size:12px;" type="search" placeholder="搜索黑话" autocomplete="off">
-                    </div>
-                </div>
-                <div class="panel-body">
-                    <div class="stats-row" id="jargonStats"></div>
-
-                    <div class="stack-section">
-                        <div id="jargonList" class="list"></div>
+            <section class="review-workspace">
+                <aside class="review-sidebar" aria-label="审查队列菜单">
+                    <div class="review-sidebar-head">
+                        <div class="review-sidebar-kicker">REVIEW CENTER</div>
+                        <h3>分类审查</h3>
+                        <p id="reviewSidebarSummary">待处理 0 条</p>
                     </div>
 
-                    <div id="jargonPagination" style="display:flex;justify-content:space-between;align-items:center;margin-top:12px;gap:8px;">
-                        <span id="jargonPageInfo" class="muted" style="font-size:12px;">--</span>
-                        <div style="display:flex;gap:4px;">
-                            <button class="action-btn" id="jargonPrevBtn" type="button" disabled>
-                                <span class="material-icons" style="font-size:16px;">chevron_left</span>
-                            </button>
-                            <button class="action-btn" id="jargonNextBtn" type="button" disabled>
-                                <span class="material-icons" style="font-size:16px;">chevron_right</span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <div class="panel">
-                <div class="panel-head">
-                    <div>
-                        <h2>最近批次</h2>
-                        <span class="hint" id="batchHint">--</span>
-                    </div>
-                    <div class="panel-tools">
-                        <button class="icon-btn" id="batchReloadBtn" type="button" aria-label="刷新批次" title="刷新批次">
-                            <span class="material-icons">sync</span>
+                    <div class="review-nav-group">待处理</div>
+                    <nav class="review-nav" aria-label="待处理审查">
+                        <button class="review-nav-btn active" type="button" data-review-tab="persona" aria-selected="true">
+                            <span class="review-nav-icon"><span class="material-icons">person_search</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">待审人格</span>
+                                <span class="review-nav-desc">Prompt 更新</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavPersonaCount">0</span>
                         </button>
-                    </div>
-                </div>
-                <div class="panel-body">
-                    <div id="batchList" class="list"></div>
+                        <button class="review-nav-btn" type="button" data-review-tab="style" aria-selected="false">
+                            <span class="review-nav-icon"><span class="material-icons">style</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">风格审查</span>
+                                <span class="review-nav-desc">表达模式</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavStyleCount">0</span>
+                        </button>
+                        <button class="review-nav-btn" type="button" data-review-tab="jargon" aria-selected="false">
+                            <span class="review-nav-icon"><span class="material-icons">translate</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">黑话候选</span>
+                                <span class="review-nav-desc">词条确认</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavJargonCount">0</span>
+                        </button>
+                    </nav>
 
-                    <div id="batchPagination" style="display:flex;justify-content:space-between;align-items:center;margin-top:12px;gap:8px;">
-                        <span id="batchPageInfo" class="muted" style="font-size:12px;">--</span>
-                        <div style="display:flex;gap:4px;">
-                            <button class="action-btn" id="batchPrevBtn" type="button" disabled>
-                                <span class="material-icons" style="font-size:16px;">chevron_left</span>
-                            </button>
-                            <button class="action-btn" id="batchNextBtn" type="button" disabled>
-                                <span class="material-icons" style="font-size:16px;">chevron_right</span>
-                            </button>
+                    <div class="review-nav-group">参考与历史</div>
+                    <nav class="review-nav" aria-label="参考与历史">
+                        <button class="review-nav-btn" type="button" data-review-tab="persona-state" aria-selected="false">
+                            <span class="review-nav-icon"><span class="material-icons">badge</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">人格现场</span>
+                                <span class="review-nav-desc">状态与备份</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavPersonaStateCount">--</span>
+                        </button>
+                        <button class="review-nav-btn" type="button" data-review-tab="reviewed" aria-selected="false">
+                            <span class="review-nav-icon"><span class="material-icons">fact_check</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">已审历史</span>
+                                <span class="review-nav-desc">最近决策</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavReviewedCount">0</span>
+                        </button>
+                        <button class="review-nav-btn" type="button" data-review-tab="batches" aria-selected="false">
+                            <span class="review-nav-icon"><span class="material-icons">school</span></span>
+                            <span class="review-nav-text">
+                                <span class="review-nav-title">学习批次</span>
+                                <span class="review-nav-desc">运行记录</span>
+                            </span>
+                            <span class="review-nav-badge" id="reviewNavBatchCount">0</span>
+                        </button>
+                    </nav>
+                </aside>
+
+                <div class="review-main">
+                    <section class="review-tab-panel active" data-review-panel="persona" aria-label="待审人格">
+                        <div class="panel">
+                            <div class="panel-head">
+                                <h2>待审人格</h2>
+                                <span class="hint" id="personaCount">0</span>
+                            </div>
+                            <div class="panel-body">
+                                <div id="personaList" class="list"></div>
+                            </div>
                         </div>
-                    </div>
+                    </section>
+
+                    <section class="review-tab-panel" data-review-panel="style" aria-label="风格审查" hidden>
+                        <div class="panel">
+                            <div class="panel-head">
+                                <h2>风格审查</h2>
+                                <span class="hint" id="styleCount">0</span>
+                            </div>
+                            <div class="panel-body">
+                                <div id="styleList" class="list"></div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="review-tab-panel" data-review-panel="jargon" aria-label="黑话候选" hidden>
+                        <div class="panel">
+                            <div class="panel-head">
+                                <div>
+                                    <h2>黑话候选</h2>
+                                    <span class="hint" id="jargonHint">--</span>
+                                </div>
+                                <div class="panel-tools">
+                                    <select id="jargonFilterSelect" class="content-search" style="width:120px;height:32px;font-size:12px;">
+                                        <option value="all">全部</option>
+                                        <option value="pending">待确认</option>
+                                        <option value="confirmed">已确认</option>
+                                        <option value="global">全局</option>
+                                        <option value="local">本地</option>
+                                    </select>
+                                    <select id="jargonSortSelect" class="content-search" style="width:120px;height:32px;font-size:12px;">
+                                        <option value="newest">最新优先</option>
+                                        <option value="oldest">最早优先</option>
+                                        <option value="name">按名称</option>
+                                    </select>
+                                    <input id="jargonSearchInput" class="content-search" style="width:160px;height:32px;font-size:12px;" type="search" placeholder="搜索黑话" autocomplete="off">
+                                </div>
+                            </div>
+                            <div class="panel-body">
+                                <div class="stats-row" id="jargonStats"></div>
+
+                                <div class="stack-section">
+                                    <div id="jargonList" class="list"></div>
+                                </div>
+
+                                <div id="jargonPagination" style="display:flex;justify-content:space-between;align-items:center;margin-top:12px;gap:8px;">
+                                    <span id="jargonPageInfo" class="muted" style="font-size:12px;">--</span>
+                                    <div style="display:flex;gap:4px;">
+                                        <button class="action-btn" id="jargonPrevBtn" type="button" disabled>
+                                            <span class="material-icons" style="font-size:16px;">chevron_left</span>
+                                        </button>
+                                        <button class="action-btn" id="jargonNextBtn" type="button" disabled>
+                                            <span class="material-icons" style="font-size:16px;">chevron_right</span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="review-tab-panel" data-review-panel="persona-state" aria-label="人格现场" hidden>
+                        <div class="review-split-grid">
+                            <div class="panel">
+                                <div class="panel-head">
+                                    <h2>当前人格状态</h2>
+                                    <span class="hint" id="personaStateHint">--</span>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="stats-row" id="personaStateStats"></div>
+                                    <div id="personaStatePreview" class="list" style="margin-top:10px;"></div>
+                                </div>
+                            </div>
+
+                            <div class="panel">
+                                <div class="panel-head">
+                                    <h2>人格备份</h2>
+                                    <span class="hint" id="personaBackupHint">--</span>
+                                </div>
+                                <div class="panel-body">
+                                    <div id="personaBackupList" class="list"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="review-tab-panel" data-review-panel="reviewed" aria-label="已审历史" hidden>
+                        <div class="panel">
+                            <div class="panel-head">
+                                <h2>最近已审人格</h2>
+                                <span class="hint" id="reviewedPersonaCount">0</span>
+                            </div>
+                            <div class="panel-body">
+                                <div id="reviewedPersonaList" class="list"></div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="review-tab-panel" data-review-panel="batches" aria-label="学习批次" hidden>
+                        <div class="panel">
+                            <div class="panel-head">
+                                <div>
+                                    <h2>最近批次</h2>
+                                    <span class="hint" id="batchHint">--</span>
+                                </div>
+                                <div class="panel-tools">
+                                    <button class="icon-btn" id="batchReloadBtn" type="button" aria-label="刷新批次" title="刷新批次">
+                                        <span class="material-icons">sync</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="panel-body">
+                                <div id="batchList" class="list"></div>
+
+                                <div id="batchPagination" style="display:flex;justify-content:space-between;align-items:center;margin-top:12px;gap:8px;">
+                                    <span id="batchPageInfo" class="muted" style="font-size:12px;">--</span>
+                                    <div style="display:flex;gap:4px;">
+                                        <button class="action-btn" id="batchPrevBtn" type="button" disabled>
+                                            <span class="material-icons" style="font-size:16px;">chevron_left</span>
+                                        </button>
+                                        <button class="action-btn" id="batchNextBtn" type="button" disabled>
+                                            <span class="material-icons" style="font-size:16px;">chevron_right</span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
-            </div>
-        </section>
+            </section>
         </section>
 
         <section class="page" id="page-content" data-page="content">
@@ -2872,6 +3123,9 @@
                     mirror: localStorage.getItem('sl-pip-mirror') || 'default',
                 },
                 actionBusy: new Set(),
+                reviews: {
+                    tab: 'persona',
+                },
                 personaState: {
                     groupId: 'default',
                 },
@@ -3867,6 +4121,15 @@
                 return map[target] || 'home';
             }
 
+            function getReviewTabForInsightTarget(target) {
+                const map = {
+                    reviews: 'persona',
+                    jargon: 'jargon',
+                    batches: 'batches',
+                };
+                return map[target] || null;
+            }
+
             function jumpToInsightTarget(target) {
                 const targetId = getInsightTargetId(target);
                 if (!targetId) {
@@ -3874,6 +4137,10 @@
                 }
 
                 navigateToPage(getInsightTargetPage(target), { keepScroll: true });
+                const reviewTab = getReviewTabForInsightTarget(target);
+                if (reviewTab) {
+                    setReviewTab(reviewTab);
+                }
                 window.setTimeout(() => {
                     const element = $(targetId);
                     if (!element) {
@@ -4076,6 +4343,72 @@
 
                 const score = safeNumber(value);
                 return `置信 ${formatPercent(score <= 1 ? score * 100 : score)}`;
+            }
+
+            function setReviewTab(tab) {
+                const validTabs = ['persona', 'style', 'jargon', 'persona-state', 'reviewed', 'batches'];
+                const nextTab = validTabs.includes(tab) ? tab : 'persona';
+                state.reviews.tab = nextTab;
+
+                document.querySelectorAll('[data-review-tab]').forEach((button) => {
+                    const active = button.dataset.reviewTab === nextTab;
+                    button.classList.toggle('active', active);
+                    button.setAttribute('aria-selected', active ? 'true' : 'false');
+                });
+
+                document.querySelectorAll('[data-review-panel]').forEach((panel) => {
+                    const active = panel.dataset.reviewPanel === nextTab;
+                    panel.classList.toggle('active', active);
+                    panel.hidden = !active;
+                });
+            }
+
+            function updateReviewNavCounts(counts = {}) {
+                const setText = (id, value) => {
+                    const target = $(id);
+                    if (target) {
+                        target.textContent = value;
+                    }
+                };
+
+                const dashboardData = state.data || {};
+                const persona = dashboardData.persona || {};
+                const personaUpdates = safeArray(persona.updates);
+                const style = dashboardData.style || {};
+                const personaReviewed = dashboardData.personaReviewed || {};
+                const personaBackups = dashboardData.personaBackups || {};
+                const jargonStats = extractJargonStats(dashboardData.jargonStats);
+                const styleBacklogDefault = safeNumber(style.total);
+                const personaTotal = safeNumber(persona.total);
+                const personaIncludesStyle = personaUpdates.some((item) => item && item.review_source === 'style_learning');
+                const personaBacklogDefault = personaIncludesStyle ? Math.max(0, personaTotal - styleBacklogDefault) : personaTotal;
+                const pendingJargonDefault = Math.max(
+                    0,
+                    safeNumber(jargonStats.total_candidates ?? jargonStats.totalCandidates)
+                        - safeNumber(jargonStats.confirmed_jargon ?? jargonStats.confirmedJargon),
+                );
+                const backupTotalDefault = personaBackups.available === false
+                    ? 0
+                    : safeNumber(personaBackups.total || safeArray(personaBackups.backups).length);
+                const valueOrDefault = (value, fallback) => (
+                    value === undefined || value === null ? fallback : safeNumber(value)
+                );
+
+                const personaBacklog = valueOrDefault(counts.personaBacklog, personaBacklogDefault);
+                const styleBacklog = valueOrDefault(counts.styleBacklog, styleBacklogDefault);
+                const pendingJargon = valueOrDefault(counts.pendingJargon, pendingJargonDefault);
+                const reviewedTotal = valueOrDefault(counts.reviewedTotal, safeNumber(personaReviewed.total));
+                const backupTotal = valueOrDefault(counts.backupTotal, backupTotalDefault);
+                const batchTotal = valueOrDefault(counts.batchTotal, state.batch.total);
+                const pendingTotal = personaBacklog + styleBacklog + pendingJargon;
+
+                setText('reviewSidebarSummary', `待处理 ${formatCount(pendingTotal)} 条`);
+                setText('reviewNavPersonaCount', formatCount(personaBacklog));
+                setText('reviewNavStyleCount', formatCount(styleBacklog));
+                setText('reviewNavJargonCount', formatCount(pendingJargon));
+                setText('reviewNavPersonaStateCount', formatCount(backupTotal));
+                setText('reviewNavReviewedCount', formatCount(reviewedTotal));
+                setText('reviewNavBatchCount', formatCount(batchTotal));
             }
 
             function actionButton(action, id, icon, label, tone = '') {
@@ -4354,6 +4687,9 @@
                 const personaTotal = safeNumber(persona.total);
                 const personaPayloadIncludesStyle = personaUpdates.some((item) => item && item.review_source === 'style_learning');
                 const personaBacklog = personaPayloadIncludesStyle ? Math.max(0, personaTotal - styleBacklog) : personaTotal;
+                const totalJargonCandidates = safeNumber(jargonStats.total_candidates ?? jargonStats.totalCandidates);
+                const confirmedJargon = safeNumber(jargonStats.confirmed_jargon ?? jargonStats.confirmedJargon);
+                const pendingJargon = Math.max(0, totalJargonCandidates - confirmedJargon);
                 const backlog = personaBacklog + styleBacklog;
                 const overallHealth = textOrDash(health.overall || 'unknown');
 
@@ -4468,6 +4804,17 @@
                 $('styleList').innerHTML = renderStyleQueue(styleUpdatesFromPersona.length ? styleUpdatesFromPersona : style.reviews);
                 $('reviewedPersonaList').innerHTML = renderReviewedPersonaHistory(personaReviewed.updates);
                 renderPersonaStatePanel(personaState, personaBackups);
+                updateReviewNavCounts({
+                    personaBacklog,
+                    styleBacklog,
+                    pendingJargon,
+                    reviewedTotal: personaReviewed.total || 0,
+                    backupTotal: personaBackups.available === false
+                        ? 0
+                        : (personaBackups.total || safeArray(personaBackups.backups).length),
+                    batchTotal: state.batch.total,
+                });
+                setReviewTab(state.reviews.tab);
 
                 $('trendHint').textContent = `最近 ${Object.keys(trends.daily_messages || {}).length || 7} 天`;
 
@@ -6690,6 +7037,13 @@
                 $('jargonNextBtn').disabled = page >= totalPages;
 
                 $('jargonHint').textContent = `候选 ${formatCount((jargonStats.total_candidates ?? jargonStats.totalCandidates) || 0)} · 第 ${page}/${totalPages} 页`;
+                updateReviewNavCounts({
+                    pendingJargon: Math.max(
+                        0,
+                        safeNumber(jargonStats.total_candidates ?? jargonStats.totalCandidates)
+                            - safeNumber(jargonStats.confirmed_jargon ?? jargonStats.confirmedJargon),
+                    ),
+                });
             }
 
             function renderBatchPanel() {
@@ -6727,6 +7081,7 @@
                 $('batchPrevBtn').disabled = page <= 1;
                 $('batchNextBtn').disabled = page >= totalPages;
                 $('batchHint').textContent = `共 ${formatCount(total)} 个批次`;
+                updateReviewNavCounts({ batchTotal: total });
             }
 
             function bindEvents() {
@@ -6866,6 +7221,12 @@
                     const dependencyTarget = event.target.closest('[data-dependency-tier]');
                     if (dependencyTarget) {
                         installDependencyTier(dependencyTarget.dataset.dependencyTier);
+                        return;
+                    }
+
+                    const reviewTab = event.target.closest('[data-review-tab]');
+                    if (reviewTab) {
+                        setReviewTab(reviewTab.dataset.reviewTab);
                         return;
                     }
 

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -3371,10 +3371,26 @@
                 embedding: 'Embedding',
                 rerank: 'Reranker',
             };
+            function safeLocalStorageGet(key, fallback = null) {
+                try {
+                    return localStorage.getItem(key) ?? fallback;
+                } catch {
+                    return fallback;
+                }
+            }
+
+            function safeLocalStorageSet(key, value) {
+                try {
+                    localStorage.setItem(key, value);
+                } catch {
+                    // Storage may be unavailable in sandboxed AstrBot Plugin Pages.
+                }
+            }
+
             const state = {
                 charts: {},
                 data: null,
-                theme: themeFromDocument || localStorage.getItem('sl-dashboard-theme') || 'light',
+                theme: themeFromDocument || safeLocalStorageGet('sl-dashboard-theme', 'light') || 'light',
                 config: {
                     schema: null,
                     original: {},
@@ -3392,7 +3408,7 @@
                 },
                 dependencyInstall: {
                     busy: false,
-                    mirror: localStorage.getItem('sl-pip-mirror') || 'default',
+                    mirror: safeLocalStorageGet('sl-pip-mirror', 'default') || 'default',
                 },
                 actionBusy: new Set(),
                 reviews: {
@@ -7607,7 +7623,7 @@
                 document.documentElement.setAttribute('data-theme', state.theme);
                 document.documentElement.style.colorScheme = state.theme;
                 document.body.setAttribute('data-theme', state.theme);
-                localStorage.setItem('sl-dashboard-theme', state.theme);
+                safeLocalStorageSet('sl-dashboard-theme', state.theme);
                 updateThemeIcon();
                 if (state.data) {
                     renderAll(state.data);
@@ -8000,7 +8016,7 @@
                     pipMirrorSelect.value = state.dependencyInstall.mirror;
                     pipMirrorSelect.addEventListener('change', (event) => {
                         state.dependencyInstall.mirror = event.target.value || 'default';
-                        localStorage.setItem('sl-pip-mirror', state.dependencyInstall.mirror);
+                        safeLocalStorageSet('sl-pip-mirror', state.dependencyInstall.mirror);
                     });
                 }
 

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -2530,7 +2530,6 @@
                             <option value="newest">最新优先</option>
                             <option value="oldest">最早优先</option>
                             <option value="name">按名称</option>
-                            <option value="occurrences">按出现次数</option>
                         </select>
                         <input id="jargonSearchInput" class="content-search" style="width:160px;height:32px;font-size:12px;" type="search" placeholder="搜索黑话" autocomplete="off">
                     </div>
@@ -6563,8 +6562,6 @@
                         items.reverse();
                     } else if (state.jargon.sort === 'name') {
                         items.sort((a, b) => (a.term || a.word || '').localeCompare(b.term || b.word || ''));
-                    } else if (state.jargon.sort === 'occurrences') {
-                        items.sort((a, b) => (b.occurrences || 0) - (a.occurrences || 0));
                     }
 
                     state.jargon.items = items;
@@ -6617,7 +6614,7 @@
                     ['候选', jargonStats.total_candidates],
                     ['确认', jargonStats.confirmed_jargon],
                     ['完成', jargonStats.completed_inference],
-                    ['出现', jargonStats.total_occurrences],
+                    ['命中', jargonStats.total_occurrences],
                 ].map(([label, value]) => `
                     <div class="small-stat">
                         <div class="k">${label}</div>
@@ -6635,7 +6632,7 @@
                     const meta = [
                         item.group_id ? `群组 ${item.group_id}` : null,
                         item.is_confirmed !== undefined ? (item.is_confirmed ? '已确认' : '待确认') : null,
-                        item.occurrences !== undefined ? `出现 ${formatCount(item.occurrences)}` : null,
+                        item.occurrences !== undefined ? `命中 ${formatCount(item.occurrences)}` : null,
                         item.created_at ? `创建 ${formatTime(item.created_at)}` : null,
                         item.updated_at ? `更新 ${formatTime(item.updated_at)}` : null,
                     ].filter(Boolean).join(' · ');

--- a/webui/manager.py
+++ b/webui/manager.py
@@ -50,8 +50,62 @@ class WebUIManager:
         self._database_degraded = False
         self._database_start_error: Optional[str] = None
         self._database_start_attempted = False
+        self._register_plugin_pages_api()
 
     # 创建
+
+    def _public_webui_base_url(self) -> str:
+        host = str(getattr(self._config, "web_interface_host", "127.0.0.1") or "127.0.0.1")
+        port = int(getattr(self._config, "web_interface_port", 7833) or 7833)
+        if host in {"0.0.0.0", "::", "[::]"}:
+            try:
+                from quart import request
+
+                host_header = request.host.split(":", 1)[0]
+            except (ImportError, RuntimeError):
+                host_header = ""
+            host = host_header or "127.0.0.1"
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"http://{host}:{port}"
+
+    def _register_plugin_pages_api(self) -> None:
+        register_web_api = getattr(self._context, "register_web_api", None)
+        if not callable(register_web_api):
+            logger.debug("[WebUI] AstrBot Plugin Pages API is not available")
+            return
+
+        plugin_name = "astrbot_plugin_self_learning"
+        plugin_instance_name = getattr(self._plugin_instance, "name", None)
+        if isinstance(plugin_instance_name, str) and plugin_instance_name.strip():
+            plugin_name = plugin_instance_name.strip()
+
+        async def dashboard_url():
+            try:
+                from quart import jsonify
+            except ImportError:
+                def jsonify(payload):
+                    return payload
+
+            base_url = self._public_webui_base_url()
+            return jsonify({
+                "url": f"{base_url}/static/html/dashboard.html",
+                "base_url": base_url,
+            })
+
+        for route in {
+            f"{plugin_name}/dashboard_url",
+            "astrbot_plugin_self_learning/dashboard_url",
+        }:
+            try:
+                register_web_api(
+                    route,
+                    dashboard_url,
+                    ["GET"],
+                    "Self Learning dashboard URL for AstrBot Plugin Pages",
+                )
+            except Exception as exc:
+                logger.debug(f"[WebUI] register Plugin Pages API failed for {route}: {exc}")
 
     def create_server(self) -> bool:
         """创建 Server 实例（不启动）。返回 True 表示需要立即启动。"""


### PR DESCRIPTION
## 改动概览

主要优化 Self Learning Dashboard 的前端体验，并新增 AstrBot Plugin Pages 支持，使用户可以直接从 AstrBot WebUI 的插件详情页进入 Dashboard。

### Dashboard 设置页重构

- 为设置页面增加侧边栏分类导航，降低大量配置项堆叠带来的阅读压力。
- 将右侧设置项从单列展示优化为响应式网格布局，更充分利用页面空间。
- 将布尔类型配置项改为切换开关样式，交互更直观。
- 优化长文本、列表、复杂配置项的布局宽度，减少页面纵向滚动。
- 优化依赖安装区域的展示、图标对齐、镜像选择和滚动条样式。
- 保留手动保存按钮和未保存状态提示，避免配置修改反馈不清晰。

### Dashboard 体验优化

- 简化顶部品牌区域，减少重复标题和过多说明文字占用空间。
- 移除黑话列表中容易产生误解的“按出现次数排序”。
- 保留更准确的样本数、审查信息和上下文展示。

### AstrBot Plugin Pages 支持

- 新增 `pages/dashboard/index.html`，支持在 AstrBot 插件详情页中打开 Dashboard。
- 新增 `.astrbot-plugin/i18n/zh-CN.json` 和 `.astrbot-plugin/i18n/en-US.json`，注册 Dashboard 页面标题。
- 通过 AstrBot Plugin Page bridge 调用插件 API 获取独立 Dashboard 地址。
- 在 `WebUIManager` 中注册 `dashboard_url` Web API，用于返回当前 WebUI Dashboard 地址。
- 使用 iframe 嵌入原有 Dashboard，因此后续修改原 Dashboard 时，AstrBot 内嵌页面也会同步生效。
- 移除 Plugin Page 内额外标题栏和无效的“直接打开/刷新”按钮，避免与 AstrBot 自带页面标题重复。

### 回归测试

- 增加 Plugin Page 入口相关断言，确认 bridge、iframe、`dashboard_url` 调用存在。
- 增加 WebUIManager 单元测试，确认 `dashboard_url` API 会被注册。
- 将 Plugin Page HTML 纳入外部 CDN 引用检查。
- 增加设置页布局、开关控件、依赖安装区域等前端结构断言。

## 验证

已执行：

- `python -m py_compile tests\integration\test_webui_static_assets.py webui\manager.py tests\unit\test_webui_manager.py`
- Node 内联脚本语法检查：`pages/dashboard/index.html` 与 `web_res/static/html/dashboard.html`
- `git diff --check`

## Summary by Sourcery

Refine the Self Learning dashboard UI and settings layout while adding AstrBot Plugin Page support for opening the dashboard from AstrBot WebUI, with corresponding tests and Web API registration.

Enhancements:
- Redesign the dashboard review queue into a categorized sidebar workspace and compact global header, and restructure the settings page with a sticky navigation sidebar, denser grid layout, and switch-style boolean controls.
- Improve dashboard resilience and UX by guarding summary text access, adjusting jargon metrics labelling, and using safe localStorage access compatible with sandboxed plugin environments.
- Expose a public WebUI base URL helper in WebUIManager and register a dashboard_url Web API for external consumers such as AstrBot Plugin Pages.

Tests:
- Add integration tests to verify AstrBot Plugin Page dashboard embedding, new dashboard review/settings layouts, and updated jargon sorting behavior.
- Add unit tests ensuring WebUIManager registers the dashboard_url API and computes the public Web UI base URL from configuration.