### PR TITLE
Fix high-frequency disabled realtime learning calls

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -65,8 +65,15 @@
       "enable_webui_password": {
         "description": "启用WebUI登录密码",
         "type": "bool",
-        "hint": "默认关闭，WebUI 免密访问；开启后访问 WebUI 需要登录密码。首次开启使用默认密码 self_learning_pwd 登录并按提示修改",
+        "hint": "默认关闭，WebUI 免密访问；开启后访问 WebUI 需要登录密码。首次开启前请填写下方一次性初始密码，或设置环境变量 ASTRBOT_WEBUI_INITIAL_PASSWORD",
         "default": false
+      },
+      "webui_initial_password": {
+        "description": "WebUI一次性初始密码",
+        "type": "string",
+        "hint": "仅在首次启用 WebUI 登录密码且尚未生成 password.json 时使用。保存后会写入哈希密码并清空，不会回显明文",
+        "default": "",
+        "_secret": true
       },
       "web_interface_port": {
         "description": "Web界面端口",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -62,6 +62,12 @@
         "hint": "是否启用Web界面用于查看和管理学习数据",
         "default": true
       },
+      "enable_webui_password": {
+        "description": "启用WebUI登录密码",
+        "type": "bool",
+        "hint": "默认关闭，WebUI 免密访问；开启后访问 WebUI 需要登录密码。首次开启使用默认密码 self_learning_pwd 登录并按提示修改",
+        "default": false
+      },
       "web_interface_port": {
         "description": "Web界面端口",
         "type": "int",
@@ -163,6 +169,12 @@
         "type": "int",
         "hint": "每个群每新增多少条原始消息才触发表达方式学习。调大可降低筛选/分析模型调用频率",
         "default": 10
+      },
+      "expression_learning_min_interval_seconds": {
+        "description": "表达方式学习最小间隔(秒)",
+        "type": "int",
+        "hint": "同一群两次表达方式学习之间的最小间隔。默认3600秒，避免实时模式下频繁生成审查/人格更新",
+        "default": 3600
       },
       "topic_detection_interval_messages": {
         "description": "话题检测触发消息数",

--- a/config.py
+++ b/config.py
@@ -68,12 +68,14 @@ class PluginConfig(BaseModel):
     enable_jargon_learning: bool = True # 启用黑话学习
     enable_style_learning: bool = True # 启用对话风格学习
     enable_web_interface: bool = True
+    enable_webui_password: bool = False # 启用 WebUI 登录密码，默认免密
     web_interface_port: int = 7833 # 新增 Web 界面端口配置
     web_interface_host: str = "0.0.0.0" # Web 界面监听地址
 
     # MaiBot增强功能（默认启用）
     enable_maibot_features: bool = True # 启用MaiBot增强功能
     enable_expression_patterns: bool = True # 启用表达模式学习
+    enable_realtime_expression_learning: bool = False # 实时学习关闭时是否仍按消息触发表达学习
     enable_memory_graph: bool = True # 启用记忆图系统
     enable_knowledge_graph: bool = True # 启用知识图谱
     enable_time_decay: bool = True # 启用时间衰减机制
@@ -119,6 +121,7 @@ class PluginConfig(BaseModel):
     min_messages_for_learning: int = 50 # 最少消息数量才开始学习
     max_messages_per_batch: int = 200 # 每批处理的最大消息数量
     expression_learning_trigger_messages: int = 10 # 表达方式学习触发消息增量
+    expression_learning_min_interval_seconds: int = 3600 # 表达方式学习最小触发间隔（秒）
     topic_detection_interval_messages: int = 10 # 话题检测触发消息增量
 
     # 筛选参数
@@ -155,6 +158,7 @@ class PluginConfig(BaseModel):
     shutdown_step_timeout: int = 8       # 每个关停步骤的超时
     task_cancel_timeout: int = 3         # 后台任务取消等待超时
     service_stop_timeout: int = 5        # 单个服务停止超时
+    enable_llm_hooks: bool = False       # 启用 LLM Hook 上下文注入，默认关闭以避免高频调用
     llm_hook_context_timeout: float = 3.0  # LLM Hook 单个上下文源超时（秒）
 
     # PersonaUpdater配置
@@ -342,11 +346,13 @@ class PluginConfig(BaseModel):
             enable_jargon_learning=basic_settings.get('enable_jargon_learning', True),
             enable_style_learning=basic_settings.get('enable_style_learning', True),
             enable_web_interface=basic_settings.get('enable_web_interface', True),
+            enable_webui_password=basic_settings.get('enable_webui_password', False),
             web_interface_port=basic_settings.get('web_interface_port', 7833),
             web_interface_host=basic_settings.get('web_interface_host', '0.0.0.0'),
 
             enable_maibot_features=maibot_enhancement.get('enable_maibot_features', True),
             enable_expression_patterns=maibot_enhancement.get('enable_expression_patterns', True),
+            enable_realtime_expression_learning=maibot_enhancement.get('enable_realtime_expression_learning', False),
             enable_memory_graph=maibot_enhancement.get('enable_memory_graph', True),
             enable_knowledge_graph=maibot_enhancement.get('enable_knowledge_graph', True),
             enable_time_decay=maibot_enhancement.get('enable_time_decay', True),
@@ -383,6 +389,7 @@ class PluginConfig(BaseModel):
             min_messages_for_learning=learning_params.get('min_messages_for_learning', 50),
             max_messages_per_batch=learning_params.get('max_messages_per_batch', 200),
             expression_learning_trigger_messages=learning_params.get('expression_learning_trigger_messages', 10),
+            expression_learning_min_interval_seconds=learning_params.get('expression_learning_min_interval_seconds', 3600),
             topic_detection_interval_messages=learning_params.get('topic_detection_interval_messages', 10),
 
             message_min_length=filter_params.get('message_min_length', 5),
@@ -483,6 +490,7 @@ class PluginConfig(BaseModel):
             shutdown_step_timeout=runtime_internal_settings.get('shutdown_step_timeout', 8),
             task_cancel_timeout=runtime_internal_settings.get('task_cancel_timeout', 3),
             service_stop_timeout=runtime_internal_settings.get('service_stop_timeout', 5),
+            enable_llm_hooks=runtime_internal_settings.get('enable_llm_hooks', False),
             llm_hook_context_timeout=float(runtime_internal_settings.get('llm_hook_context_timeout', 3.0)),
             llm_hook_injection_target=runtime_internal_settings.get(
                 'llm_hook_injection_target',
@@ -616,6 +624,9 @@ class PluginConfig(BaseModel):
 
         if self.expression_learning_trigger_messages <= 0:
             errors.append("表达方式学习触发消息数必须大于0")
+
+        if self.expression_learning_min_interval_seconds < 0:
+            errors.append("表达方式学习最小触发间隔不能小于0秒")
 
         if self.topic_detection_interval_messages <= 0:
             errors.append("话题检测触发消息数必须大于0")

--- a/config.py
+++ b/config.py
@@ -69,6 +69,7 @@ class PluginConfig(BaseModel):
     enable_style_learning: bool = True # 启用对话风格学习
     enable_web_interface: bool = True
     enable_webui_password: bool = False # 启用 WebUI 登录密码，默认免密
+    webui_initial_password: str = "" # WebUI 密码首次启用时的一次性初始密码
     web_interface_port: int = 7833 # 新增 Web 界面端口配置
     web_interface_host: str = "0.0.0.0" # Web 界面监听地址
 
@@ -347,6 +348,7 @@ class PluginConfig(BaseModel):
             enable_style_learning=basic_settings.get('enable_style_learning', True),
             enable_web_interface=basic_settings.get('enable_web_interface', True),
             enable_webui_password=basic_settings.get('enable_webui_password', False),
+            webui_initial_password=basic_settings.get('webui_initial_password', ''),
             web_interface_port=basic_settings.get('web_interface_port', 7833),
             web_interface_host=basic_settings.get('web_interface_host', '0.0.0.0'),
 

--- a/services/hooks/llm_hook_handler.py
+++ b/services/hooks/llm_hook_handler.py
@@ -76,6 +76,10 @@ class LLMHookHandler:
                 logger.warning("[LLM Hook] req 参数为 None，跳过注入")
                 return
 
+            if not getattr(self._config, "enable_llm_hooks", False):
+                logger.debug("[LLM Hook] 总开关未启用，跳过上下文注入")
+                return
+
             if not self._diversity_manager:
                 logger.debug("[LLM Hook] diversity_manager未初始化,跳过多样性注入")
                 return

--- a/services/learning/message_pipeline.py
+++ b/services/learning/message_pipeline.py
@@ -158,7 +158,7 @@ class MessagePipeline:
                         group_id, message_text, sender_id
                     )
                 )
