### PR TITLE
fix: embedded page batch operations, jargon re-learn overwrite, and UI polish

### DIFF
--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -1302,7 +1302,7 @@
       const item = (state.pageData.lastJargonItems || []).find((entry) => String(entry.id) === String(id)) || {};
       showModal(t("modal.editJargon", "编辑黑话"), `
         <label class="config-field"><span><strong>${escapeHtml(t("jargon.term", "词条"))}</strong></span><input id="modal-jargon-content" value="${escapeAttr(item.term || item.content || "")}"></label>
-        <label class="config-field"><span><strong>${escapeHtml(t("jargon.definition", "释义"))}</strong></span><textarea id="modal-jargon-meaning" rows="4">${escapeHtml(item.meaning || item.definition || "")}</textarea></label>
+        <label class="config-field"><span><strong>${escapeHtml(t("jargon.definition", "释义"))}</strong></span><textarea id="modal-jargon-meaning" rows="10">${escapeHtml(item.meaning || item.definition || "")}</textarea></label>
         <button class="solid-button" type="button" id="modal-jargon-save" data-id="${escapeAttr(id)}">${escapeHtml(t("actions.save", "保存"))}</button>
       `);
       return;

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -712,8 +712,8 @@
         ${pill(item.is_global ? t("jargon.global", "全局") : t("jargon.local", "本地"))}
         <div class="row-actions">
           ${button(t("actions.edit", "编辑"), `data-jargon-action="edit" data-id="${escapeAttr(item.id)}"`)}
-          ${button(t("actions.confirm", "确认"), `data-jargon-action="approve" data-id="${escapeAttr(item.id)}"`)}
-          ${button(t("actions.reject", "驳回"), `data-jargon-action="reject" data-id="${escapeAttr(item.id)}"`)}
+          ${item.is_confirmed ? "" : button(t("actions.confirm", "确认"), `data-jargon-action="approve" data-id="${escapeAttr(item.id)}"`, "solid-button")}
+          ${item.is_confirmed ? "" : button(t("actions.reject", "驳回"), `data-jargon-action="reject" data-id="${escapeAttr(item.id)}"`)}
           ${button(item.is_global ? t("actions.unsetGlobal", "取消全局") : t("actions.setGlobal", "设为全局"), `data-jargon-action="toggle_global" data-id="${escapeAttr(item.id)}"`)}
           ${button(t("actions.delete", "删除"), `data-jargon-action="delete" data-id="${escapeAttr(item.id)}"`, "danger-button")}
         </div>

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -408,6 +408,34 @@
     else modal.removeAttribute("open");
   }
 
