### PR TITLE
fix: skip persona reviews for no-update outputs

### DIFF
--- a/services/learning/persona_learning.py
+++ b/services/learning/persona_learning.py
@@ -5,6 +5,7 @@ learning. The progressive learning service remains the batch orchestrator.
 """
 
 import json
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -18,6 +19,20 @@ from ..monitoring.instrumentation import monitored
 
 class PersonaLearningModule:
     """Generate persona candidates and create review records."""
+
+    _NO_PERSONA_UPDATE_PHRASES = (
+        "无需更新",
+        "不需要更新",
+        "没有需要更新",
+        "无需要更新",
+        "无需修改",
+        "不需要修改",
+        "没有必要更新",
+        "保持不变",
+        "no update",
+        "no changes",
+        "no change",
+    )
 
     def __init__(
         self,
@@ -441,10 +456,20 @@ class PersonaLearningModule:
             original_prompt = current_persona.get("prompt", "")
             new_prompt = updated_persona.get("prompt", "")
 
-            if len(new_prompt) > len(original_prompt):
+            if new_prompt.startswith(original_prompt):
                 incremental_content = new_prompt[len(original_prompt):].strip()
             else:
                 incremental_content = new_prompt
+
+            if self._is_no_update_persona_output(
+                updated_persona,
+                incremental_content,
+            ):
+                logger.info(
+                    "人格学习模型明确判断无需更新，跳过审查记录创建 "
+                    f"(group: {group_id})"
+                )
+                return None
 
             metadata = {
                 "progressive_learning": True,
@@ -510,6 +535,39 @@ class PersonaLearningModule:
         except Exception as exc:
             logger.error(f"创建人格学习审查记录失败: {exc}", exc_info=True)
             return None
+
+    @staticmethod
+    def _normalize_persona_update_text(value: Any) -> str:
+        text = str(value or "").strip().lower()
+        return re.sub(r"[\s，。,.!！?？；;：:\"'“”‘’（）()\[\]【】<>《》]+", "", text)
+
+    @classmethod
+    def _is_no_update_persona_output(
+        cls,
+        updated_persona: Any,
+        incremental_content: str,
+    ) -> bool:
+        if isinstance(updated_persona, dict):
+            should_update = updated_persona.get("should_update")
+            if should_update is False:
+                return True
+            if isinstance(should_update, str) and should_update.strip().lower() in {
+                "false",
+                "no",
+                "0",
+                "否",
+                "不",
+            }:
+                return True
+
+        normalized = cls._normalize_persona_update_text(incremental_content)
+        if not normalized:
+            return True
+
+        return len(normalized) <= 80 and any(
+            cls._normalize_persona_update_text(phrase) in normalized
+            for phrase in cls._NO_PERSONA_UPDATE_PHRASES
+        )
 
     @staticmethod
     def _coerce_persona(

--- a/statics/prompts.py
+++ b/statics/prompts.py
@@ -346,6 +346,9 @@ PROGRESSIVE_LEARNING_GENERATE_UPDATED_PERSONA_PROMPT = """
 风格分析结果：
 {style_analysis_json}
 
+请先判断风格分析结果是否包含稳定、明确、值得写入人格的新增特征。若没有可靠的新特征，必须返回
+`"should_update": false`，并保持当前人格内容不变，不要把“无需更新/不需要修改”之类说明写进 prompt。
+
 请根据风格分析结果对人格进行渐进式更新，确保：
 1. 保持核心人格特征不变
 2. 根据风格分析适当调整表达方式