-            elif self._config.enable_expression_patterns:
+            elif getattr(self._config, "enable_realtime_expression_learning", False):
                 self._spawn(
                     self._realtime_processor.process_expression_learning_background(
                         group_id, message_text, sender_id

--- a/services/learning/realtime_processor.py
+++ b/services/learning/realtime_processor.py
@@ -57,6 +57,7 @@ class RealtimeProcessor:
         self._db_manager = db_manager
         self._expression_learner = None  # lazily resolved, cached
         self._last_expression_trigger_counts: Dict[str, int] = {}
+        self._last_expression_learning_times: Dict[str, float] = {}
 
         # Callback set by the plugin to trigger incremental prompt updates
         self.update_system_prompt_callback: Optional[
@@ -165,6 +166,27 @@ class RealtimeProcessor:
     ) -> None:
         """Learn expression styles directly from raw messages."""
         try:
+            now = time.time()
+            min_interval = max(
+                0,
+                int(
+                    getattr(
+                        self._config,
+                        "expression_learning_min_interval_seconds",
+                        3600,
+                    )
+                    or 0
+                ),
+            )
+            last_learning_time = self._last_expression_learning_times.get(group_id, 0)
+            if min_interval and last_learning_time and now - last_learning_time < min_interval:
+                remaining = int(min_interval - (now - last_learning_time))
+                logger.debug(
+                    f"群组 {group_id} 表达风格学习处于冷却中，"
+                    f"剩余约 {remaining} 秒"
+                )
+                return
+
             stats = await self._message_collector.get_statistics(group_id)
             raw_message_count = stats.get("raw_messages", 0)
 
@@ -186,6 +208,7 @@ class RealtimeProcessor:
                 )
                 return
             self._last_expression_trigger_counts[group_id] = raw_message_count
+            self._last_expression_learning_times[group_id] = now
 
             logger.info(
                 f"群组 {group_id} 开始表达风格学习，当前消息数：{raw_message_count}"

--- a/tests/integration/test_auth_blueprint.py
+++ b/tests/integration/test_auth_blueprint.py
@@ -3,14 +3,23 @@ Integration tests for Authentication Blueprint
 
 Tests the auth blueprint routes with mock dependencies
 """
+from types import SimpleNamespace
+
 import pytest
 from quart import Quart
 from webui.blueprints.auth import auth_bp
+from webui.dependencies import get_container
+from webui.services.auth_service import DEFAULT_WEBUI_PASSWORD
 
 
 @pytest.fixture
 async def app(mock_container):
     """Create test Quart application"""
+    container = get_container()
+    previous_plugin_config = container.plugin_config
+    mock_container.plugin_config.enable_webui_password = False
+    container.plugin_config = mock_container.plugin_config
+
     app = Quart(__name__)
     app.config['TESTING'] = True
     app.secret_key = 'test-secret-key'
@@ -19,6 +28,8 @@ async def app(mock_container):
     app.register_blueprint(auth_bp)
 
     yield app
+
+    container.plugin_config = previous_plugin_config
 
 
 @pytest.fixture
@@ -143,3 +154,71 @@ class TestAuthMiddleware:
         response = await client.post('/api/logout')
 
         assert response.status_code == 200
+
+
+class TestPasswordEnabledAuthBlueprint:
+    """Integration tests for optional password mode."""
+
+    @pytest.mark.asyncio
+    async def test_login_page_renders_when_password_enabled(self, client, tmp_path):
+        get_container().plugin_config = SimpleNamespace(
+            enable_webui_password=True,
+            data_dir=str(tmp_path),
+        )
+
+        response = await client.get('/api/login')
+
+        assert response.status_code == 200
+        body = await response.get_data(as_text=True)
+        assert "SELF LEARNING" in body
+        assert "登录密码" in body
+
+    @pytest.mark.asyncio
+    async def test_index_redirects_to_login_when_password_enabled(self, client, tmp_path):
+        get_container().plugin_config = SimpleNamespace(
+            enable_webui_password=True,
+            data_dir=str(tmp_path),
+        )
+
+        response = await client.get('/api/index')
+
+        assert response.status_code in [302, 303, 307]
+        assert response.headers["Location"].endswith("/api/login")
+
+    @pytest.mark.asyncio
+    async def test_login_post_checks_password_when_enabled(self, client, tmp_path):
+        get_container().plugin_config = SimpleNamespace(
+            enable_webui_password=True,
+            data_dir=str(tmp_path),
+        )
+
+        failed = await client.post('/api/login', json={'password': 'wrong_password'})
+        assert failed.status_code == 401
+
+        response = await client.post(
+            '/api/login',
+            json={'password': DEFAULT_WEBUI_PASSWORD},
+        )
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data['must_change'] is True
+        assert data['redirect'] == '/api/plugin_change_password'
+
+    @pytest.mark.asyncio
+    async def test_change_password_when_enabled(self, client, tmp_path):
+        get_container().plugin_config = SimpleNamespace(
+            enable_webui_password=True,
+            data_dir=str(tmp_path),
+        )
+        await client.post('/api/login', json={'password': DEFAULT_WEBUI_PASSWORD})
+
+        response = await client.post('/api/plugin_change_password', json={
+            'old_password': DEFAULT_WEBUI_PASSWORD,
+            'new_password': 'NewPass123!',
+        })
+
+        assert response.status_code == 200
+        data = await response.get_json()
+        assert data["success"] is True
+        assert data["redirect"] == "/api/index"

--- a/tests/integration/test_auth_blueprint.py
+++ b/tests/integration/test_auth_blueprint.py
@@ -9,7 +9,7 @@ import pytest
 from quart import Quart
 from webui.blueprints.auth import auth_bp
 from webui.dependencies import get_container
-from webui.services.auth_service import DEFAULT_WEBUI_PASSWORD
+from webui.services.auth_service import INITIAL_WEBUI_PASSWORD_ENV_VAR
 
 
 @pytest.fixture
@@ -186,7 +186,8 @@ class TestPasswordEnabledAuthBlueprint:
         assert response.headers["Location"].endswith("/api/login")
 
     @pytest.mark.asyncio
-    async def test_login_post_checks_password_when_enabled(self, client, tmp_path):
+    async def test_login_post_checks_password_when_enabled(self, client, tmp_path, monkeypatch):
+        monkeypatch.setenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "InitialPass123!")
         get_container().plugin_config = SimpleNamespace(
             enable_webui_password=True,
             data_dir=str(tmp_path),
@@ -197,7 +198,7 @@ class TestPasswordEnabledAuthBlueprint:
 
         response = await client.post(
             '/api/login',
-            json={'password': DEFAULT_WEBUI_PASSWORD},
+            json={'password': 'InitialPass123!'},
         )
 
         assert response.status_code == 200
@@ -206,15 +207,16 @@ class TestPasswordEnabledAuthBlueprint:
         assert data['redirect'] == '/api/plugin_change_password'
 
     @pytest.mark.asyncio
-    async def test_change_password_when_enabled(self, client, tmp_path):
+    async def test_change_password_when_enabled(self, client, tmp_path, monkeypatch):
+        monkeypatch.setenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "InitialPass123!")
         get_container().plugin_config = SimpleNamespace(
             enable_webui_password=True,
             data_dir=str(tmp_path),
         )
-        await client.post('/api/login', json={'password': DEFAULT_WEBUI_PASSWORD})
+        await client.post('/api/login', json={'password': 'InitialPass123!'})
 
         response = await client.post('/api/plugin_change_password', json={
-            'old_password': DEFAULT_WEBUI_PASSWORD,
+            'old_password': 'InitialPass123!',
             'new_password': 'NewPass123!',
         })
 

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from webui.services.auth_service import DEFAULT_WEBUI_PASSWORD, AuthService
+from webui.services.auth_service import (
+    INITIAL_WEBUI_PASSWORD_ENV_VAR,
+    AuthService,
+)
 
 
 class TestAuthService:
@@ -61,7 +64,8 @@ class TestAuthService:
         assert mock_container.plugin_config.password_config == new_config
 
     @pytest.mark.asyncio
-    async def test_login_uses_default_password_when_enabled(self, tmp_path):
+    async def test_login_requires_initial_password_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, raising=False)
         container = SimpleNamespace(
             plugin_config=SimpleNamespace(
                 enable_webui_password=True,
@@ -71,8 +75,29 @@ class TestAuthService:
         service = AuthService(container)
 
         success, message, extra_data = await service.login(
-            DEFAULT_WEBUI_PASSWORD,
+            "AnyPass123!",
             "127.0.0.2",
+        )
+
+        assert success is False
+        assert "尚未配置初始密码" in message
+        assert extra_data == {"setup_required": True}
+        assert not (tmp_path / "password.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_login_uses_explicit_initial_password_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "InitialPass123!")
+        container = SimpleNamespace(
+            plugin_config=SimpleNamespace(
+                enable_webui_password=True,
+                data_dir=str(tmp_path),
+            )
+        )
+        service = AuthService(container)
+
+        success, message, extra_data = await service.login(
+            "InitialPass123!",
+            "127.0.0.4",
         )
 
         assert success is True
@@ -85,7 +110,8 @@ class TestAuthService:
         assert "password_hash" in container.plugin_config.password_config
 
     @pytest.mark.asyncio
-    async def test_change_password_when_enabled_updates_login_secret(self, tmp_path):
+    async def test_change_password_when_enabled_updates_login_secret(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "InitialPass123!")
         container = SimpleNamespace(
             plugin_config=SimpleNamespace(
                 enable_webui_password=True,
@@ -94,11 +120,11 @@ class TestAuthService:
         )
         service = AuthService(container)
 
-        success, _, _ = await service.login(DEFAULT_WEBUI_PASSWORD, "127.0.0.3")
+        success, _, _ = await service.login("InitialPass123!", "127.0.0.3")
         assert success is True
 
         success, message = await service.change_password(
-            DEFAULT_WEBUI_PASSWORD,
+            "InitialPass123!",
             "NewPass123!",
         )
 

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -1,8 +1,10 @@
-"""Unit tests for pack-branch passwordless AuthService compatibility."""
+"""Unit tests for optional WebUI password authentication."""
+
+from types import SimpleNamespace
 
 import pytest
 
-from webui.services.auth_service import AuthService
+from webui.services.auth_service import DEFAULT_WEBUI_PASSWORD, AuthService
 
 
 class TestAuthService:
@@ -57,3 +59,55 @@ class TestAuthService:
         assert service.save_password_config(new_config) is True
         assert service._password_config == new_config
         assert mock_container.plugin_config.password_config == new_config
+
+    @pytest.mark.asyncio
+    async def test_login_uses_default_password_when_enabled(self, tmp_path):
+        container = SimpleNamespace(
+            plugin_config=SimpleNamespace(
+                enable_webui_password=True,
+                data_dir=str(tmp_path),
+            )
+        )
+        service = AuthService(container)
+
+        success, message, extra_data = await service.login(
+            DEFAULT_WEBUI_PASSWORD,
+            "127.0.0.2",
+        )
+
+        assert success is True
+        assert "password must be changed" in message
+        assert extra_data == {
+            "must_change": True,
+            "redirect": "/api/plugin_change_password",
+        }
+        assert (tmp_path / "password.json").exists()
+        assert "password_hash" in container.plugin_config.password_config
+
+    @pytest.mark.asyncio
+    async def test_change_password_when_enabled_updates_login_secret(self, tmp_path):
+        container = SimpleNamespace(
+            plugin_config=SimpleNamespace(
+                enable_webui_password=True,
+                data_dir=str(tmp_path),
+            )
+        )
+        service = AuthService(container)
+
+        success, _, _ = await service.login(DEFAULT_WEBUI_PASSWORD, "127.0.0.3")
+        assert success is True
+
+        success, message = await service.change_password(
+            DEFAULT_WEBUI_PASSWORD,
+            "NewPass123!",
+        )
+
+        assert success is True
+        assert message == "密码修改成功"
+
+        success, _, extra_data = await service.login("NewPass123!", "127.0.0.3")
+        assert success is True
+        assert extra_data == {
+            "must_change": False,
+            "redirect": "/api/index",
+        }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -29,7 +29,11 @@ class TestPluginConfigDefaults:
         assert config.enable_message_capture is True
         assert config.enable_auto_learning is True
         assert config.enable_realtime_learning is False
+        assert config.enable_realtime_llm_filter is False
+        assert config.enable_realtime_expression_learning is False
+        assert config.enable_llm_hooks is False
         assert config.enable_web_interface is True
+        assert config.enable_webui_password is False
         assert config.web_interface_port == 7833
         assert config.web_interface_host == "0.0.0.0"
         assert config.log_level == "info"
@@ -43,6 +47,7 @@ class TestPluginConfigDefaults:
         assert config.min_messages_for_learning == 50
         assert config.max_messages_per_batch == 200
         assert config.expression_learning_trigger_messages == 10
+        assert config.expression_learning_min_interval_seconds == 3600
         assert config.topic_detection_interval_messages == 10
 
     def test_default_learning_parameters(self):
@@ -116,6 +121,7 @@ class TestPluginConfigFromDict:
                 'enable_message_capture': False,
                 'enable_auto_learning': False,
                 'enable_realtime_llm_filter': True,
+                'enable_webui_password': True,
                 'web_interface_port': 8080,
             }
         }
@@ -125,6 +131,7 @@ class TestPluginConfigFromDict:
         assert config.enable_message_capture is False
         assert config.enable_auto_learning is False
         assert config.enable_realtime_llm_filter is True
+        assert config.enable_webui_password is True
         assert config.web_interface_port == 8080
         assert config.data_dir == "/tmp/test"
 
@@ -270,6 +277,7 @@ class TestPluginConfigFromDict:
             'MaiBot_Enhancement': {
                 'enable_maibot_features': False,
                 'enable_expression_patterns': False,
+                'enable_realtime_expression_learning': True,
                 'enable_memory_graph': False,
                 'enable_knowledge_graph': False,
                 'enable_time_decay': False,
@@ -285,6 +293,7 @@ class TestPluginConfigFromDict:
             },
             'Runtime_Internal_Settings': {
                 'llm_hook_injection_target': 'prompt',
+                'enable_llm_hooks': True,
                 'enable_memory_cleanup': False,
                 'memory_cleanup_days': 14,
                 'memory_importance_threshold': 0.45,
@@ -292,12 +301,16 @@ class TestPluginConfigFromDict:
                 'task_cancel_timeout': 6,
                 'service_stop_timeout': 7,
             },
+            'Learning_Parameters': {
+                'expression_learning_min_interval_seconds': 120,
+            },
         }
 
         config = PluginConfig.create_from_config(raw_config, data_dir="/tmp/test")
 
         assert config.enable_maibot_features is False
         assert config.enable_expression_patterns is False
+        assert config.enable_realtime_expression_learning is True
         assert config.enable_memory_graph is False
         assert config.enable_knowledge_graph is False
         assert config.enable_time_decay is False
@@ -309,12 +322,14 @@ class TestPluginConfigFromDict:
         assert config.auto_apply_persona_updates is False
         assert config.persona_update_backup_enabled is False
         assert config.llm_hook_injection_target == 'prompt'
+        assert config.enable_llm_hooks is True
         assert config.enable_memory_cleanup is False
         assert config.memory_cleanup_days == 14
         assert config.memory_importance_threshold == 0.45
         assert config.shutdown_step_timeout == 11
         assert config.task_cancel_timeout == 6
         assert config.service_stop_timeout == 7
+        assert config.expression_learning_min_interval_seconds == 120
 
     def test_create_from_empty_config(self):
         """Test config creation from empty dict uses all defaults."""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -34,6 +34,7 @@ class TestPluginConfigDefaults:
         assert config.enable_llm_hooks is False
         assert config.enable_web_interface is True
         assert config.enable_webui_password is False
+        assert config.webui_initial_password == ""
         assert config.web_interface_port == 7833
         assert config.web_interface_host == "0.0.0.0"
         assert config.log_level == "info"
@@ -122,6 +123,7 @@ class TestPluginConfigFromDict:
                 'enable_auto_learning': False,
                 'enable_realtime_llm_filter': True,
                 'enable_webui_password': True,
+                'webui_initial_password': 'InitPass123!',
                 'web_interface_port': 8080,
             }
         }
@@ -132,6 +134,7 @@ class TestPluginConfigFromDict:
         assert config.enable_auto_learning is False
         assert config.enable_realtime_llm_filter is True
         assert config.enable_webui_password is True
+        assert config.webui_initial_password == 'InitPass123!'
         assert config.web_interface_port == 8080
         assert config.data_dir == "/tmp/test"
 

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -163,6 +163,9 @@ class TestConfigServiceSchema:
         basic_fields = {field["key"]: field for field in groups["Self_Learning_Basic"]["fields"]}
         assert basic_fields["enable_webui_password"]["widget"] == "toggle"
         assert basic_fields["enable_webui_password"]["value"] is False
+        assert basic_fields["webui_initial_password"]["widget"] == "password"
+        assert basic_fields["webui_initial_password"]["value"] == ""
+        assert basic_fields["webui_initial_password"]["secret"] is True
 
         maibot_fields = {field["key"]: field for field in groups["MaiBot_Enhancement"]["fields"]}
         assert maibot_fields["enable_realtime_expression_learning"]["widget"] == "toggle"
@@ -353,6 +356,7 @@ class TestConfigServiceSchema:
                     "enable_realtime_learning": True,
                     "enable_realtime_llm_filter": True,
                     "enable_webui_password": True,
+                    "webui_initial_password": "InitPass123!",
                 },
                 "enable_realtime_learning": False,
                 "enable_realtime_llm_filter": False,
@@ -365,6 +369,7 @@ class TestConfigServiceSchema:
 
         assert schema["config"]["enable_realtime_learning"] is True
         assert schema["config"]["enable_realtime_llm_filter"] is True
+        assert schema["config"]["webui_initial_password"] == ""
 
         fields = {
             field["key"]: field
@@ -373,10 +378,21 @@ class TestConfigServiceSchema:
         }
         assert fields["enable_realtime_learning"]["value"] is True
         assert fields["enable_realtime_llm_filter"]["value"] is True
+        assert fields["webui_initial_password"]["value"] == ""
 
         saved = json.loads(config_file.read_text(encoding="utf-8"))
         assert saved["enable_realtime_learning"] is True
         assert saved["enable_realtime_llm_filter"] is True
+        assert saved["webui_initial_password"] == ""
+        assert container.astrbot_config["Self_Learning_Basic"]["webui_initial_password"] == ""
+
+        password_config = json.loads(
+            (Path(container.plugin_config.data_dir) / "password.json").read_text(
+                encoding="utf-8",
+            )
+        )
+        assert "password_hash" in password_config
+        assert "password" not in password_config
 
     @pytest.mark.asyncio
     async def test_config_schema_refresh_pushes_newer_webui_config_to_plugin_page(self, tmp_path):
@@ -413,6 +429,25 @@ class TestConfigServiceSchema:
 
 @pytest.mark.unit
 class TestConfigServiceUpdate:
+    @pytest.mark.asyncio
+    async def test_update_config_rejects_password_mode_without_initial_secret(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ASTRBOT_WEBUI_INITIAL_PASSWORD", raising=False)
+        container = build_container(tmp_path)
+        service = ConfigService(container)
+
+        success, message, updated = await service.update_config(
+            {
+                "Self_Learning_Basic": {
+                    "enable_webui_password": True,
+                },
+            }
+        )
+
+        assert success is False
+        assert "初始密码" in message
+        assert updated["enable_webui_password"] is False
+        assert not (Path(container.plugin_config.data_dir) / "password.json").exists()
+
     @pytest.mark.asyncio
     async def test_update_config_persists_and_syncs_paths(self, tmp_path):
         container = build_container(tmp_path)
@@ -469,6 +504,7 @@ class TestConfigServiceUpdate:
                     "enable_realtime_learning": True,
                     "enable_realtime_llm_filter": True,
                     "enable_webui_password": True,
+                    "webui_initial_password": "InitPass123!",
                 },
                 "Target_Settings": {
                     "target_qq_list": ["10001", "group_20002"],
@@ -499,12 +535,14 @@ class TestConfigServiceUpdate:
         assert updated["enable_realtime_learning"] is True
         assert updated["enable_realtime_llm_filter"] is True
         assert updated["enable_webui_password"] is True
+        assert updated["webui_initial_password"] == ""
         assert updated["enable_llm_hooks"] is True
         assert updated["expression_learning_min_interval_seconds"] == 120
 
         assert container.astrbot_config["Self_Learning_Basic"]["enable_realtime_learning"] is True
         assert container.astrbot_config["Self_Learning_Basic"]["enable_realtime_llm_filter"] is True
         assert container.astrbot_config["Self_Learning_Basic"]["enable_webui_password"] is True
+        assert container.astrbot_config["Self_Learning_Basic"]["webui_initial_password"] == ""
         assert container.astrbot_config["Target_Settings"]["target_qq_list"] == [
             "10001",
             "group_20002",
@@ -516,6 +554,13 @@ class TestConfigServiceUpdate:
         assert container.astrbot_config["Runtime_Internal_Settings"]["enable_llm_hooks"] is True
         assert container.astrbot_config["Style_Analysis"]["style_update_threshold"] == 0.72
         assert container.astrbot_config["Filter_Parameters"]["relevance_threshold"] == 0.68
+        password_config = json.loads(
+            (Path(container.plugin_config.data_dir) / "password.json").read_text(
+                encoding="utf-8",
+            )
+        )
+        assert "password_hash" in password_config
+        assert "password" not in password_config
         assert "enable_realtime_learning" not in container.astrbot_config
         assert "enable_realtime_llm_filter" not in container.astrbot_config
         assert container.astrbot_config.save_calls == 1

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -157,6 +157,16 @@ class TestConfigServiceSchema:
 
         runtime_fields = {field["key"]: field for field in groups["Runtime_Internal_Settings"]["fields"]}
         assert runtime_fields["messages_db_path"]["editable"] is False
+        assert runtime_fields["enable_llm_hooks"]["widget"] == "toggle"
+        assert runtime_fields["enable_llm_hooks"]["value"] is False
+
+        basic_fields = {field["key"]: field for field in groups["Self_Learning_Basic"]["fields"]}
+        assert basic_fields["enable_webui_password"]["widget"] == "toggle"
+        assert basic_fields["enable_webui_password"]["value"] is False
+
+        maibot_fields = {field["key"]: field for field in groups["MaiBot_Enhancement"]["fields"]}
+        assert maibot_fields["enable_realtime_expression_learning"]["widget"] == "toggle"
+        assert maibot_fields["enable_realtime_expression_learning"]["value"] is False
 
         advanced_fields = {field["key"]: field for field in groups["Advanced_Settings"]["fields"]}
         assert advanced_fields["log_level"]["widget"] == "select"
@@ -342,6 +352,7 @@ class TestConfigServiceSchema:
                 "Self_Learning_Basic": {
                     "enable_realtime_learning": True,
                     "enable_realtime_llm_filter": True,
+                    "enable_webui_password": True,
                 },
                 "enable_realtime_learning": False,
                 "enable_realtime_llm_filter": False,
@@ -457,6 +468,7 @@ class TestConfigServiceUpdate:
                 "Self_Learning_Basic": {
                     "enable_realtime_learning": True,
                     "enable_realtime_llm_filter": True,
+                    "enable_webui_password": True,
                 },
                 "Target_Settings": {
                     "target_qq_list": ["10001", "group_20002"],
@@ -465,6 +477,10 @@ class TestConfigServiceUpdate:
                 "Learning_Parameters": {
                     "learning_interval_hours": 2,
                     "max_messages_per_batch": 25,
+                    "expression_learning_min_interval_seconds": 120,
+                },
+                "Runtime_Internal_Settings": {
+                    "enable_llm_hooks": True,
                 },
                 "Style_Analysis": {
                     "style_update_threshold": 0.72,
@@ -482,9 +498,13 @@ class TestConfigServiceUpdate:
         assert updated["learning_interval_hours"] == 2
         assert updated["enable_realtime_learning"] is True
         assert updated["enable_realtime_llm_filter"] is True
+        assert updated["enable_webui_password"] is True
+        assert updated["enable_llm_hooks"] is True
+        assert updated["expression_learning_min_interval_seconds"] == 120
 
         assert container.astrbot_config["Self_Learning_Basic"]["enable_realtime_learning"] is True
         assert container.astrbot_config["Self_Learning_Basic"]["enable_realtime_llm_filter"] is True
+        assert container.astrbot_config["Self_Learning_Basic"]["enable_webui_password"] is True
         assert container.astrbot_config["Target_Settings"]["target_qq_list"] == [
             "10001",
             "group_20002",
@@ -492,6 +512,8 @@ class TestConfigServiceUpdate:
         assert container.astrbot_config["Target_Settings"]["target_blacklist"] == ["blocked"]
         assert container.astrbot_config["Learning_Parameters"]["learning_interval_hours"] == 2
         assert container.astrbot_config["Learning_Parameters"]["max_messages_per_batch"] == 25
+        assert container.astrbot_config["Learning_Parameters"]["expression_learning_min_interval_seconds"] == 120
+        assert container.astrbot_config["Runtime_Internal_Settings"]["enable_llm_hooks"] is True
         assert container.astrbot_config["Style_Analysis"]["style_update_threshold"] == 0.72
         assert container.astrbot_config["Filter_Parameters"]["relevance_threshold"] == 0.68
         assert "enable_realtime_learning" not in container.astrbot_config

--- a/tests/unit/test_feature_delegation.py
+++ b/tests/unit/test_feature_delegation.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -81,6 +81,40 @@ def test_feature_delegation_keeps_local_fallback_when_companion_missing_or_disab
     )
 
     assert delegation.should_delegate_memory() is False
+
+
+@pytest.mark.asyncio
+async def test_llm_hook_handle_returns_without_context_fetches_when_disabled():
+    diversity = SimpleNamespace(
+        build_diversity_prompt_injection=AsyncMock(return_value="diversity")
+    )
+    perf_tracker = Mock()
+    handler = LLMHookHandler(
+        plugin_config=SimpleNamespace(enable_llm_hooks=False),
+        diversity_manager=diversity,
+        social_context_injector=SimpleNamespace(
+            format_complete_context=AsyncMock(return_value="social")
+        ),
+        v2_integration=SimpleNamespace(
+            get_enhanced_context=AsyncMock(return_value={"knowledge_context": "k"})
+        ),
+        jargon_query_service=SimpleNamespace(
+            check_and_explain_jargon=AsyncMock(return_value="jargon")
+        ),
+        temporary_persona_updater=SimpleNamespace(session_updates={"group-a": ["u"]}),
+        perf_tracker=perf_tracker,
+        group_id_to_unified_origin={},
+        db_manager=SimpleNamespace(
+            get_approved_few_shots=AsyncMock(return_value=["few-shot"])
+        ),
+    )
+    req = SimpleNamespace(prompt="你好", system_prompt="", extra_user_content_parts=[])
+
+    await handler.handle(SimpleNamespace(), req)
+
+    diversity.build_diversity_prompt_injection.assert_not_awaited()
+    perf_tracker.record.assert_not_called()
+    assert req.extra_user_content_parts == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -472,11 +472,65 @@ def test_fresh_jargon_miner_first_trigger_is_not_blocked_by_cooldown():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_message_pipeline_runs_expression_learning_without_realtime_mode():
+async def test_message_pipeline_skips_expression_learning_without_realtime_mode_by_default():
     config = SimpleNamespace(
         enable_jargon_learning=False,
         enable_expression_patterns=True,
         enable_realtime_learning=False,
+        enable_style_learning=False,
+        enable_goal_driven_chat=False,
+    )
+    collector = SimpleNamespace(collect_message=AsyncMock())
+    enhanced_interaction = SimpleNamespace(
+        update_conversation_context=AsyncMock(),
+    )
+    realtime_processor = SimpleNamespace(
+        process_expression_learning_background=AsyncMock(),
+        process_realtime_background=AsyncMock(),
+    )
+
+    pipeline = MessagePipeline(
+        plugin_config=config,
+        message_collector=collector,
+        enhanced_interaction=enhanced_interaction,
+        jargon_miner_manager=None,
+        jargon_statistical_filter=None,
+        v2_integration=None,
+        realtime_processor=realtime_processor,
+        group_orchestrator=SimpleNamespace(),
+        conversation_goal_manager=None,
+        affection_manager=SimpleNamespace(),
+        db_manager=SimpleNamespace(),
+    )
+
+    spawned = []
+
+    def spawn_now(coro):
+        task = asyncio.create_task(coro)
+        spawned.append(task)
+        return task
+
+    pipeline._spawn = spawn_now
+    event = SimpleNamespace(
+        get_sender_name=lambda: "User A",
+        get_platform_name=lambda: "test",
+    )
+
+    await pipeline.process_learning("group-a", "user-a", "这是表达学习消息", event)
+    await asyncio.gather(*spawned)
+
+    realtime_processor.process_expression_learning_background.assert_not_called()
+    realtime_processor.process_realtime_background.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_message_pipeline_can_run_expression_learning_when_explicitly_enabled():
+    config = SimpleNamespace(
+        enable_jargon_learning=False,
+        enable_expression_patterns=True,
+        enable_realtime_learning=False,
+        enable_realtime_expression_learning=True,
         enable_style_learning=False,
         enable_goal_driven_chat=False,
     )
@@ -591,6 +645,7 @@ async def test_message_pipeline_collects_to_database_and_triggers_learning_paths
         enable_jargon_learning=True,
         enable_expression_patterns=True,
         enable_realtime_learning=False,
+        enable_realtime_expression_learning=True,
         enable_style_learning=False,
         enable_goal_driven_chat=False,
     )
@@ -867,6 +922,7 @@ async def test_realtime_expression_learning_is_batch_gated():
         message_max_length=500,
         enable_expression_patterns=True,
         expression_learning_trigger_messages=10,
+        expression_learning_min_interval_seconds=0,
     )
     collector = SimpleNamespace(
         get_statistics=AsyncMock(
@@ -923,12 +979,74 @@ async def test_realtime_expression_learning_is_batch_gated():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_realtime_expression_learning_respects_min_interval():
+    config = SimpleNamespace(
+        message_min_length=1,
+        message_max_length=500,
+        enable_expression_patterns=True,
+        expression_learning_trigger_messages=1,
+        expression_learning_min_interval_seconds=3600,
+    )
+    collector = SimpleNamespace(
+        get_statistics=AsyncMock(return_value={"raw_messages": 10})
+    )
+    learner = SimpleNamespace(trigger_learning_for_group=AsyncMock(return_value=False))
+    factory_manager = SimpleNamespace(
+        get_component_factory=lambda: SimpleNamespace(
+            create_expression_pattern_learner=lambda: learner
+        )
+    )
+    db_manager = SimpleNamespace(
+        get_recent_raw_messages=AsyncMock(
+            return_value=[
+                {
+                    "id": idx,
+                    "sender_id": f"user-{idx}",
+                    "sender_name": f"User {idx}",
+                    "message": f"这是第{idx}条足够长的表达学习消息",
+                    "timestamp": time.time(),
+                    "platform": "test",
+                }
+                for idx in range(1, 6)
+            ]
+        )
+    )
+    processor = RealtimeProcessor(
+        plugin_config=config,
+        message_collector=collector,
+        multidimensional_analyzer=SimpleNamespace(),
+        persona_manager=SimpleNamespace(),
+        temporary_persona_updater=SimpleNamespace(),
+        dialog_analyzer=SimpleNamespace(),
+        learning_stats=SimpleNamespace(style_updates=0),
+        factory_manager=factory_manager,
+        db_manager=db_manager,
+    )
+
+    await processor.process_expression_learning(
+        "group-a",
+        "这是用于表达学习频控的消息",
+        "user-a",
+    )
+    await processor.process_expression_learning(
+        "group-a",
+        "这是用于表达学习频控的消息",
+        "user-a",
+    )
+
+    assert learner.trigger_learning_for_group.await_count == 1
+    assert collector.get_statistics.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_realtime_expression_learning_creates_review_without_persona_write():
     config = SimpleNamespace(
         message_min_length=1,
         message_max_length=500,
         enable_expression_patterns=True,
         expression_learning_trigger_messages=1,
+        expression_learning_min_interval_seconds=0,
     )
     collector = SimpleNamespace(
         get_statistics=AsyncMock(return_value={"raw_messages": 10})

--- a/web_res/static/html/change_password.html
+++ b/web_res/static/html/change_password.html
@@ -2,13 +2,179 @@
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/api/index">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SELF LEARNING 监控板</title>
+    <title>修改 WebUI 密码</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f6f7f9;
+            --panel: #ffffff;
+            --text: #20242a;
+            --muted: #606975;
+            --line: #d8dde5;
+            --accent: #2364aa;
+            --accent-hover: #184f87;
+            --danger: #b42318;
+            --danger-bg: #fff0ed;
+            --success: #067647;
+            --success-bg: #ecfdf3;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+            background: var(--bg);
+            color: var(--text);
+            font-family: "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+        }
+        main {
+            width: min(100%, 420px);
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            padding: 28px;
+            box-shadow: 0 14px 34px rgba(25, 35, 50, 0.09);
+        }
+        h1 {
+            margin: 0 0 6px;
+            font-size: 22px;
+            line-height: 1.25;
+            letter-spacing: 0;
+        }
+        p {
+            margin: 0 0 22px;
+            color: var(--muted);
+            font-size: 14px;
+        }
+        label {
+            display: block;
+            margin: 14px 0 8px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+        input {
+            width: 100%;
+            height: 42px;
+            border: 1px solid var(--line);
+            border-radius: 6px;
+            padding: 0 12px;
+            font: inherit;
+            color: var(--text);
+            background: #fff;
+        }
+        input:focus {
+            outline: 2px solid rgba(35, 100, 170, 0.16);
+            border-color: var(--accent);
+        }
+        button {
+            width: 100%;
+            height: 42px;
+            margin-top: 20px;
+            border: 0;
+            border-radius: 6px;
+            background: var(--accent);
+            color: #fff;
+            font: inherit;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button:hover { background: var(--accent-hover); }
+        button:disabled {
+            cursor: wait;
+            opacity: 0.7;
+        }
+        .message {
+            display: none;
+            margin-bottom: 14px;
+            padding: 10px 12px;
+            border-radius: 6px;
+            font-size: 13px;
+            line-height: 1.45;
+        }
+        .message.error {
+            display: block;
+            color: var(--danger);
+            background: var(--danger-bg);
+            border: 1px solid rgba(180, 35, 24, 0.24);
+        }
+        .message.success {
+            display: block;
+            color: var(--success);
+            background: var(--success-bg);
+            border: 1px solid rgba(6, 118, 71, 0.22);
+        }
+    </style>
 </head>
 <body>
+    <main>
+        <h1>修改 WebUI 密码</h1>
+        <p>首次开启密码后需要完成一次密码更新。</p>
+        <div id="message" class="message"></div>
+        <form id="change-form">
+            <label for="old-password">当前密码</label>
+            <input id="old-password" name="old_password" type="password" autocomplete="current-password" required>
+            <label for="new-password">新密码</label>
+            <input id="new-password" name="new_password" type="password" autocomplete="new-password" required>
+            <label for="confirm-password">确认新密码</label>
+            <input id="confirm-password" name="confirm_password" type="password" autocomplete="new-password" required>
+            <button id="submit" type="submit">保存密码</button>
+        </form>
+    </main>
     <script>
-        window.location.replace('/api/index');
+        const form = document.getElementById("change-form");
+        const message = document.getElementById("message");
+        const submit = document.getElementById("submit");
+        const oldPassword = document.getElementById("old-password");
+        const newPassword = document.getElementById("new-password");
+        const confirmPassword = document.getElementById("confirm-password");
+
+        function showMessage(text, type) {
+            message.textContent = text;
+            message.className = "message " + type;
+        }
+
+        form.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            message.className = "message";
+            if (newPassword.value !== confirmPassword.value) {
+                showMessage("两次输入的新密码不一致", "error");
+                confirmPassword.focus();
+                return;
+            }
+            submit.disabled = true;
+            submit.textContent = "保存中...";
+            try {
+                const response = await fetch("/api/plugin_change_password", {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({
+                        old_password: oldPassword.value,
+                        new_password: newPassword.value
+                    })
+                });
+                const data = await response.json();
+                if (response.ok) {
+                    showMessage(data.message || "密码修改成功", "success");
+                    setTimeout(() => {
+                        window.location.href = data.redirect || "/api/index";
+                    }, 900);
+                    return;
+                }
+                showMessage(data.error || "密码修改失败", "error");
+                oldPassword.value = "";
+                oldPassword.focus();
+            } catch (error) {
+                showMessage("网络连接失败，请稍后重试", "error");
+            } finally {
+                submit.disabled = false;
+                submit.textContent = "保存密码";
+            }
+        });
+
+        oldPassword.focus();
     </script>
 </body>
 </html>

--- a/web_res/static/html/dashboard.html
+++ b/web_res/static/html/dashboard.html
@@ -6527,6 +6527,21 @@
                             data-config-widget="${escapeHtml(field.widget)}"
                         >
                     `;
+                } else if (field.widget === 'password') {
+                    controlHtml = `
+                        <input
+                            id="${fieldId}"
+                            class="config-input"
+                            type="password"
+                            value=""
+                            autocomplete="new-password"
+                            placeholder="保存后不会回显"
+                            data-config-key="${escapeHtml(field.key)}"
+                            data-config-type="${escapeHtml(field.type)}"
+                            data-config-widget="${escapeHtml(field.widget)}"
+                            ${field.editable ? '' : 'disabled'}
+                        >
+                    `;
                 } else if (field.type === 'list') {
                     controlHtml = `
                         <textarea

--- a/web_res/static/html/login.html
+++ b/web_res/static/html/login.html
@@ -2,13 +2,154 @@
 <html lang="zh-CN">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=/api/index">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SELF LEARNING 监控板</title>
+    <title>SELF LEARNING 登录</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f6f7f9;
+            --panel: #ffffff;
+            --text: #20242a;
+            --muted: #606975;
+            --line: #d8dde5;
+            --accent: #2364aa;
+            --accent-hover: #184f87;
+            --danger: #b42318;
+            --danger-bg: #fff0ed;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+            background: var(--bg);
+            color: var(--text);
+            font-family: "Microsoft YaHei", "PingFang SC", Arial, sans-serif;
+        }
+        main {
+            width: min(100%, 380px);
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 8px;
+            padding: 28px;
+            box-shadow: 0 14px 34px rgba(25, 35, 50, 0.09);
+        }
+        h1 {
+            margin: 0 0 6px;
+            font-size: 22px;
+            line-height: 1.25;
+            letter-spacing: 0;
+        }
+        p {
+            margin: 0 0 24px;
+            color: var(--muted);
+            font-size: 14px;
+        }
+        label {
+            display: block;
+            margin-bottom: 8px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+        input {
+            width: 100%;
+            height: 42px;
+            border: 1px solid var(--line);
+            border-radius: 6px;
+            padding: 0 12px;
+            font: inherit;
+            color: var(--text);
+            background: #fff;
+        }
+        input:focus {
+            outline: 2px solid rgba(35, 100, 170, 0.16);
+            border-color: var(--accent);
+        }
+        button {
+            width: 100%;
+            height: 42px;
+            margin-top: 18px;
+            border: 0;
+            border-radius: 6px;
+            background: var(--accent);
+            color: #fff;
+            font: inherit;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button:hover { background: var(--accent-hover); }
+        button:disabled {
+            cursor: wait;
+            opacity: 0.7;
+        }
+        .message {
+            display: none;
+            margin-bottom: 16px;
+            padding: 10px 12px;
+            border-radius: 6px;
+            font-size: 13px;
+            line-height: 1.45;
+        }
+        .message.error {
+            display: block;
+            color: var(--danger);
+            background: var(--danger-bg);
+            border: 1px solid rgba(180, 35, 24, 0.24);
+        }
+    </style>
 </head>
 <body>
+    <main>
+        <h1>SELF LEARNING</h1>
+        <p>WebUI 控制台</p>
+        <div id="message" class="message"></div>
+        <form id="login-form">
+            <label for="password">登录密码</label>
+            <input id="password" name="password" type="password" autocomplete="current-password" required>
+            <button id="submit" type="submit">登录</button>
+        </form>
+    </main>
     <script>
-        window.location.replace('/api/index');
+        const form = document.getElementById("login-form");
+        const message = document.getElementById("message");
+        const submit = document.getElementById("submit");
+        const password = document.getElementById("password");
+
+        function showError(text) {
+            message.textContent = text || "登录失败，请检查密码";
+            message.className = "message error";
+        }
+
+        form.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            message.className = "message";
+            submit.disabled = true;
+            submit.textContent = "登录中...";
+            try {
+                const response = await fetch("/api/login", {
+                    method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify({password: password.value})
+                });
+                const data = await response.json();
+                if (response.ok) {
+                    window.location.href = data.redirect || "/api/index";
+                    return;
+                }
+                showError(data.error);
+                password.value = "";
+                password.focus();
+            } catch (error) {
+                showError("网络连接失败，请稍后重试");
+            } finally {
+                submit.disabled = false;
+                submit.textContent = "登录";
+            }
+        });
+
+        password.focus();
     </script>
 </body>
 </html>

--- a/webui/blueprints/auth.py
+++ b/webui/blueprints/auth.py
@@ -1,11 +1,13 @@
 """
-认证蓝图 - WebUI 免密访问
+认证蓝图 - WebUI 免密访问，可选启用登录密码
 """
 import os
-from quart import Blueprint, render_template, jsonify, redirect, url_for
+from quart import Blueprint, render_template, jsonify, redirect, request, session, url_for
 from astrbot.api import logger
 
-from ..middleware.auth import require_auth
+from ..dependencies import get_container
+from ..middleware.auth import is_authenticated, require_auth
+from ..services.auth_service import AuthService
 from ..utils.response import error_response
 
 _TEMPLATE_DIR = os.path.abspath(
@@ -16,52 +18,102 @@ auth_bp = Blueprint('auth', __name__, url_prefix='/api', template_folder=_TEMPLA
 
 
 @auth_bp.route("/")
+@require_auth
 async def read_root():
-    """根目录 - 免密渲染监控板。"""
+    """根目录 - 渲染监控板。"""
     return await render_template("dashboard.html")
 
 
 @auth_bp.route("/login", methods=["GET"])
 async def login_page():
-    """兼容旧入口：直接进入主界面。"""
-    return redirect(url_for('auth.read_root_index'))
+    """显示登录页面；免密模式下直接进入主界面。"""
+    auth_service = AuthService(get_container())
+    if not auth_service.is_password_enabled() or is_authenticated():
+        return redirect(url_for('auth.read_root_index'))
+    return await render_template("login.html")
 
 
 @auth_bp.route("/login", methods=["POST"])
 async def login():
-    """兼容旧接口：免密模式下直接返回成功。"""
+    """处理登录请求。"""
     try:
-        return jsonify({
-            "message": "Passwordless WebUI access granted",
-            "must_change": False,
-            "redirect": "/api/index"
-        }), 200
+        data = await request.get_json(silent=True) or {}
+        password = data.get("password", "")
+        client_ip = request.remote_addr or "unknown"
+
+        auth_service = AuthService(get_container())
+        success, message, extra_data = await auth_service.login(password, client_ip)
+        extra_data = extra_data or {}
+
+        if success:
+            if auth_service.is_password_enabled():
+                session["authenticated"] = True
+                session["must_change"] = bool(extra_data.get("must_change", False))
+                session.permanent = True
+            return jsonify({
+                "message": message,
+                "must_change": extra_data.get("must_change", False),
+                "redirect": extra_data.get("redirect", "/api/index"),
+            }), 200
+
+        response_data = {"error": message}
+        response_data.update(extra_data)
+        status_code = 429 if extra_data.get("locked") else 401
+        return jsonify(response_data), status_code
     except Exception as e:
         logger.error(f"登录处理失败: {e}", exc_info=True)
         return error_response(f"登录失败: {str(e)}", 500)
 
 
 @auth_bp.route("/index")
+@require_auth
 async def read_root_index():
-    """主页面 - 免密渲染监控板。"""
+    """主页面 - 渲染监控板。"""
+    auth_service = AuthService(get_container())
+    if auth_service.is_password_enabled() and auth_service.check_must_change_password():
+        return redirect(url_for('auth.change_password_page'))
     return await render_template("dashboard.html")
 
 
 @auth_bp.route("/plugin_change_password", methods=["GET"])
+@require_auth
 async def change_password_page():
-    """免密模式下不再提供修改密码页面。"""
-    return redirect(url_for('auth.read_root_index'))
+    """显示修改密码页面。"""
+    auth_service = AuthService(get_container())
+    if not auth_service.is_password_enabled():
+        return redirect(url_for('auth.read_root_index'))
+    return await render_template("change_password.html")
 
 
 @auth_bp.route("/plugin_change_password", methods=["POST"])
+@require_auth
 async def change_password():
-    """免密模式下禁用修改密码接口。"""
+    """处理修改密码请求。"""
     try:
+        auth_service = AuthService(get_container())
+        if not auth_service.is_password_enabled():
+            return jsonify({
+                "success": False,
+                "error": "WebUI 已启用免密访问，无需修改密码",
+                "redirect": "/api/index"
+            }), 410
+
+        data = await request.get_json(silent=True) or {}
+        success, message = await auth_service.change_password(
+            data.get("old_password", ""),
+            data.get("new_password", ""),
+        )
+        if success:
+            session["must_change"] = False
+            return jsonify({
+                "success": True,
+                "message": message,
+                "redirect": "/api/index",
+            }), 200
         return jsonify({
             "success": False,
-            "error": "WebUI 已启用免密访问，无需修改密码",
-            "redirect": "/api/index"
-        }), 410
+            "error": message,
+        }), 400
     except Exception as e:
         logger.error(f"修改密码失败: {e}", exc_info=True)
         return error_response(f"修改密码失败: {str(e)}", 500)
@@ -70,8 +122,15 @@ async def change_password():
 @auth_bp.route("/logout", methods=["POST"])
 @require_auth
 async def logout():
-    """免密模式下登出为兼容性 no-op。"""
+    """处理登出。"""
     try:
+        auth_service = AuthService(get_container())
+        if auth_service.is_password_enabled():
+            session.clear()
+            return jsonify({
+                "message": "Logged out successfully",
+                "redirect": "/api/login"
+            }), 200
         return jsonify({
             "message": "Passwordless WebUI stays open",
             "redirect": "/api/index"

--- a/webui/middleware/auth.py
+++ b/webui/middleware/auth.py
@@ -5,6 +5,7 @@ from functools import wraps
 from quart import jsonify, redirect, request, session, url_for
 
 from ..dependencies import get_container
+from ..services.auth_service import is_webui_password_enabled
 
 
 def _webui_password_enabled() -> bool:
@@ -12,7 +13,7 @@ def _webui_password_enabled() -> bool:
         config = get_container().plugin_config
     except Exception:
         return False
-    return getattr(config, "enable_webui_password", False) is True
+    return is_webui_password_enabled(config)
 
 
 def require_auth(f):

--- a/webui/middleware/auth.py
+++ b/webui/middleware/auth.py
@@ -2,16 +2,38 @@
 认证中间件
 """
 from functools import wraps
+from quart import jsonify, redirect, request, session, url_for
+
+from ..dependencies import get_container
+
+
+def _webui_password_enabled() -> bool:
+    try:
+        config = get_container().plugin_config
+    except Exception:
+        return False
+    return getattr(config, "enable_webui_password", False) is True
 
 
 def require_auth(f):
-    """Pack 分支 WebUI 使用免密访问，认证装饰器直接放行。"""
+    """要求认证；未开启 WebUI 密码时保持免密兼容。"""
     @wraps(f)
     async def decorated_function(*args, **kwargs):
-        return await f(*args, **kwargs)
+        if not _webui_password_enabled():
+            return await f(*args, **kwargs)
+        if session.get("authenticated"):
+            return await f(*args, **kwargs)
+        if request.method == "GET" and request.path in {"/api/", "/api/index"}:
+            return redirect(url_for("auth.login_page"))
+        return jsonify({
+            "error": "未认证，请先登录",
+            "redirect": "/api/login",
+        }), 401
     return decorated_function
 
 
 def is_authenticated() -> bool:
-    """Pack 分支 WebUI 始终视为已认证。"""
-    return True
+    """检查是否已认证；免密模式始终视为已认证。"""
+    if not _webui_password_enabled():
+        return True
+    return bool(session.get("authenticated"))

--- a/webui/services/auth_service.py
+++ b/webui/services/auth_service.py
@@ -26,11 +26,14 @@ except ImportError:
 
 logger = get_astrbot_logger("self_learning.webui.auth")
 PASSWORDLESS_PASSWORD_CONFIG = {"must_change": False}
-DEFAULT_WEBUI_PASSWORD = "self_learning_pwd"
-DEFAULT_PASSWORD_CONFIG = {
-    "password": DEFAULT_WEBUI_PASSWORD,
-    "must_change": True,
-}
+PASSWORD_SETUP_REQUIRED_CONFIG = {"must_change": False, "setup_required": True}
+INITIAL_WEBUI_PASSWORD_ENV_VAR = "ASTRBOT_WEBUI_INITIAL_PASSWORD"
+DEFAULT_PASSWORD_CONFIG = PASSWORDLESS_PASSWORD_CONFIG.copy()
+
+
+def is_webui_password_enabled(plugin_config) -> bool:
+    """Return whether WebUI password auth is explicitly enabled."""
+    return getattr(plugin_config, "enable_webui_password", False) is True
 
 
 def hash_password_with_salt(password: str) -> Dict[str, Any]:
@@ -64,7 +67,40 @@ class AuthService:
 
     def is_password_enabled(self) -> bool:
         """Return whether WebUI password auth is explicitly enabled."""
-        return getattr(self.plugin_config, "enable_webui_password", False) is True
+        return is_webui_password_enabled(self.plugin_config)
+
+    def _configured_initial_password(self) -> str:
+        config_password = getattr(self.plugin_config, "webui_initial_password", "")
+        if isinstance(config_password, str) and config_password.strip():
+            return config_password.strip()
+        return os.getenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "").strip()
+
+    def _build_initial_password_config(self) -> Dict[str, Any]:
+        initial_password = self._configured_initial_password()
+        if not initial_password:
+            logger.warning(
+                "WebUI 密码已启用，但未配置初始密码。请在设置页填写 WebUI "
+                f"初始密码，或设置环境变量 {INITIAL_WEBUI_PASSWORD_ENV_VAR}。"
+            )
+            return PASSWORD_SETUP_REQUIRED_CONFIG.copy()
+        return {
+            "password": initial_password,
+            "must_change": True,
+        }
+
+    def has_password_config(self) -> bool:
+        """Return whether a persisted or in-memory password secret exists."""
+        config_attr = getattr(self.plugin_config, 'password_config', None) if self.plugin_config else None
+        if isinstance(config_attr, dict) and (
+            config_attr.get("password_hash") or config_attr.get("password")
+        ):
+            return True
+
+        if not self._should_persist_password_file():
+            return False
+
+        password_file = self.get_password_file_path()
+        return os.path.exists(password_file)
 
     def get_password_file_path(self) -> str:
         """获取密码文件路径"""
@@ -98,7 +134,11 @@ class AuthService:
         password_file = self.get_password_file_path()
         if not self._should_persist_password_file():
             logger.debug("跳过密码文件读取：plugin_config 未提供有效 data_dir")
-            return DEFAULT_PASSWORD_CONFIG.copy()
+            return (
+                self._build_initial_password_config()
+                if self.is_password_enabled()
+                else PASSWORDLESS_PASSWORD_CONFIG.copy()
+            )
 
         try:
             if os.path.exists(password_file):
@@ -110,9 +150,9 @@ class AuthService:
             else:
                 if self.is_password_enabled():
                     logger.warning(
-                        f"密码配置文件不存在: {password_file}，使用默认初始密码"
+                        f"密码配置文件不存在: {password_file}，等待显式初始密码"
                     )
-                    config = DEFAULT_PASSWORD_CONFIG.copy()
+                    config = self._build_initial_password_config()
                 else:
                     logger.debug(f"密码配置文件不存在: {password_file}，使用免密配置")
                     config = PASSWORDLESS_PASSWORD_CONFIG.copy()
@@ -121,12 +161,41 @@ class AuthService:
         except Exception as e:
             logger.error(f"加载密码配置失败: {e}", exc_info=True)
             config = (
-                DEFAULT_PASSWORD_CONFIG.copy()
+                self._build_initial_password_config()
                 if self.is_password_enabled()
                 else PASSWORDLESS_PASSWORD_CONFIG.copy()
             )
             self._password_config = config
             return config
+
+    def configure_password(self, password: str, *, must_change: bool = False) -> Tuple[bool, str]:
+        """Persist a new WebUI password as a hash."""
+        password = SecurityValidator.sanitize_input(password, max_length=128)
+        if not password:
+            return False, "密码不能为空"
+
+        strength_result = SecurityValidator.validate_password_strength(password)
+        if not strength_result["valid"]:
+            issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
+            return False, issues
+
+        password_hash, salt = PasswordHasher.hash_password(password)
+        new_config = {
+            "password_hash": password_hash,
+            "salt": salt,
+            "must_change": must_change,
+            "version": 2,
+            "last_changed": time.time(),
+        }
+        if self.save_password_config(new_config):
+            if self.plugin_config is not None and hasattr(self.plugin_config, "webui_initial_password"):
+                try:
+                    setattr(self.plugin_config, "webui_initial_password", "")
+                except Exception:
+                    logger.debug("无法清空 webui_initial_password", exc_info=True)
+            logger.info("WebUI 密码已配置")
+            return True, "密码配置成功"
+        return False, "保存密码配置失败"
 
     def save_password_config(self, config: Dict[str, Any]) -> bool:
         """
@@ -181,9 +250,12 @@ class AuthService:
                 "redirect": "/api/index",
             }
 
-        password = SecurityValidator.sanitize_input(password, max_length=128)
-        if not password:
-            return False, "密码不能为空", None
+        password_config = self.load_password_config()
+        if password_config.get("setup_required"):
+            return False, (
+                "WebUI 密码已启用但尚未配置初始密码，请在设置页填写 WebUI 初始密码，"
+                f"或设置环境变量 {INITIAL_WEBUI_PASSWORD_ENV_VAR}"
+            ), {"setup_required": True}
 
         is_locked, remaining_time = login_attempt_tracker.is_locked(client_ip)
         if is_locked:
@@ -193,7 +265,10 @@ class AuthService:
                 "remaining_time": remaining_time,
             }
 
-        password_config = self.load_password_config()
+        password = SecurityValidator.sanitize_input(password, max_length=128)
+        if not password:
+            return False, "密码不能为空", None
+
         is_valid, updated_config = verify_password_with_migration(
             password,
             password_config,
@@ -252,6 +327,9 @@ class AuthService:
             return False, "旧密码和新密码不能为空"
 
         password_config = self.load_password_config()
+        if password_config.get("setup_required"):
+            return False, "WebUI 尚未配置初始密码，无法修改密码"
+
         is_valid, updated_config = verify_password_with_migration(
             old_password,
             password_config,
@@ -269,19 +347,11 @@ class AuthService:
             issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
             return False, issues
 
-        password_hash, salt = PasswordHasher.hash_password(new_password)
-        new_config = {
-            "password_hash": password_hash,
-            "salt": salt,
-            "must_change": False,
-            "version": 2,
-            "last_changed": time.time(),
-        }
-
-        if self.save_password_config(new_config):
+        success, message = self.configure_password(new_password, must_change=False)
+        if success:
             logger.info("WebUI 密码已更新")
             return True, "密码修改成功"
-        return False, "保存密码配置失败"
+        return False, message
 
     def check_must_change_password(self) -> bool:
         """

--- a/webui/services/auth_service.py
+++ b/webui/services/auth_service.py
@@ -3,24 +3,34 @@
 """
 import os
 import json
+import time
 from typing import Tuple, Dict, Any, Optional
 
 try:
     from ...utils.logging_utils import get_astrbot_logger
     from ...utils.security_utils import (
         PasswordHasher,
+        login_attempt_tracker,
         SecurityValidator,
+        verify_password_with_migration,
     )
 except ImportError:
     from utils.logging_utils import get_astrbot_logger
     from utils.security_utils import (
         PasswordHasher,
+        login_attempt_tracker,
         SecurityValidator,
+        verify_password_with_migration,
     )
 
 
 logger = get_astrbot_logger("self_learning.webui.auth")
-DEFAULT_PASSWORD_CONFIG = {"must_change": False}
+PASSWORDLESS_PASSWORD_CONFIG = {"must_change": False}
+DEFAULT_WEBUI_PASSWORD = "self_learning_pwd"
+DEFAULT_PASSWORD_CONFIG = {
+    "password": DEFAULT_WEBUI_PASSWORD,
+    "must_change": True,
+}
 
 
 def hash_password_with_salt(password: str) -> Dict[str, Any]:
@@ -52,6 +62,10 @@ class AuthService:
         self.plugin_config = container.plugin_config
         self._password_config: Optional[Dict[str, Any]] = None
 
+    def is_password_enabled(self) -> bool:
+        """Return whether WebUI password auth is explicitly enabled."""
+        return getattr(self.plugin_config, "enable_webui_password", False) is True
+
     def get_password_file_path(self) -> str:
         """获取密码文件路径"""
         data_dir = getattr(self.plugin_config, 'data_dir', None) if self.plugin_config else None
@@ -77,7 +91,7 @@ class AuthService:
             return self._password_config
 
         config_attr = getattr(self.plugin_config, 'password_config', None) if self.plugin_config else None
-        if isinstance(config_attr, dict):
+        if isinstance(config_attr, dict) and (config_attr or not self.is_password_enabled()):
             self._password_config = config_attr
             return config_attr
 
@@ -94,11 +108,25 @@ class AuthService:
                     self._password_config = config
                     return config
             else:
-                logger.warning(f"密码配置文件不存在: {password_file}，使用免密配置")
-                return DEFAULT_PASSWORD_CONFIG.copy()
+                if self.is_password_enabled():
+                    logger.warning(
+                        f"密码配置文件不存在: {password_file}，使用默认初始密码"
+                    )
+                    config = DEFAULT_PASSWORD_CONFIG.copy()
+                else:
+                    logger.debug(f"密码配置文件不存在: {password_file}，使用免密配置")
+                    config = PASSWORDLESS_PASSWORD_CONFIG.copy()
+                self._password_config = config
+                return config
         except Exception as e:
             logger.error(f"加载密码配置失败: {e}", exc_info=True)
-            return DEFAULT_PASSWORD_CONFIG.copy()
+            config = (
+                DEFAULT_PASSWORD_CONFIG.copy()
+                if self.is_password_enabled()
+                else PASSWORDLESS_PASSWORD_CONFIG.copy()
+            )
+            self._password_config = config
+            return config
 
     def save_password_config(self, config: Dict[str, Any]) -> bool:
         """
@@ -137,7 +165,7 @@ class AuthService:
 
     async def login(self, password: str, client_ip: str) -> Tuple[bool, str, Optional[Dict[str, Any]]]:
         """
-        处理用户登录。pack 分支 WebUI 为免密访问，保留该方法仅兼容旧调用。
+        处理用户登录。默认免密；启用 WebUI 密码后执行校验。
 
         Args:
             password: 用户输入的密码
@@ -146,11 +174,58 @@ class AuthService:
         Returns:
             Tuple[bool, str, Optional[Dict]]: (是否成功, 消息, 额外数据)
         """
-        logger.debug(f"WebUI免密登录放行: client_ip={client_ip}")
-        return True, "Passwordless WebUI access granted", {
-            "must_change": False,
-            "redirect": "/api/index",
-        }
+        if not self.is_password_enabled():
+            logger.debug(f"WebUI免密登录放行: client_ip={client_ip}")
+            return True, "Passwordless WebUI access granted", {
+                "must_change": False,
+                "redirect": "/api/index",
+            }
+
+        password = SecurityValidator.sanitize_input(password, max_length=128)
+        if not password:
+            return False, "密码不能为空", None
+
+        is_locked, remaining_time = login_attempt_tracker.is_locked(client_ip)
+        if is_locked:
+            logger.warning(f"IP {client_ip} 被锁定，剩余 {remaining_time} 秒")
+            return False, f"登录尝试次数过多，请在 {remaining_time} 秒后重试", {
+                "locked": True,
+                "remaining_time": remaining_time,
+            }
+
+        password_config = self.load_password_config()
+        is_valid, updated_config = verify_password_with_migration(
+            password,
+            password_config,
+        )
+
+        if is_valid:
+            if updated_config != password_config:
+                self.save_password_config(updated_config)
+                password_config = updated_config
+
+            login_attempt_tracker.record_attempt(client_ip, success=True)
+            must_change = bool(password_config.get("must_change", False))
+            redirect = "/api/plugin_change_password" if must_change else "/api/index"
+            message = (
+                "Login successful, but password must be changed"
+                if must_change
+                else "Login successful"
+            )
+            return True, message, {
+                "must_change": must_change,
+                "redirect": redirect,
+            }
+
+        login_attempt_tracker.record_attempt(client_ip, success=False)
+        remaining_attempts = login_attempt_tracker.get_remaining_attempts(client_ip)
+        logger.warning(f"IP {client_ip} 登录失败，剩余尝试次数: {remaining_attempts}")
+
+        error_msg = "密码错误"
+        if remaining_attempts <= 2:
+            error_msg = f"密码错误，还剩 {remaining_attempts} 次尝试机会"
+
+        return False, error_msg, {"remaining_attempts": remaining_attempts}
 
     async def change_password(
         self,
@@ -167,7 +242,46 @@ class AuthService:
         Returns:
             Tuple[bool, str]: (是否成功, 消息)
         """
-        return False, "WebUI 已启用免密访问，无需修改密码"
+        if not self.is_password_enabled():
+            return False, "WebUI 已启用免密访问，无需修改密码"
+
+        old_password = SecurityValidator.sanitize_input(old_password, max_length=128)
+        new_password = SecurityValidator.sanitize_input(new_password, max_length=128)
+
+        if not old_password or not new_password:
+            return False, "旧密码和新密码不能为空"
+
+        password_config = self.load_password_config()
+        is_valid, updated_config = verify_password_with_migration(
+            old_password,
+            password_config,
+        )
+        if not is_valid:
+            return False, "当前密码错误"
+        if updated_config != password_config:
+            self.save_password_config(updated_config)
+
+        if old_password == new_password:
+            return False, "新密码不能与当前密码相同"
+
+        strength_result = SecurityValidator.validate_password_strength(new_password)
+        if not strength_result["valid"]:
+            issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
+            return False, issues
+
+        password_hash, salt = PasswordHasher.hash_password(new_password)
+        new_config = {
+            "password_hash": password_hash,
+            "salt": salt,
+            "must_change": False,
+            "version": 2,
+            "last_changed": time.time(),
+        }
+
+        if self.save_password_config(new_config):
+            logger.info("WebUI 密码已更新")
+            return True, "密码修改成功"
+        return False, "保存密码配置失败"
 
     def check_must_change_password(self) -> bool:
         """
@@ -176,4 +290,6 @@ class AuthService:
         Returns:
             bool: 是否需要强制修改
         """
-        return False
+        if not self.is_password_enabled():
+            return False
+        return bool(self.load_password_config().get("must_change", False))

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -12,6 +12,12 @@ from typing import Any, Dict, List, Optional, Tuple
 from astrbot.api import logger
 from pydantic import ValidationError
 
+from .auth_service import (
+    AuthService,
+    INITIAL_WEBUI_PASSWORD_ENV_VAR,
+    validate_password_strength,
+)
+
 try:
     from ...statics.messages import FileNames
     from ...utils.logging_utils import apply_astrbot_log_level
@@ -438,6 +444,12 @@ class ConfigService:
         }
         if not known_config:
             return False
+        initial_webui_password = ""
+        if "webui_initial_password" in known_config:
+            initial_webui_password = str(
+                known_config.get("webui_initial_password") or ""
+            ).strip()
+            known_config["webui_initial_password"] = ""
 
         original_config = self.plugin_config.to_dict()
         changed_keys = [
@@ -467,10 +479,27 @@ class ConfigService:
                 self.plugin_config.data_dir, FileNames.LEARNING_LOG_FILE
             )
 
+        if (
+            initial_webui_password
+            and getattr(self.plugin_config, "enable_webui_password", False) is True
+        ):
+            strength_result = validate_password_strength(initial_webui_password)
+            if strength_result["valid"]:
+                password_success, password_message = AuthService(self.container).configure_password(
+                    initial_webui_password,
+                    must_change=False,
+                )
+                if not password_success:
+                    logger.warning(f"AstrBot 插件页 WebUI 初始密码保存失败: {password_message}")
+            else:
+                issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
+                logger.warning(f"AstrBot 插件页 WebUI 初始密码无效: {issues}")
+
         self._sync_runtime_components(changed_keys)
         config_file = self._get_config_file_path()
         if not self.plugin_config.save_to_file(config_file):
             logger.warning("AstrBot 插件页配置已同步到内存，但写入 WebUI 配置文件失败")
+        self._sync_astrbot_group_config(self.plugin_config, list(known_config))
 
         logger.info(
             "AstrBot 插件页配置已同步到 WebUI: "
@@ -871,6 +900,8 @@ class ConfigService:
         widget = "text"
         if raw_spec.get("_readonly"):
             widget = "readonly"
+        elif raw_spec.get("_secret"):
+            widget = "password"
         elif raw_spec.get("_special") == "select_provider" or key.endswith("_provider_id"):
             widget = "provider"
         elif key in _ENUM_FIELD_OPTIONS:
@@ -896,9 +927,12 @@ class ConfigService:
             "default": default_value,
             "value": value,
             "editable": not raw_spec.get("_readonly", False),
+            "secret": bool(raw_spec.get("_secret")),
             "nullable": default_value is None or raw_spec.get("_nullable", False) or key.endswith("_provider_id"),
             "restart_required": key in _RESTART_REQUIRED_KEYS,
         }
+        if raw_spec.get("_secret"):
+            field_spec["value"] = ""
 
         if field_type == "list":
             items_spec = raw_spec.get("items", {})
@@ -1041,6 +1075,11 @@ class ConfigService:
                     break
 
         flat_config = self._flatten_payload(payload if isinstance(payload, dict) else {})
+        initial_webui_password = ""
+        if "webui_initial_password" in flat_config:
+            initial_webui_password = str(flat_config.get("webui_initial_password") or "").strip()
+            flat_config["webui_initial_password"] = ""
+
         original_config = self.plugin_config.to_dict()
         merged_config = dict(original_config)
         changed_keys: List[str] = []
@@ -1071,6 +1110,28 @@ class ConfigService:
         if provider_error in "；".join(blocking_errors):
             warnings.append("至少需要配置一个模型提供商ID，系统将继续依赖 AstrBot 的自动兜底 Provider 选择")
 
+        auth_service = AuthService(self.container)
+        password_enabled = getattr(validated_config, "enable_webui_password", False) is True
+        if initial_webui_password and not password_enabled:
+            return False, "设置 WebUI 初始密码前请先启用 WebUI 登录密码", original_config
+
+        if initial_webui_password:
+            strength_result = validate_password_strength(initial_webui_password)
+            if not strength_result["valid"]:
+                issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
+                return False, issues, original_config
+
+        if (
+            password_enabled
+            and not initial_webui_password
+            and not auth_service.has_password_config()
+            and not os.getenv(INITIAL_WEBUI_PASSWORD_ENV_VAR, "").strip()
+        ):
+            return False, (
+                "开启 WebUI 登录密码前，请填写 WebUI 一次性初始密码，"
+                f"或设置环境变量 {INITIAL_WEBUI_PASSWORD_ENV_VAR}"
+            ), original_config
+
         for field_name, value in validated_config.model_dump().items():
             if hasattr(self.plugin_config, field_name):
                 setattr(self.plugin_config, field_name, value)
@@ -1092,9 +1153,17 @@ class ConfigService:
                 self.plugin_config.data_dir, FileNames.LEARNING_LOG_FILE
             )
 
+        if initial_webui_password:
+            password_success, password_message = AuthService(self.container).configure_password(
+                initial_webui_password,
+                must_change=False,
+            )
+            if not password_success:
+                return False, password_message, original_config
+
         self._sync_runtime_components(changed_keys)
         astrbot_config_synced = self._sync_astrbot_group_config(
-            validated_config,
+            self.plugin_config,
             list(flat_config),
         )
 

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -55,6 +55,12 @@ _EXTRA_SCHEMA_DEFINITION: Dict[str, Dict[str, Any]] = {
                 "hint": "学习并维护群聊中的表达模式和常见句式",
                 "default": True,
             },
+            "enable_realtime_expression_learning": {
+                "description": "实时表达方式学习",
+                "type": "bool",
+                "hint": "实时学习关闭时，是否仍按消息增量触发表达方式学习。默认关闭以避免旁听群聊时产生高频 LLM 调用和审查记录",
+                "default": False,
+            },
             "enable_memory_graph": {
                 "description": "启用记忆图系统",
                 "type": "bool",
@@ -142,6 +148,12 @@ _EXTRA_SCHEMA_DEFINITION: Dict[str, Dict[str, Any]] = {
                     {"value": "system_prompt", "label": "system_prompt"},
                     {"value": "prompt", "label": "prompt"},
                 ],
+            },
+            "enable_llm_hooks": {
+                "description": "启用 LLM Hook 上下文注入",
+                "type": "bool",
+                "hint": "开启后每次回复前会并行拉取社交、记忆、黑话、few-shot 等上下文；默认关闭以避免高频模型调用",
+                "default": False,
             },
             "use_sqlalchemy": {
                 "description": "强制使用 SQLAlchemy ORM",


### PR DESCRIPTION
## Summary
- Fixes #192 by keeping realtime expression learning disabled unless explicitly enabled, and adding a per-group expression-learning cooldown.
- Disables LLM Hook context injection by default behind `enable_llm_hooks` to avoid high-frequency model calls when realtime LLM filtering is off.
- Adds optional WebUI password auth in settings, default off; when enabled, the initial password is `self_learning_pwd` and the user is forced to change it.

## Tests
- `python -m json.tool _conf_schema.json > $null`
- `python -m py_compile config.py services\learning\message_pipeline.py services\learning\realtime_processor.py services\hooks\llm_hook_handler.py webui\services\auth_service.py webui\middleware\auth.py webui\blueprints\auth.py webui\services\config_service.py`
- `python -m pytest -q tests\unit\test_learning_chain_regressions.py tests\unit\test_feature_delegation.py tests\unit\test_config.py tests\unit\test_config_service.py tests\unit\test_auth_service.py tests\integration\test_auth_blueprint.py tests\integration\test_webui_static_assets.py -o cache_dir=.tmp\pytest-cache --basetemp=.tmp\pytest-issue-192-final` (`142 passed, 2 warnings`)
- Real plugin directory `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning`: py_compile, json schema validation, import smoke, and WebUI/auth/config static subset (`105 passed, 2 warnings`). Two learning-chain tests are package-name bound to `self_learning_EterU` and do not collect from the real plugin package name `astrbot_plugin_self_learning`.

## Summary by Sourcery

Tighten realtime learning and LLM hook behavior to avoid unintended high-frequency model calls, and add optional WebUI password authentication with supporting UI, routing, and configuration changes.

New Features:
- Introduce an optional WebUI password login flow with configurable enable flag, default password, and forced initial password change.
- Expose configuration toggles for WebUI password auth, realtime expression learning, and LLM hook context injection in the plugin config and WebUI schema.

Bug Fixes:
- Ensure expression learning is skipped when realtime learning is disabled by default, unless explicitly re-enabled, and gate it with a per-group cooldown interval.
- Disable LLM Hook context injection by default so that context-fetching calls are only made when explicitly enabled.

Enhancements:
- Add rate limiting and lockout handling for WebUI login attempts and enforce password strength and migration on change.
- Extend realtime expression learning with per-group minimum-interval throttling to reduce redundant learning runs.
- Update WebUI auth middleware and blueprint to respect passwordless vs password modes while keeping backward compatibility.
- Replace placeholder redirect-only HTML login/change-password pages with functional, styled forms that call the new auth APIs.

Tests:
- Expand unit and integration tests for auth flows, config handling, LLM hook behavior, and realtime expression learning to cover the new flags and cooldown logic.