### PR TITLE
fix: dedupe legacy jargon rows before migration

### DIFF
--- a/core/database/engine.py
+++ b/core/database/engine.py
@@ -18,6 +18,7 @@ from typing import Optional
 import asyncio
 import threading
 import os
+import json
 from pathlib import Path
 
 try:
@@ -385,6 +386,12 @@ class DatabaseEngine:
                     return result
 
                 existing_indexes = await conn.run_sync(_get_existing_indexes)
+                await self._prepare_unique_index_data(
+                    conn,
+                    existing,
+                    existing_indexes,
+                    dialect,
+                )
                 index_statements = []
                 for table in Base.metadata.sorted_tables:
                     if table.name not in existing:
@@ -414,6 +421,220 @@ class DatabaseEngine:
 
         except Exception as e:
             logger.warning(f"[DatabaseEngine] 自动列迁移检测失败（不影响运行）: {e}")
+
+    async def _prepare_unique_index_data(
+        self,
+        conn,
+        existing_tables: dict,
+        existing_indexes: dict,
+        dialect,
+    ):
+        """Repair legacy duplicate rows before creating new unique indexes."""
+        if "jargon" not in existing_tables:
+            return
+        if "uk_chat_content" in existing_indexes.get("jargon", set()):
+            return
+
+        await self._dedupe_jargon_rows_for_unique_index(conn, dialect, existing_tables)
+
+    async def _dedupe_jargon_rows_for_unique_index(self, conn, dialect, existing_tables):
+        """Merge duplicate jargon rows so ``uk_chat_content`` can be added."""
+        from sqlalchemy import bindparam, text
+
+        quote = dialect.identifier_preparer.quote
+        table_name = quote("jargon")
+        duplicate_stmt = text(
+            f"""
+            SELECT {quote("chat_id")} AS chat_id,
+                   {quote("content")} AS content,
+                   COUNT(*) AS duplicate_count
+            FROM {table_name}
+            GROUP BY {quote("chat_id")}, {quote("content")}
+            HAVING COUNT(*) > 1
+            """
+        )
+        duplicate_groups = (await conn.execute(duplicate_stmt)).mappings().all()
+        if not duplicate_groups:
+            return
+
+        select_stmt = text(
+            f"""
+            SELECT {quote("id")} AS id,
+                   {quote("raw_content")} AS raw_content,
+                   {quote("meaning")} AS meaning,
+                   {quote("is_jargon")} AS is_jargon,
+                   {quote("count")} AS count,
+                   {quote("last_inference_count")} AS last_inference_count,
+                   {quote("is_complete")} AS is_complete,
+                   {quote("is_global")} AS is_global,
+                   {quote("created_at")} AS created_at,
+                   {quote("updated_at")} AS updated_at
+            FROM {table_name}
+            WHERE {quote("chat_id")} = :chat_id
+              AND {quote("content")} = :content
+            ORDER BY {quote("id")} ASC
+            """
+        )
+        update_stmt = text(
+            f"""
+            UPDATE {table_name}
+            SET {quote("raw_content")} = :raw_content,
+                {quote("meaning")} = :meaning,
+                {quote("is_jargon")} = :is_jargon,
+                {quote("count")} = :count,
+                {quote("last_inference_count")} = :last_inference_count,
+                {quote("is_complete")} = :is_complete,
+                {quote("is_global")} = :is_global,
+                {quote("created_at")} = :created_at,
+                {quote("updated_at")} = :updated_at
+            WHERE {quote("id")} = :id
+            """
+        )
+        delete_stmt = text(
+            f"DELETE FROM {table_name} WHERE {quote('id')} IN :ids"
+        ).bindparams(bindparam("ids", expanding=True))
+        usage_stmt = None
+        if "jargon_usage_frequency" in existing_tables:
+            usage_table = quote("jargon_usage_frequency")
+            usage_stmt = text(
+                f"""
+                UPDATE {usage_table}
+                SET {quote("jargon_id")} = :keeper_id
+                WHERE {quote("jargon_id")} IN :ids
+                """
+            ).bindparams(bindparam("ids", expanding=True))
+
+        merged_groups = 0
+        removed_rows = 0
+        for group in duplicate_groups:
+            result = await conn.execute(
+                select_stmt,
+                {
+                    "chat_id": group["chat_id"],
+                    "content": group["content"],
+                },
+            )
+            rows = [dict(row) for row in result.mappings().all()]
+            if len(rows) <= 1:
+                continue
+
+            merged = self._merge_duplicate_jargon_rows(rows)
+            delete_ids = [row["id"] for row in rows if row["id"] != merged["id"]]
+
+            await conn.execute(update_stmt, merged)
+            if delete_ids:
+                if usage_stmt is not None:
+                    await conn.execute(
+                        usage_stmt,
+                        {"keeper_id": merged["id"], "ids": delete_ids},
+                    )
+                await conn.execute(delete_stmt, {"ids": delete_ids})
+
+            merged_groups += 1
+            removed_rows += len(delete_ids)
+
+        if merged_groups:
+            logger.info(
+                "[DatabaseEngine] 自动迁移合并重复黑话记录: "
+                f"groups={merged_groups}, removed_rows={removed_rows}"
+            )
+
+    @staticmethod
+    def _merge_duplicate_jargon_rows(rows: list[dict]) -> dict:
+        """Return one merged jargon row while preserving manual completions."""
+
+        def truthy(value) -> bool:
+            if isinstance(value, str):
+                return value.strip().lower() not in {"", "0", "false", "none", "null"}
+            return bool(value)
+
+        def int_or_none(value):
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return None
+
+        def int_or_zero(value) -> int:
+            parsed = int_or_none(value)
+            return parsed if parsed is not None else 0
+
+        def row_priority(row: dict):
+            return (
+                not truthy(row.get("is_complete")),
+                not truthy(row.get("is_jargon")),
+                -int_or_zero(row.get("count")),
+                int_or_zero(row.get("id")),
+            )
+
+        rows = sorted(rows, key=row_priority)
+        keeper = rows[0]
+        completed = truthy(keeper.get("is_complete"))
+
+        raw_items = DatabaseEngine._extract_jargon_raw_items(keeper.get("raw_content"))
+        if not completed:
+            for row in rows[1:]:
+                raw_items.extend(
+                    DatabaseEngine._extract_jargon_raw_items(row.get("raw_content"))
+                )
+        raw_items = list(dict.fromkeys(str(item) for item in raw_items if str(item)))
+
+        meaning = keeper.get("meaning")
+        if not meaning:
+            meaning = next(
+                (row.get("meaning") for row in rows if row.get("meaning")),
+                None,
+            )
+
+        if completed:
+            is_jargon = keeper.get("is_jargon")
+        elif any(truthy(row.get("is_jargon")) for row in rows):
+            is_jargon = True
+        elif any(row.get("is_jargon") is not None for row in rows):
+            is_jargon = False
+        else:
+            is_jargon = None
+
+        created_values = [int_or_none(row.get("created_at")) for row in rows]
+        updated_values = [int_or_none(row.get("updated_at")) for row in rows]
+        created_values = [value for value in created_values if value is not None]
+        updated_values = [value for value in updated_values if value is not None]
+
+        return {
+            "id": keeper["id"],
+            "raw_content": json.dumps(raw_items, ensure_ascii=False),
+            "meaning": meaning,
+            "is_jargon": is_jargon,
+            "count": sum(max(int_or_zero(row.get("count")), 0) for row in rows),
+            "last_inference_count": max(
+                int_or_zero(row.get("last_inference_count")) for row in rows
+            ),
+            "is_complete": any(truthy(row.get("is_complete")) for row in rows),
+            "is_global": any(truthy(row.get("is_global")) for row in rows),
+            "created_at": min(created_values) if created_values else keeper.get("created_at"),
+            "updated_at": max(updated_values) if updated_values else keeper.get("updated_at"),
+        }
+
+    @staticmethod
+    def _extract_jargon_raw_items(value) -> list:
+        if value is None:
+            return []
+        if not isinstance(value, str):
+            return [value]
+
+        stripped = value.strip()
+        if not stripped:
+            return []
+
+        try:
+            parsed = json.loads(stripped)
+        except (TypeError, ValueError):
+            return [stripped]
+
+        if isinstance(parsed, list):
+            return parsed
+        if parsed:
+            return [parsed]
+        return []
 
     @staticmethod
     def _compile_add_column(col: Column, dialect) -> str:

--- a/services/database/facades/jargon_facade.py
+++ b/services/database/facades/jargon_facade.py
@@ -23,6 +23,36 @@ except ImportError:
 class JargonFacade(BaseFacade):
     """黑话管理 Facade"""
 
+    @staticmethod
+    def _jargon_to_dict(record: Jargon) -> Dict[str, Any]:
+        return {
+            'id': record.id,
+            'content': record.content,
+            'raw_content': record.raw_content,
+            'meaning': record.meaning,
+            'is_jargon': record.is_jargon,
+            'count': record.count or 0,
+            'last_inference_count': record.last_inference_count or 0,
+            'is_complete': record.is_complete,
+            'is_global': record.is_global or False,
+            'chat_id': record.chat_id,
+            'created_at': record.created_at,
+            'updated_at': record.updated_at,
+        }
+
+    @staticmethod
+    def _dedupe_jargon_dicts_by_content(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Drop duplicate content rows while preserving query order priority."""
+        deduped: List[Dict[str, Any]] = []
+        seen = set()
+        for item in items:
+            content_key = str(item.get('content') or '').strip().casefold()
+            if not content_key or content_key in seen:
+                continue
+            seen.add(content_key)
+            deduped.append(item)
+        return deduped
+
     # 1. get_jargon
     async def get_jargon(self, chat_id: str, content: str) -> Optional[Dict[str, Any]]:
         """查询指定黑话（按 chat_id + content 唯一定位）
@@ -335,25 +365,12 @@ class JargonFacade(BaseFacade):
                 jargon_list = []
                 for record in jargon_records:
                     try:
-                        jargon_list.append({
-                            'id': record.id,
-                            'content': record.content,
-                            'raw_content': record.raw_content,
-                            'meaning': record.meaning,
-                            'is_jargon': record.is_jargon,
-                            'count': record.count or 0,
-                            'last_inference_count': record.last_inference_count or 0,
-                            'is_complete': record.is_complete,
-                            'chat_id': record.chat_id,
-                            'created_at': record.created_at,
-                            'updated_at': record.updated_at,
-                            'is_global': record.is_global or False
-                        })
+                        jargon_list.append(self._jargon_to_dict(record))
                     except Exception as row_error:
                         self._logger.warning(f"处理黑话记录行时出错，跳过: {row_error}")
                         continue
 
-                return jargon_list
+                return self._dedupe_jargon_dicts_by_content(jargon_list)
 
         except Exception as e:
             self._logger.error(f"[JargonFacade] 获取最近黑话列表失败: {e}", exc_info=True)
@@ -383,7 +400,11 @@ class JargonFacade(BaseFacade):
         try:
             async with self.get_session() as session:
 
-                stmt = select(func.count(Jargon.id))
+                count_expr = Jargon.id
+                if chat_id is None:
+                    count_expr = func.distinct(func.lower(func.trim(Jargon.content)))
+
+                stmt = select(func.count(count_expr))
 
                 if chat_id is not None:
                     stmt = stmt.where(Jargon.chat_id == chat_id)
@@ -467,22 +488,9 @@ class JargonFacade(BaseFacade):
                 result = await session.execute(stmt)
                 records = result.scalars().all()
 
-                return [
-                    {
-                        'id': r.id,
-                        'content': r.content,
-                        'raw_content': r.raw_content,
-                        'meaning': r.meaning,
-                        'is_jargon': r.is_jargon,
-                        'count': r.count or 0,
-                        'is_complete': r.is_complete,
-                        'is_global': r.is_global or False,
-                        'chat_id': r.chat_id,
-                        'created_at': r.created_at,
-                        'updated_at': r.updated_at,
-                    }
-                    for r in records
-                ]
+                return self._dedupe_jargon_dicts_by_content([
+                    self._jargon_to_dict(r) for r in records
+                ])
         except Exception as e:
             self._logger.error(f"[JargonFacade] 搜索黑话失败: {e}", exc_info=True)
             return []

--- a/tests/unit/test_database_engine.py
+++ b/tests/unit/test_database_engine.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -176,6 +177,212 @@ async def test_sqlite_auto_migration_adds_expression_user_id(tmp_path):
         assert "idx_expression_scope_user_active" in indexes
     finally:
         await engine.close()
+
+
+
+@pytest.mark.asyncio
+async def test_sqlite_auto_migration_dedupes_jargon_before_unique_index(tmp_path):
+    db_path = tmp_path / "messages.db"
+    engine = DatabaseEngine(f"sqlite:///{db_path.as_posix()}")
+
+    try:
+        async with engine.engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE jargon (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        content TEXT NOT NULL,
+                        raw_content TEXT,
+                        meaning TEXT,
+                        is_jargon BOOLEAN,
+                        count INTEGER DEFAULT 1,
+                        last_inference_count INTEGER DEFAULT 0,
+                        is_complete BOOLEAN DEFAULT 0,
+                        is_global BOOLEAN DEFAULT 0,
+                        chat_id VARCHAR(255) NOT NULL,
+                        created_at BIGINT NOT NULL,
+                        updated_at BIGINT NOT NULL
+                    )
+                    """
+                )
+            )
+            await conn.execute(text("CREATE INDEX idx_jargon_chat_id ON jargon (chat_id)"))
+            await conn.execute(
+                text(
+                    """
+                    CREATE TABLE jargon_usage_frequency (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        jargon_id INTEGER NOT NULL REFERENCES jargon(id),
+                        group_id VARCHAR(255) NOT NULL,
+                        usage_count INTEGER DEFAULT 0,
+                        last_used_at FLOAT NOT NULL,
+                        success_rate FLOAT,
+                        context_types TEXT,
+                        created_at DATETIME
+                    )
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jargon (
+                        content, raw_content, meaning, is_jargon, count,
+                        last_inference_count, is_complete, is_global,
+                        chat_id, created_at, updated_at
+                    )
+                    VALUES
+                    ('打爆', '["ctx-a"]', NULL, NULL, 2, 1, 0, 0, 'group-a', 10, 20),
+                    ('打爆', '["ctx-b"]', '人工释义', 1, 5, 4, 1, 1, 'group-a', 8, 30),
+                    ('打爆', '["ctx-c"]', '自动释义', 0, 3, 2, 0, 0, 'group-a', 12, 25),
+                    ('打爆', '["other-group"]', '其他群释义', 1, 1, 1, 1, 0, 'group-b', 15, 35)
+                    """
+                )
+            )
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO jargon_usage_frequency (
+                        jargon_id, group_id, usage_count, last_used_at
+                    )
+                    VALUES (1, 'group-a', 1, 20.0), (3, 'group-a', 2, 25.0)
+                    """
+                )
+            )
+
+        await engine.create_tables(enable_auto_migration=True)
+
+        async with engine.engine.begin() as conn:
+            rows = (
+                await conn.execute(
+                    text(
+                        """
+                        SELECT id, chat_id, content, raw_content, meaning,
+                               is_jargon, count, last_inference_count,
+                               is_complete, is_global, created_at, updated_at
+                        FROM jargon
+                        WHERE content = '打爆'
+                        ORDER BY chat_id, id
+                        """
+                    )
+                )
+            ).mappings().all()
+            indexes = await conn.run_sync(
+                lambda sync_conn: {
+                    index["name"]
+                    for index in sa_inspect(sync_conn).get_indexes("jargon")
+                }
+            )
+            usage_jargon_ids = [
+                row["jargon_id"]
+                for row in (
+                    await conn.execute(
+                        text(
+                            """
+                            SELECT jargon_id
+                            FROM jargon_usage_frequency
+                            ORDER BY id
+                            """
+                        )
+                    )
+                ).mappings().all()
+            ]
+
+        group_a_rows = [row for row in rows if row["chat_id"] == "group-a"]
+        group_b_rows = [row for row in rows if row["chat_id"] == "group-b"]
+
+        assert "uk_chat_content" in indexes
+        assert len(group_a_rows) == 1
+        assert len(group_b_rows) == 1
+
+        merged = group_a_rows[0]
+        assert merged["meaning"] == "人工释义"
+        assert bool(merged["is_jargon"]) is True
+        assert bool(merged["is_complete"]) is True
+        assert bool(merged["is_global"]) is True
+        assert merged["count"] == 10
+        assert merged["last_inference_count"] == 4
+        assert merged["created_at"] == 8
+        assert merged["updated_at"] == 30
+        assert json.loads(merged["raw_content"]) == ["ctx-b"]
+        assert usage_jargon_ids == [2, 2]
+    finally:
+        await engine.close()
+
+
+@pytest.mark.asyncio
+async def test_jargon_facade_dedupes_cross_group_content_for_global_queries(tmp_path):
+    config = PluginConfig(
+        data_dir=str(tmp_path),
+        enable_web_interface=False,
+        db_type="sqlite",
+    )
+    config.messages_db_path = str(tmp_path / "messages.db")
+    manager = SQLAlchemyDatabaseManager(config)
+
+    try:
+        assert await manager.start() is True
+
+        await manager.save_or_update_jargon(
+            "group-a",
+            "猫娘",
+            {
+                "raw_content": '["group-a ctx"]',
+                "meaning": "group-a meaning",
+                "is_jargon": True,
+                "count": 2,
+                "is_complete": True,
+            },
+        )
+        await manager.save_or_update_jargon(
+            "group-b",
+            "猫娘",
+            {
+                "raw_content": '["group-b ctx"]',
+                "meaning": "group-b meaning",
+                "is_jargon": True,
+                "count": 9,
+                "is_complete": True,
+            },
+        )
+        await manager.save_or_update_jargon(
+            "group-c",
+            "上强度",
+            {
+                "raw_content": '["group-c ctx"]',
+                "meaning": "increase intensity",
+                "is_jargon": True,
+                "count": 1,
+                "is_complete": True,
+            },
+        )
+
+        search_results = await manager.search_jargon(
+            "猫",
+            confirmed_only=True,
+            limit=10,
+        )
+        recent_results = await manager.get_recent_jargon_list(
+            limit=10,
+            only_confirmed=True,
+        )
+        total_count = await manager.get_jargon_count(only_confirmed=True)
+        scoped_results = await manager.search_jargon(
+            "猫",
+            chat_id="group-a",
+            confirmed_only=True,
+            limit=10,
+        )
+
+        assert [row["content"] for row in search_results] == ["猫娘"]
+        assert search_results[0]["chat_id"] == "group-b"
+        assert [row["content"] for row in recent_results].count("猫娘") == 1
+        assert total_count == 2
+        assert [row["content"] for row in scoped_results] == ["猫娘"]
+        assert scoped_results[0]["chat_id"] == "group-a"
+    finally:
+        await manager.stop()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- repair legacy duplicate `(chat_id, content)` jargon rows before auto-creating the `uk_chat_content` unique index
- keep `jargon_usage_frequency` references pointed at the retained jargon row during migration
- dedupe cross-group jargon search/list/count responses by normalized `content`