+  function showConfirm(title, message, confirmText) {
+    return new Promise((resolve) => {
+      const modal = $("detail-modal");
+      if (!modal) { resolve(window.confirm(message)); return; }
+      setText("modal-title", title);
+      setHtml("modal-body", `
+        <p style="margin:0 0 16px;line-height:1.6">${escapeHtml(message)}</p>
+        <div style="display:flex;gap:8px;justify-content:flex-end">
+          <button class="ghost-button" type="button" id="confirm-cancel">${escapeHtml(t("actions.cancel", "取消"))}</button>
+          <button class="solid-button" type="button" id="confirm-ok">${escapeHtml(confirmText || t("actions.confirm", "确定"))}</button>
+        </div>
+      `);
+      const done = (result) => {
+        if (typeof modal.close === "function") modal.close();
+        else modal.removeAttribute("open");
+        resolve(result);
+      };
+      $("confirm-ok").addEventListener("click", () => done(true), { once: true });
+      $("confirm-cancel").addEventListener("click", () => done(false), { once: true });
+      $("modal-close").addEventListener("click", () => done(false), { once: true });
+      modal.addEventListener("cancel", (e) => { e.preventDefault(); done(false); }, { once: true });
+      if (typeof modal.showModal === "function") {
+        try { modal.showModal(); return; } catch (_) {}
+      }
+      modal.setAttribute("open", "");
+    });
+  }
+
   function resolvePageFromHash() {
     const raw = window.location.hash.replace(/^#\/?/, "");
     return PAGE_META[raw] ? raw : "home";
@@ -1095,11 +1123,11 @@
     const typeText = { persona: t("reviews.personaUpdates", "人格更新"), style: t("reviews.expressionReviews", "表达审查"), jargon: t("reviews.jargonCandidates", "黑话候选") }[kind] || t("reviews.items", "审查项");
     const actionText = action === "approve" ? t("actions.pass", "通过") : action === "reject" ? t("actions.reject", "拒绝") : t("actions.delete", "删除");
     const scopeText = selectedReviewIds(kind).length ? t("selection.selected", "选中") : t("selection.currentPage", "当前页");
-    if (!window.confirm(t("reviews.confirmBatch", "确定批量{action}{scope} {count} 条{type}？")
+    if (!await showConfirm(t("reviews.batchConfirmTitle", "批量操作确认"), t("reviews.confirmBatch", "确定批量{action}{scope} {count} 条{type}？")
       .replace("{action}", actionText)
       .replace("{scope}", scopeText)
       .replace("{count}", fmt(ids.length, 0))
-      .replace("{type}", typeText))) return;
+      .replace("{type}", typeText), actionText)) return;
 
     const payload = {
       action: action === "delete"
@@ -1305,7 +1333,7 @@
       return;
     }
     const actionText = action === "approve" ? t("actions.confirm", "确认") : action === "reject" ? t("actions.rejectBack", "驳回") : t("actions.delete", "删除");
-    if (!window.confirm(t("jargon.confirmBatch", "确定批量{action}选中的 {count} 条黑话？").replace("{action}", actionText).replace("{count}", fmt(ids.length, 0)))) return;
+    if (!await showConfirm(t("jargon.batchConfirmTitle", "批量操作确认"), t("jargon.confirmBatch", "确定批量{action}选中的 {count} 条黑话？").replace("{action}", actionText).replace("{count}", fmt(ids.length, 0)), actionText)) return;
 
     const result = await apiPost("jargon/action", {
       action: action === "delete" ? "batch_delete" : "batch_review",
@@ -1367,7 +1395,7 @@
       return;
     }
     const actionText = action === "approve" ? t("actions.approve", "批准") : action === "reject" ? t("actions.reject", "拒绝") : t("actions.delete", "删除");
-    if (!window.confirm(t("style.confirmBatch", "确定批量{action}选中的 {count} 条表达审查？").replace("{action}", actionText).replace("{count}", fmt(ids.length, 0)))) return;
+    if (!await showConfirm(t("style.batchConfirmTitle", "批量操作确认"), t("style.confirmBatch", "确定批量{action}选中的 {count} 条表达审查？").replace("{action}", actionText).replace("{count}", fmt(ids.length, 0)), actionText)) return;
 
     const result = await apiPost("style/action", {
       action: action === "delete" ? "batch_delete" : "batch_review",

--- a/pages/dashboard/styles.css
+++ b/pages/dashboard/styles.css
@@ -1167,7 +1167,7 @@ textarea {
 }
 
 .modal {
-  width: min(760px, calc(100vw - 28px));
+  width: min(900px, calc(100vw - 28px));
   padding: 0;
   border: 0;
   background: transparent;

--- a/services/core_learning/v2_learning_integration.py
+++ b/services/core_learning/v2_learning_integration.py
@@ -733,6 +733,16 @@ class V2LearningIntegration:
                     return
                 for candidate in candidates[:10]:
                     try:
+                        # 跳过已被手动编辑或已完成推断的黑话，避免覆盖用户修改
+                        if db and hasattr(db, "get_jargon"):
+                            existing = await db.get_jargon(group_id, candidate["term"])
+                            if existing and existing.get("is_complete"):
+                                logger.debug(
+                                    f"[V2Integration] 跳过已完成的黑话: "
+                                    f"'{candidate['term']}'"
+                                )
+                                continue
+
                         meaning = await llm.generate_response(
                             f"Explain the slang/jargon term "
                             f"'{candidate['term']}' in the context of an "
@@ -744,16 +754,21 @@ class V2LearningIntegration:
                             and db
                             and hasattr(db, "save_or_update_jargon")
                         ):
+                            jargon_data = {
+                                "meaning": meaning,
+                                "raw_content": "[]",
+                                "is_jargon": True,
+                                "is_complete": True,
+                            }
+                            # 已有记录时保留原始计数，不重置为1
+                            if existing:
+                                jargon_data["count"] = existing.get("count", 1)
+                            else:
+                                jargon_data["count"] = 1
                             await db.save_or_update_jargon(
                                 group_id,
                                 candidate["term"],
-                                {
-                                    "meaning": meaning,
-                                    "raw_content": "[]",
-                                    "is_jargon": True,
-                                    "count": 1,
-                                    "is_complete": True,
-                                },
+                                jargon_data,
                             )
                     except Exception as exc:
                         logger.debug(


### PR DESCRIPTION
Fixes #211, Fixes #212, Fixes #213

## Summary

修复内嵌 Plugin Page 的三个问题：批量操作在 sandbox iframe 中失效、学习系统覆盖手动编辑的黑话、已确认黑话仍显示确认/驳回按钮。

## Changes

### 1. 批量操作修复 (#211)
- 新增 `showConfirm()` 函数，基于 `<dialog>` 元素实现自定义确认弹窗
- 替换 3 处 `window.confirm()` 调用（审查队列、黑话学习、表达方式学习）

### 2. 黑话学习保护 (#212)
- `v2_learning_integration.py`：学习前检查 `is_complete`，跳过已手动编辑的黑话
- 保留已有记录的 `count`，不再重置为 1

### 3. UI 改进 (#213)
- 已确认黑话隐藏「确认」「驳回」按钮
- 黑话编辑弹窗 textarea 高度从 4 行增加到 10 行
- 弹窗宽度从 760px 增加到 900px

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update

## Checklist

- [x] Code follows the project's coding style
- [x] Self-reviewed the code changes
- [x] No new warnings or errors introduced
- [x] Tested in sandboxed iframe environment