@@ -354,8 +357,20 @@ PROGRESSIVE_LEARNING_GENERATE_UPDATED_PERSONA_PROMPT = """
 
 请以JSON格式返回更新后的完整人格信息：
 {{
+    "should_update": true,
+    "reason": "简要说明本次是否需要更新以及依据",
     "name": "更新后的人格名称",
     "prompt": "更新后的完整人格描述",
+    "begin_dialogs": [],
+    "mood_imitation_dialogs": []
+}}
+
+若无需更新，请返回：
+{{
+    "should_update": false,
+    "reason": "没有发现稳定的新人格特征",
+    "name": "当前人格名称",
+    "prompt": "当前完整人格描述",
     "begin_dialogs": [],
     "mood_imitation_dialogs": []
 }}

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -43,6 +43,7 @@ from self_learning_EterU.services.integration.maibot_enhanced_learning_manager i
 )
 from self_learning_EterU.services.jargon.jargon_miner import JargonMiner
 from self_learning_EterU.services.learning.remember_service import RememberService
+from self_learning_EterU.services.learning.persona_learning import PersonaLearningModule
 from self_learning_EterU.webui.services.learning_service import LearningService
 from self_learning_EterU.services.learning.message_pipeline import MessagePipeline
 from self_learning_EterU.services.learning.realtime_processor import RealtimeProcessor
@@ -238,6 +239,62 @@ async def test_manual_learning_batch_generates_persona_review():
     service.db_manager.add_persona_learning_review.assert_awaited_once()
     review_kwargs = service.db_manager.add_persona_learning_review.await_args.kwargs
     assert review_kwargs["proposed_content"] == "手动学习新增人格特征"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_persona_learning_skips_review_when_model_decides_no_update():
+    module = PersonaLearningModule(
+        config=SimpleNamespace(),
+        context=SimpleNamespace(),
+        db_manager=SimpleNamespace(add_persona_learning_review=AsyncMock(return_value=1)),
+        persona_manager=SimpleNamespace(),
+        multidimensional_analyzer=SimpleNamespace(),
+        prompts=SimpleNamespace(),
+        resolve_umo=lambda group_id: group_id,
+        json_serializer=str,
+    )
+
+    review_id = await module.create_persona_review(
+        "group-a",
+        AnalysisResult(success=True, confidence=0.8, data={"summary": "稳定"}),
+        [{"message": "最近风格稳定"}],
+        current_persona={"prompt": "原人格", "name": "default"},
+        updated_persona={
+            "prompt": "无需更新人格，当前设定已经足够稳定。",
+            "should_update": False,
+            "reason": "没有新的稳定特征",
+        },
+    )
+
+    assert review_id is None
+    module.db_manager.add_persona_learning_review.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_persona_learning_skips_short_no_update_text_review():
+    module = PersonaLearningModule(
+        config=SimpleNamespace(),
+        context=SimpleNamespace(),
+        db_manager=SimpleNamespace(add_persona_learning_review=AsyncMock(return_value=1)),
+        persona_manager=SimpleNamespace(),
+        multidimensional_analyzer=SimpleNamespace(),
+        prompts=SimpleNamespace(),
+        resolve_umo=lambda group_id: group_id,
+        json_serializer=str,
+    )
+
+    review_id = await module.create_persona_review(
+        "group-a",
+        AnalysisResult(success=True, confidence=0.8, data={"summary": "稳定"}),
+        [{"message": "最近没有新风格"}],
+        current_persona={"prompt": "原人格", "name": "default"},
+        updated_persona={"prompt": "不需要更新人格。", "name": "default"},
+    )
+
+    assert review_id is None
+    module.db_manager.add_persona_learning_review.assert_not_awaited()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add a structured `should_update` decision to the progressive persona prompt so the model can explicitly decline no-op updates
- skip creating persona review rows when the model returns `should_update: false`, an empty increment, or a short no-update phrase
- preserve normal review creation for real prompt changes and add regression coverage for both structured and legacy natural-language no-update outputs

Fixes #224.

## Evidence
- Issue #224 reports that “不需要更新” text is currently inserted into the persona review queue.
- `services/learning/persona_learning.py` creates review records through `add_persona_learning_review(...)`, so the guard is placed immediately before that write.

## Validation
- `python -m pytest tests\unit\test_learning_chain_regressions.py -q`
- `python -m ruff check services\learning\persona_learning.py tests\unit\test_learning_chain_regressions.py statics\prompts.py`
- `python -m py_compile services\learning\persona_learning.py tests\unit\test_learning_chain_regressions.py statics\prompts.py`
- `git diff --check`
- installed changed files into `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning` and ran install-directory py_compile plus a `should_update: false` smoke test

## Summary by Sourcery

Skip creating persona learning reviews when the model explicitly indicates no persona update is needed, and update prompts/tests to support a structured should_update decision.

Bug Fixes:
- Prevent no-update explanations from being inserted into the persona review queue by treating structured should_update=false and short no-update outputs as non-updates.

Enhancements:
- Add normalization and phrase-matching logic to detect no-op persona updates, including support for both structured flags and legacy natural-language outputs in Chinese and English.

Documentation:
- Clarify the progressive persona prompt to require a structured should_update field and provide explicit examples for update and no-update responses.

Tests:
- Add regression tests ensuring persona reviews are skipped when the model returns should_update=false or short no-update prompts.