### PR TITLE
fix: SQLite upsert race condition in save_or_update_jargon

### DIFF
--- a/services/database/facades/jargon_facade.py
+++ b/services/database/facades/jargon_facade.py
@@ -670,54 +670,69 @@ class JargonFacade(BaseFacade):
                     jargon_data,
                 )
 
-            async with self.get_session() as session:
+            # SQLite 路径：使用 SELECT→INSERT/UPDATE 模式，
+            # 并在 INSERT 因并发竞争触发 UNIQUE 约束时自动重试一次，
+            # 使重试的 SELECT 能命中另一请求刚提交的记录，走 UPDATE 分支。
+            max_attempts = 2
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    async with self.get_session() as session:
 
-                stmt = select(Jargon).where(and_(
-                    Jargon.chat_id == chat_id,
-                    Jargon.content == content,
-                ))
-                result = await session.execute(stmt)
-                record = result.scalars().first()
+                        stmt = select(Jargon).where(and_(
+                            Jargon.chat_id == chat_id,
+                            Jargon.content == content,
+                        ))
+                        result = await session.execute(stmt)
+                        record = result.scalars().first()
 
-                now_ts = self._coerce_jargon_timestamp()
+                        now_ts = self._coerce_jargon_timestamp()
 
-                if record:
-                    # 更新已有记录
-                    if 'meaning' in jargon_data:
-                        record.meaning = jargon_data['meaning']
-                    if 'raw_content' in jargon_data:
-                        record.raw_content = jargon_data['raw_content']
-                    if 'is_jargon' in jargon_data:
-                        record.is_jargon = jargon_data['is_jargon']
-                    if 'count' in jargon_data:
-                        record.count = jargon_data['count']
-                    if 'last_inference_count' in jargon_data:
-                        record.last_inference_count = jargon_data['last_inference_count']
-                    if 'is_complete' in jargon_data:
-                        record.is_complete = jargon_data['is_complete']
-                    if 'is_global' in jargon_data:
-                        record.is_global = jargon_data['is_global']
-                    record.updated_at = now_ts
+                        if record:
+                            # 更新已有记录
+                            if 'meaning' in jargon_data:
+                                record.meaning = jargon_data['meaning']
+                            if 'raw_content' in jargon_data:
+                                record.raw_content = jargon_data['raw_content']
+                            if 'is_jargon' in jargon_data:
+                                record.is_jargon = jargon_data['is_jargon']
+                            if 'count' in jargon_data:
+                                record.count = jargon_data['count']
+                            if 'last_inference_count' in jargon_data:
+                                record.last_inference_count = jargon_data['last_inference_count']
+                            if 'is_complete' in jargon_data:
+                                record.is_complete = jargon_data['is_complete']
+                            if 'is_global' in jargon_data:
+                                record.is_global = jargon_data['is_global']
+                            record.updated_at = now_ts
 
-                    await session.commit()
-                    self._logger.debug(
-                        f"[JargonFacade] 更新黑话: content='{content}', chat_id={chat_id}, "
-                        f"id={record.id}"
-                    )
-                    return record.id
-                else:
-                    # 插入新记录
-                    new_record = Jargon(
-                        **self._jargon_insert_values(chat_id, content, jargon_data, now_ts)
-                    )
-                    session.add(new_record)
-                    await session.commit()
-                    await session.refresh(new_record)
-                    self._logger.debug(
-                        f"[JargonFacade] 插入黑话: content='{content}', chat_id={chat_id}, "
-                        f"id={new_record.id}"
-                    )
-                    return new_record.id
+                            await session.commit()
+                            self._logger.debug(
+                                f"[JargonFacade] 更新黑话: content='{content}', chat_id={chat_id}, "
+                                f"id={record.id}"
+                            )
+                            return record.id
+                        else:
+                            # 插入新记录
+                            new_record = Jargon(
+                                **self._jargon_insert_values(chat_id, content, jargon_data, now_ts)
+                            )
+                            session.add(new_record)
+                            await session.commit()
+                            await session.refresh(new_record)
+                            self._logger.debug(
+                                f"[JargonFacade] 插入黑话: content='{content}', chat_id={chat_id}, "
+                                f"id={new_record.id}"
+                            )
+                            return new_record.id
+                except IntegrityError:
+                    if attempt < max_attempts:
+                        self._logger.debug(
+                            f"[JargonFacade] 并发竞争导致 UNIQUE 冲突，重试 "
+                            f"(content='{content}', chat_id={chat_id}, attempt={attempt})"
+                        )
+                        continue
+                    # 最后一次尝试也失败，向上抛出
+                    raise
 
         except Exception as e:
             self._logger.error(


### PR DESCRIPTION
Description:

  Wrap the SELECT→INSERT/UPDATE logic in a retry loop so that when
  concurrent requests trigger a UNIQUE constraint violation on INSERT,
  the retry finds the record the other request just committed and takes
  the UPDATE path instead.

  Fixes: sqlite3.IntegrityError: UNIQUE constraint failed: jargon.chat_id, jargon.content

  ## Summary

  修复 `save_or_update_jargon` 在 SQLite 模式下的并发竞争问题。当多个请求同时触发同一个 `(chat_id, content)`
  黑话词汇时，原逻辑因 TOCTOU 竞争导致重复 INSERT 并抛出 `IntegrityError`。通过捕获异常并重试一次，使重试的 SELECT
  能命中并发请求刚提交的记录并走 UPDATE 分支。

  ## Changes

  - 在 SQLite 路径的 SELECT→INSERT/UPDATE 逻辑外层增加重试循环（最多 2 次）
  - 捕获 `IntegrityError` 后自动重试，重试时 SELECT 可命中已提交记录并走 UPDATE
  - 添加并发竞争时的 debug 日志，便于排查

  ## Related Issues

  <!-- Closes #204  -->

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactoring (no functional changes)
  - [ ] Documentation update
  - [ ] Other: <!-- describe -->

  ## Checklist

  - [ ] Code follows the project's coding style
  - [ ] Self-reviewed the code changes
  - [ ] No new warnings or errors introduced
  - [ ] Tested on SQLite mode
  - [ ] Tested on MySQL mode (if applicable)

  ---

## Summary by Sourcery

Handle concurrent upserts of jargon records in SQLite without raising UNIQUE constraint errors.

Bug Fixes:
- Wrap the SQLite SELECT→INSERT/UPDATE jargon upsert logic in a bounded retry loop to avoid IntegrityError on concurrent INSERTs.

Enhancements:
- Add debug logging when SQLite upsert retries due to UNIQUE constraint conflicts to aid diagnosing concurrency issues.