### PR TITLE
fix: preserve role provider config on reload

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,6 +22,11 @@ POSTGRESQL_DB_TYPE_ALIASES = {"postgres", "pg", "pgsql"}
 HIGH_COST_LIGHTRAG_QUERY_MODES = {"hybrid", "mix"}
 CACHE_FRIENDLY_LLM_HOOK_TARGET = "extra_user_content_parts"
 LEGACY_LLM_HOOK_TARGETS = {"system_prompt", "prompt"}
+ROLE_PROVIDER_ID_FIELDS = (
+    "filter_provider_id",
+    "refine_provider_id",
+    "reinforce_provider_id",
+)
 LLM_HOOK_TARGET_ALIASES = {
     "extra_user_content_parts": CACHE_FRIENDLY_LLM_HOOK_TARGET,
     "extra_user_content": CACHE_FRIENDLY_LLM_HOOK_TARGET,
@@ -57,6 +62,18 @@ def _read_config_value(config_like: Any, key: str, default: Any = None) -> Any:
                 return group.get(key, default)
         return default
     return getattr(config_like, key, default)
+
+
+def _read_grouped_or_flat(
+    config_like: Dict[str, Any],
+    group_key: str,
+    field_key: str,
+    default: Any = None,
+) -> Any:
+    group = config_like.get(group_key, {})
+    if isinstance(group, dict) and field_key in group:
+        return group.get(field_key, default)
+    return config_like.get(field_key, default)
 
 
 def _read_config_bool(config_like: Any, key: str, default: bool = False) -> bool:
@@ -383,12 +400,23 @@ class PluginConfig(BaseModel):
         basic_settings = config.get('Self_Learning_Basic', {})
         target_settings = config.get('Target_Settings', {})
         model_configuration = config.get('Model_Configuration', {})
+        if not isinstance(model_configuration, dict):
+            model_configuration = {}
+        filter_provider_id = _read_grouped_or_flat(
+            config, 'Model_Configuration', 'filter_provider_id', None
+        )
+        refine_provider_id = _read_grouped_or_flat(
+            config, 'Model_Configuration', 'refine_provider_id', None
+        )
+        reinforce_provider_id = _read_grouped_or_flat(
+            config, 'Model_Configuration', 'reinforce_provider_id', None
+        )
 
         # 添加调试日志：显示原始配置数据
         logger.info(f" [配置加载] Model_Configuration原始数据: {model_configuration}")
-        logger.info(f" [配置加载] filter_provider_id: {model_configuration.get('filter_provider_id', 'NOT_FOUND')}")
-        logger.info(f" [配置加载] refine_provider_id: {model_configuration.get('refine_provider_id', 'NOT_FOUND')}")
-        logger.info(f" [配置加载] reinforce_provider_id: {model_configuration.get('reinforce_provider_id', 'NOT_FOUND')}")
+        logger.info(f" [配置加载] filter_provider_id: {filter_provider_id}")
+        logger.info(f" [配置加载] refine_provider_id: {refine_provider_id}")
+        logger.info(f" [配置加载] reinforce_provider_id: {reinforce_provider_id}")
 
         learning_params = config.get('Learning_Parameters', {})
         filter_params = config.get('Filter_Parameters', {})
@@ -440,9 +468,9 @@ class PluginConfig(BaseModel):
             target_blacklist=target_settings.get('target_blacklist', []),
             current_persona_name=target_settings.get('current_persona_name', ''),
 
-            filter_provider_id=model_configuration.get('filter_provider_id', None),
-            refine_provider_id=model_configuration.get('refine_provider_id', None),
-            reinforce_provider_id=model_configuration.get('reinforce_provider_id', None),
+            filter_provider_id=filter_provider_id,
+            refine_provider_id=refine_provider_id,
+            reinforce_provider_id=reinforce_provider_id,
 
             # v2 Architecture
             embedding_provider_id=v2_settings.get('embedding_provider_id', None),
@@ -658,6 +686,13 @@ class PluginConfig(BaseModel):
 
         merged = runtime_config.to_dict()
         persisted_config = cls._flatten_config_payload(persisted_data)
+        for provider_field in ROLE_PROVIDER_ID_FIELDS:
+            if (
+                getattr(runtime_config, provider_field, None)
+                and not persisted_config.get(provider_field)
+            ):
+                persisted_config.pop(provider_field, None)
+
         overridden = sorted(
             key
             for key, value in persisted_config.items()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -205,6 +205,20 @@ class TestPluginConfigFromDict:
         assert config.refine_provider_id == 'provider_2'
         assert config.reinforce_provider_id == 'provider_3'
 
+    def test_create_from_config_accepts_flat_model_provider_settings(self):
+        """AstrBot/runtime payloads may provide role providers without grouping."""
+        raw_config = {
+            'filter_provider_id': 'provider_filter',
+            'refine_provider_id': 'provider_refine',
+            'reinforce_provider_id': 'provider_reinforce',
+        }
+
+        config = PluginConfig.create_from_config(raw_config, data_dir="/tmp/test")
+
+        assert config.filter_provider_id == 'provider_filter'
+        assert config.refine_provider_id == 'provider_refine'
+        assert config.reinforce_provider_id == 'provider_reinforce'
+
     def test_create_from_config_missing_data_dir(self):
         """Test config creation with empty data_dir uses fallback."""
         config = PluginConfig.create_from_config({}, data_dir="")
@@ -743,6 +757,38 @@ class TestPluginConfigSerialization:
         assert config.db_type == "sqlite"
         assert config.postgresql_host == "pg"
         assert config.enable_message_capture is False
+
+    def test_create_from_runtime_sources_keeps_runtime_role_providers_over_stale_empty_persisted_values(self, tmp_path):
+        """Old WebUI snapshots with empty provider IDs must not erase plugin-page choices."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "Model_Configuration": {
+                        "filter_provider_id": None,
+                        "refine_provider_id": "",
+                    },
+                    "reinforce_provider_id": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        config = PluginConfig.create_from_runtime_sources(
+            {
+                "Model_Configuration": {
+                    "filter_provider_id": "siliconflow/Qwen/Qwen3-8B",
+                    "refine_provider_id": "deepseek/deepseek-v4-flash",
+                    "reinforce_provider_id": "deepseek/deepseek-v4-pro",
+                }
+            },
+            data_dir=str(tmp_path),
+            config_file=str(config_file),
+        )
+
+        assert config.filter_provider_id == "siliconflow/Qwen/Qwen3-8B"
+        assert config.refine_provider_id == "deepseek/deepseek-v4-flash"
+        assert config.reinforce_provider_id == "deepseek/deepseek-v4-pro"
 
     def test_create_from_runtime_sources_top_level_overrides_grouped_config(self, tmp_path):
         """Top-level persisted fields should win over grouped persisted fields."""


### PR DESCRIPTION
## Summary
- Fixes #226.
- Read role provider IDs from both grouped `Model_Configuration` and flat runtime payloads.
- Prevents stale persisted WebUI config with empty role provider IDs from overriding explicit AstrBot plugin-page provider choices during reload/restart.
- Keeps startup logs focused on the effective provider IDs that will be used by `FrameworkLLMAdapter`.

## Evidence
Issue #226 reports AstrBot 4.25.6 / plugin 3.4.3 logging `配置文件中未指定任何Provider，尝试自动配置...` even after the user configured distinct filter/refine/reinforce providers. That warning is emitted when `PluginConfig` reaches `FrameworkLLMAdapter.initialize_providers()` with all three role provider IDs empty.

## Validation
- `python -m pytest tests\unit\test_config.py tests\unit\test_config_service.py -q` (81 passed)
- `python -m ruff check config.py tests\unit\test_config.py`
- `python -m py_compile config.py tests\unit\test_config.py`
- `git diff --check`
- Installed-file smoke under `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning`: `python -m py_compile config.py tests\unit\test_config.py`, plus runtime-source load smoke preserving the three configured provider IDs over empty persisted values.

## Summary by Sourcery

Ensure role provider IDs from runtime configs are preserved and correctly read from both grouped and flat configurations while preventing stale persisted values from overriding them.

New Features:
- Allow role provider IDs to be read from either grouped Model_Configuration sections or flat top-level config fields.

Bug Fixes:
- Prevent empty or missing persisted role provider IDs from overwriting explicitly configured runtime provider IDs when reloading config.
- Align startup logging to report the effective role provider IDs derived from the merged configuration.

Tests:
- Add tests to verify flat role provider IDs are accepted when not grouped under Model_Configuration.
- Add tests to ensure runtime role provider selections are preserved over stale empty values from persisted config snapshots.