Fixes #223.

## Evidence
- Issue #223 reports SQLite 3.4.2 databases returning repeated jargon entries for the same `content` in WebUI and LLM query paths.
- Upstream `61ab1b4` already moved new writes/query merge paths toward content dedupe, but legacy databases can still contain duplicate same-group rows before `uk_chat_content` exists, causing auto-index migration to fail.

## Validation
- `python -m pytest tests/unit/test_database_engine.py::test_sqlite_auto_migration_dedupes_jargon_before_unique_index tests/unit/test_database_engine.py::test_jargon_facade_dedupes_cross_group_content_for_global_queries tests/unit/test_jargon_query_service.py -o addopts=''`
- `python -m py_compile core/database/engine.py services/database/facades/jargon_facade.py tests/unit/test_database_engine.py`
- `python -m ruff check core/database/engine.py services/database/facades/jargon_facade.py tests/unit/test_database_engine.py`
- `git diff --check`
- installed tracked plugin files into `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning` and ran a SQLite migration smoke test there

## Summary by Sourcery

Ensure legacy jargon data is deduplicated so new unique indexes and global queries work correctly.

Bug Fixes:
- Repair legacy duplicate jargon rows before creating the jargon chat/content unique index to prevent SQLite auto-migration failures.
- Keep jargon usage frequency records pointing to the surviving jargon row when duplicates are merged.
- Deduplicate global jargon search, recent list, and count results by normalized content to avoid repeated entries across groups.

Enhancements:
- Introduce reusable helpers to normalize jargon records and deduplicate them by content in the jargon facade.

Tests:
- Add migration tests that verify jargon deduplication runs before adding the unique index and preserves usage frequency references.
- Add facade tests that verify cross-group jargon queries return deduplicated content and consistent counts.