### PR TITLE
fix: support qq-chat-exporter QCE imports

### DIFF
--- a/services/integration/qq_chat_history_importer.py
+++ b/services/integration/qq_chat_history_importer.py
@@ -620,6 +620,7 @@ class QQChatHistoryImporter:
             group_id=group_id,
             timestamp=timestamp,
             platform="qq",
+            reply_to=block.get("reply_to"),
             source_type="qce_html",
             metadata={"source_label": source_label},
         )
@@ -855,10 +856,12 @@ _URL_RE = re.compile(r"https?://\S+")
 
 def _clean_text(value: str) -> str:
     text = html.unescape(str(value or ""))
-    text = _PLACEHOLDER_RE.sub("", text)
-    text = _URL_RE.sub("", text)
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
+    text_without_urls = _URL_RE.sub("", text)
+    text_without_placeholders = _PLACEHOLDER_RE.sub("", text_without_urls)
+    normalized = re.sub(r"\s+", " ", text_without_placeholders).strip()
+    if normalized:
+        return normalized
+    return re.sub(r"\s+", " ", text_without_urls).strip()
 
 
 def _stable_message_id(message: QQChatMessage) -> str:
@@ -1011,6 +1014,7 @@ class _QCEHTMLMessageParser(HTMLParser):
         if tag_name == "div" and "message" in class_tokens and self._current is None:
             self._current = {
                 "id": attr_map.get("data-message-id", ""),
+                "reply_to": "",
                 "sender": [],
                 "time": [],
                 "content": [],
@@ -1032,6 +1036,9 @@ class _QCEHTMLMessageParser(HTMLParser):
             if "reply-content" in class_tokens:
                 self._reply_depth += 1
                 reply_started = True
+                reply_to = attr_map.get("data-reply-to", "")
+                if reply_to and not self._current.get("reply_to"):
+                    self._current["reply_to"] = reply_to.removeprefix("msg-")
 
         if tag_name == "br" and self._current is not None and self._current_field() == "content" and self._reply_depth <= 0:
             self._current["content"].append("\n")
@@ -1057,6 +1064,7 @@ class _QCEHTMLMessageParser(HTMLParser):
                 self.messages.append(
                     {
                         "id": str(current.get("id") or "").strip(),
+                        "reply_to": str(current.get("reply_to") or "").strip(),
                         "sender": _collapse_html_text(current.get("sender", [])),
                         "time": _collapse_html_text(current.get("time", [])),
                         "content": _collapse_html_text(current.get("content", [])),

--- a/services/integration/qq_chat_history_importer.py
+++ b/services/integration/qq_chat_history_importer.py
@@ -1,9 +1,10 @@
 """QQ chat history import bridge.
 
-The importer focuses on QQChatExporter V5 chunked JSONL exports and the
-Alpaca-style training data produced by the local formatting script.  It also
-contains a small best-effort parser for plain QQ TXT/HTML logs so the WebUI can
-accept common lightweight exports without a schema change.
+The importer supports QQChatExporter/qq-chat-exporter V5 JSONL, single JSON,
+and self-contained HTML exports, plus the Alpaca-style training data produced
+by the local formatting script. It also contains a small best-effort parser for
+plain QQ TXT/HTML logs so the WebUI can accept common lightweight exports
+without a schema change.
 """
 
 from __future__ import annotations
@@ -282,7 +283,11 @@ class QQChatHistoryImporter:
         if payload is None and json_text:
             payload = _json_decode(json_text)
         if payload is not None:
-            return QQChatSource(payload=payload, source_format=_payload_format(payload))
+            return QQChatSource(
+                payload=payload,
+                manifest=_payload_manifest(payload),
+                source_format=_payload_format(payload),
+            )
 
         if not source_path:
             raise ValueError("请提供 QQ 聊天记录路径、JSON 内容或 payload")
@@ -321,7 +326,12 @@ class QQChatHistoryImporter:
             return QQChatSource(path=path, qce_files=[path], source_format="qce_jsonl")
         if suffix == ".json":
             payload = _read_json_file(path)
-            return QQChatSource(path=path, payload=payload, source_format=_payload_format(payload))
+            return QQChatSource(
+                path=path,
+                payload=payload,
+                manifest=_payload_manifest(payload),
+                source_format=_payload_format(payload),
+            )
         if suffix in {".txt", ".log"}:
             return QQChatSource(path=path, text_file=path, source_format="qq_text")
         if suffix in {".html", ".htm"}:
@@ -337,7 +347,7 @@ class QQChatHistoryImporter:
         min_text_length: int = 2,
     ) -> Iterator[QQChatMessage]:
         group_id = self._group_id(source, default_group_id)
-        chat_info = _chat_info(source.manifest)
+        chat_info = _source_chat_info(source)
         self_uid = str(chat_info.get("selfUid") or chat_info.get("selfUin") or "")
 
         if source.qce_files:
@@ -356,7 +366,19 @@ class QQChatHistoryImporter:
             return
 
         if source.html_file:
-            text = _html_to_text(source.html_file.read_text(encoding="utf-8-sig", errors="ignore"))
+            html_text = source.html_file.read_text(encoding="utf-8-sig", errors="ignore")
+            qce_messages = list(
+                self._iter_qce_html(
+                    html_text,
+                    group_id=group_id,
+                    source_label=str(source.html_file),
+                    min_text_length=min_text_length,
+                )
+            )
+            if qce_messages:
+                yield from qce_messages
+                return
+            text = _html_to_text(html_text)
             yield from self._iter_text_blocks(text.splitlines(), group_id=group_id, source_label=str(source.html_file), min_text_length=min_text_length)
             return
 
@@ -527,6 +549,29 @@ class QQChatHistoryImporter:
             if message:
                 yield message
 
+    def _iter_qce_html(
+        self,
+        value: str,
+        *,
+        group_id: str,
+        source_label: str,
+        min_text_length: int,
+    ) -> Iterator[QQChatMessage]:
+        parser = _QCEHTMLMessageParser()
+        parser.feed(value or "")
+        parsed_group_id = group_id
+        if parsed_group_id in {"", "global"} and parser.chat_title:
+            parsed_group_id = parser.chat_title
+        for block in parser.messages:
+            message = self._message_from_qce_html_block(
+                block,
+                group_id=parsed_group_id,
+                source_label=source_label,
+                min_text_length=min_text_length,
+            )
+            if message:
+                yield message
+
     def _message_from_text_block(
         self,
         block: Mapping[str, Any],
@@ -553,6 +598,32 @@ class QQChatHistoryImporter:
             metadata={"source_label": source_label},
         )
 
+    def _message_from_qce_html_block(
+        self,
+        block: Mapping[str, Any],
+        *,
+        group_id: str,
+        source_label: str,
+        min_text_length: int,
+    ) -> Optional[QQChatMessage]:
+        text = _clean_text(str(block.get("content") or ""))
+        if len(text) < min_text_length:
+            return None
+        sender = str(block.get("sender") or "unknown").strip()
+        timestamp = int(_to_timestamp(block.get("time"), default=time.time()))
+        source_id = str(block.get("id") or "")
+        return self._build_message(
+            source_id=source_id or f"html:{source_label}:{timestamp}:{sender}:{text[:64]}",
+            sender_id=_sender_id_from_text(sender),
+            sender_name=_sender_name_from_text(sender),
+            message=text,
+            group_id=group_id,
+            timestamp=timestamp,
+            platform="qq",
+            source_type="qce_html",
+            metadata={"source_label": source_label},
+        )
+
     def _message_from_qce(
         self,
         raw: Any,
@@ -566,7 +637,7 @@ class QQChatHistoryImporter:
         if raw.get("system") or raw.get("recalled"):
             return None
         msg_type = str(raw.get("type") or "").lower()
-        if msg_type and msg_type not in {"text", "reply"}:
+        if msg_type and msg_type not in {"text", "reply"} and not re.fullmatch(r"type_\d+", msg_type):
             return None
 
         message = _extract_qce_text(raw.get("content"))
@@ -640,7 +711,7 @@ class QQChatHistoryImporter:
         explicit = str(default_group_id or "").strip()
         if explicit:
             return explicit
-        info = _chat_info(source.manifest)
+        info = _source_chat_info(source)
         return str(info.get("uin") or info.get("id") or info.get("name") or "global")
 
 
@@ -652,7 +723,7 @@ def qq_chat_import_destinations() -> dict[str, str]:
 
 
 def _empty_summary(source: QQChatSource, *, default_group_id: str) -> dict[str, Any]:
-    chat_info = _chat_info(source.manifest)
+    chat_info = _source_chat_info(source)
     return {
         "version": QQ_HISTORY_EXPORT_VERSION,
         "source": QQ_HISTORY_SOURCE,
@@ -676,6 +747,8 @@ def _empty_summary(source: QQChatSource, *, default_group_id: str) -> dict[str, 
 
 
 def _add_summary_message(summary: dict[str, Any], message: QQChatMessage) -> None:
+    if summary.get("group_id") in {"", "global"} and message.group_id:
+        summary["group_id"] = message.group_id
     counts = summary["counts"]
     counts["messages"] += 1
     counts["bot_messages"] += 1 if message.is_bot else 0
@@ -705,6 +778,28 @@ def _add_summary_message(summary: dict[str, Any], message: QQChatMessage) -> Non
 def _chat_info(manifest: Mapping[str, Any]) -> dict[str, Any]:
     info = manifest.get("chatInfo") if isinstance(manifest, Mapping) else {}
     return dict(info) if isinstance(info, Mapping) else {}
+
+
+def _source_chat_info(source: QQChatSource) -> dict[str, Any]:
+    info = _chat_info(source.manifest)
+    if info:
+        return info
+    if isinstance(source.payload, Mapping):
+        payload_info = source.payload.get("chatInfo")
+        if isinstance(payload_info, Mapping):
+            return dict(payload_info)
+    return {}
+
+
+def _payload_manifest(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            return {}
+    if isinstance(payload, Mapping) and isinstance(payload.get("chatInfo"), Mapping):
+        return {"chatInfo": dict(payload["chatInfo"])}
+    return {}
 
 
 def _extract_qce_text(content: Any) -> str:
@@ -754,7 +849,7 @@ def _extract_qce_reply_to(content: Any) -> Optional[str]:
     return None
 
 
-_PLACEHOLDER_RE = re.compile(r"\[(?:图片|表情|文件|语音|视频|回复消息)[^\]]*\]")
+_PLACEHOLDER_RE = re.compile(r"\[(?:图片|表情|文件|语音|视频|回复消息|回复[^\]]*)[^\]]*\]")
 _URL_RE = re.compile(r"https?://\S+")
 
 
@@ -891,6 +986,111 @@ def _html_to_text(value: str) -> str:
     parser = _TextExtractor()
     parser.feed(value or "")
     return html.unescape("".join(parser.parts))
+
+
+_HTML_VOID_TAGS = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track", "wbr"}
+
+
+class _QCEHTMLMessageParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.messages: list[dict[str, str]] = []
+        self.chat_title = ""
+        self._current: Optional[dict[str, Any]] = None
+        self._message_depth = 0
+        self._active_fields: list[tuple[Optional[str], bool]] = []
+        self._reply_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        tag_name = tag.lower()
+        attr_map = {key.lower(): value or "" for key, value in attrs}
+        class_tokens = _class_tokens(attr_map.get("class", ""))
+        field: Optional[str] = None
+        reply_started = False
+
+        if tag_name == "div" and "message" in class_tokens and self._current is None:
+            self._current = {
+                "id": attr_map.get("data-message-id", ""),
+                "sender": [],
+                "time": [],
+                "content": [],
+                "skip": "system" in class_tokens,
+            }
+            self._message_depth = 1
+        elif self._current is not None and tag_name not in _HTML_VOID_TAGS:
+            self._message_depth += 1
+
+        if "chat-title" in class_tokens:
+            field = "chat_title"
+        elif self._current is not None:
+            if "message-sender" in class_tokens:
+                field = "sender"
+            elif "message-time" in class_tokens:
+                field = "time"
+            elif "message-content" in class_tokens:
+                field = "content"
+            if "reply-content" in class_tokens:
+                self._reply_depth += 1
+                reply_started = True
+
+        if tag_name == "br" and self._current is not None and self._current_field() == "content" and self._reply_depth <= 0:
+            self._current["content"].append("\n")
+
+        if tag_name not in _HTML_VOID_TAGS:
+            self._active_fields.append((field, reply_started))
+
+    def handle_endtag(self, tag: str) -> None:
+        reply_started = False
+        if self._active_fields:
+            _field, reply_started = self._active_fields.pop()
+        if reply_started:
+            self._reply_depth = max(0, self._reply_depth - 1)
+
+        if self._current is None:
+            return
+        if tag.lower() not in _HTML_VOID_TAGS:
+            self._message_depth -= 1
+        if self._message_depth <= 0:
+            current = self._current
+            self._current = None
+            if not current.get("skip"):
+                self.messages.append(
+                    {
+                        "id": str(current.get("id") or "").strip(),
+                        "sender": _collapse_html_text(current.get("sender", [])),
+                        "time": _collapse_html_text(current.get("time", [])),
+                        "content": _collapse_html_text(current.get("content", [])),
+                    }
+                )
+
+    def handle_data(self, data: str) -> None:
+        if not data:
+            return
+        field = self._current_field()
+        if field == "chat_title":
+            self.chat_title = _collapse_html_text([self.chat_title, data])
+            return
+        if self._current is None or field not in {"sender", "time", "content"}:
+            return
+        if field == "content" and self._reply_depth > 0:
+            return
+        self._current[field].append(data)
+
+    def _current_field(self) -> Optional[str]:
+        for field, _reply_started in reversed(self._active_fields):
+            if field:
+                return field
+        return None
+
+
+def _class_tokens(value: str) -> set[str]:
+    return {item for item in str(value or "").split() if item}
+
+
+def _collapse_html_text(parts: Any) -> str:
+    if not isinstance(parts, list):
+        parts = [parts]
+    return re.sub(r"[ \t\r\f\v]+", " ", html.unescape("".join(str(part) for part in parts))).strip()
 
 
 def _preview_text(value: str, *, limit: int = 120) -> str:

--- a/tests/unit/test_qq_chat_history_importer.py
+++ b/tests/unit/test_qq_chat_history_importer.py
@@ -110,11 +110,12 @@ def test_qq_chat_history_importer_previews_qce_chunked_jsonl(tmp_path):
 
     assert preview["source_format"] == "qce_chunked_jsonl"
     assert preview["group_id"] == "AstrBot 大学"
-    assert preview["counts"]["messages"] == 2
+    assert preview["counts"]["messages"] == 3
     assert preview["counts"]["bot_messages"] == 1
     assert preview["counts"]["unique_senders"] == 2
     assert preview["samples"]["messages"][0]["message"] == "这不160兆吗"
-    assert preview["samples"]["messages"][1]["reply_to"] == "m1"
+    assert preview["samples"]["messages"][1]["message"] == "[图片:demo.jpg]"
+    assert preview["samples"]["messages"][2]["reply_to"] == "m1"
 
 
 def test_qq_chat_history_importer_previews_qce_single_json_type_codes(tmp_path):
@@ -192,6 +193,18 @@ def test_qq_chat_history_importer_previews_qce_single_json_type_codes(tmp_path):
                         "recalled": False,
                         "system": False,
                     },
+                    {
+                        "seq": "1004",
+                        "timestamp": 1704067560000,
+                        "sender": {"uid": "u_bob", "uin": "22222", "name": "Bob"},
+                        "type": "type_6",
+                        "content": {
+                            "text": "[语音 7秒]",
+                            "elements": [{"type": "audio", "data": {"filename": "voice_msg.silk"}}],
+                        },
+                        "recalled": False,
+                        "system": False,
+                    },
                 ],
             },
             ensure_ascii=False,
@@ -204,12 +217,14 @@ def test_qq_chat_history_importer_previews_qce_single_json_type_codes(tmp_path):
     assert preview["source_format"] == "qce_json"
     assert preview["chat_info"]["name"] == "QCE Testing Group"
     assert preview["group_id"] == "QCE Testing Group"
-    assert preview["counts"]["messages"] == 2
-    assert preview["counts"]["unique_senders"] == 1
+    assert preview["counts"]["messages"] == 4
+    assert preview["counts"]["unique_senders"] == 2
     assert preview["samples"]["messages"][0]["sender_id"] == "u_alice"
     assert preview["samples"]["messages"][0]["sender_name"] == "Alice (PM)"
     assert preview["samples"]["messages"][1]["message"] == "thanks team, fix incoming"
     assert preview["samples"]["messages"][1]["reply_to"] == "m_1001"
+    assert preview["samples"]["messages"][2]["message"] == "[文件: trace.json]"
+    assert preview["samples"]["messages"][3]["message"] == "[语音 7秒]"
 
 
 def test_qq_chat_history_importer_previews_qce_self_contained_html(tmp_path):
@@ -245,7 +260,7 @@ def test_qq_chat_history_importer_previews_qce_self_contained_html(tmp_path):
           <span class="message-time">2024-01-01 00:04:00</span>
         </div>
         <div class="message-content">
-          <div class="reply-content">
+          <div class="reply-content" data-reply-to="msg-m_1">
             <strong>Alice (PM):</strong>
             Anyone seen the build break?
           </div>
@@ -272,11 +287,13 @@ def test_qq_chat_history_importer_previews_qce_self_contained_html(tmp_path):
 
     assert preview["source_format"] == "qq_html_text"
     assert preview["group_id"] == "QCE Testing Group"
-    assert preview["counts"]["messages"] == 3
-    assert preview["counts"]["unique_senders"] == 2
+    assert preview["counts"]["messages"] == 4
+    assert preview["counts"]["unique_senders"] == 3
     assert preview["samples"]["messages"][0]["message"] == "Anyone seen the build break?"
     assert preview["samples"]["messages"][1]["sender_name"] == "Bob"
     assert preview["samples"]["messages"][2]["message"] == "thanks team, fix incoming"
+    assert preview["samples"]["messages"][2]["reply_to"] == "m_1"
+    assert preview["samples"]["messages"][3]["message"] == "[语音: voice_msg.silk]"
 
 
 def test_qq_chat_history_importer_can_include_training_pairs(tmp_path):
@@ -287,7 +304,7 @@ def test_qq_chat_history_importer_can_include_training_pairs(tmp_path):
         include_training_pairs=True,
     )
 
-    assert preview["counts"]["messages"] == 4
+    assert preview["counts"]["messages"] == 5
     assert preview["counts"]["bot_messages"] == 2
     assert any(
         item["message"] == "所以游戏都删了"
@@ -314,11 +331,11 @@ async def test_qq_chat_history_importer_imports_and_deduplicates_raw_messages(tm
         second = await importer.import_from_source(source_path=export_dir)
 
         assert first["success"] is True
-        assert first["messages_seen"] == 2
-        assert first["messages_imported"] == 2
+        assert first["messages_seen"] == 3
+        assert first["messages_imported"] == 3
         assert first["duplicate_messages"] == 0
         assert second["messages_imported"] == 0
-        assert second["duplicate_messages"] == 2
+        assert second["duplicate_messages"] == 3
 
         async with manager.get_session() as session:
             rows = (
@@ -327,12 +344,13 @@ async def test_qq_chat_history_importer_imports_and_deduplicates_raw_messages(tm
                 )
             ).scalars().all()
 
-        assert len(rows) == 2
+        assert len(rows) == 3
         assert rows[0].group_id == "AstrBot 大学"
         assert rows[0].message == "这不160兆吗"
         assert rows[0].message_id.startswith("qq-history:")
-        assert rows[1].reply_to == "m1"
-        assert rows[1].processed is False
+        assert rows[1].message == "[图片:demo.jpg]"
+        assert rows[2].reply_to == "m1"
+        assert rows[2].processed is False
     finally:
         await manager.stop()
 

--- a/tests/unit/test_qq_chat_history_importer.py
+++ b/tests/unit/test_qq_chat_history_importer.py
@@ -117,6 +117,168 @@ def test_qq_chat_history_importer_previews_qce_chunked_jsonl(tmp_path):
     assert preview["samples"]["messages"][1]["reply_to"] == "m1"
 
 
+def test_qq_chat_history_importer_previews_qce_single_json_type_codes(tmp_path):
+    export_file = tmp_path / "qce.json"
+    export_file.write_text(
+        json.dumps(
+            {
+                "metadata": {"name": "QQChatExporter V5"},
+                "chatInfo": {
+                    "name": "QCE Testing Group",
+                    "type": "group",
+                    "participantCount": 4,
+                },
+                "messages": [
+                    {
+                        "seq": "1001",
+                        "timestamp": 1704067300000,
+                        "time": "2024-01-01 00:01:40",
+                        "sender": {
+                            "uid": "u_alice",
+                            "uin": "11111",
+                            "name": "Alice",
+                            "groupCard": "Alice (PM)",
+                        },
+                        "type": "type_1",
+                        "content": {
+                            "text": "Anyone seen the build break?",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "data": {"text": "Anyone seen the build break?"},
+                                }
+                            ],
+                        },
+                        "recalled": False,
+                        "system": False,
+                    },
+                    {
+                        "seq": "1002",
+                        "timestamp": 1704067440000,
+                        "sender": {
+                            "uid": "u_alice",
+                            "uin": "11111",
+                            "name": "Alice",
+                            "groupCard": "Alice (PM)",
+                        },
+                        "type": "type_3",
+                        "content": {
+                            "text": "[回复 Alice: Anyone seen the build break?]\nthanks team, fix incoming",
+                            "elements": [
+                                {
+                                    "type": "text",
+                                    "data": {
+                                        "text": "[回复 Alice: Anyone seen the build break?]\nthanks team, fix incoming"
+                                    },
+                                },
+                                {
+                                    "type": "reply",
+                                    "data": {"referencedMessageId": "m_1001"},
+                                },
+                            ],
+                        },
+                        "recalled": False,
+                        "system": False,
+                    },
+                    {
+                        "seq": "1003",
+                        "timestamp": 1704067500000,
+                        "sender": {"uid": "u_bob", "uin": "22222", "name": "Bob"},
+                        "type": "type_8",
+                        "content": {
+                            "text": "[文件: trace.json]",
+                            "elements": [{"type": "file", "data": {"filename": "trace.json"}}],
+                        },
+                        "recalled": False,
+                        "system": False,
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    preview = QQChatHistoryImporter().preview(source_path=export_file)
+
+    assert preview["source_format"] == "qce_json"
+    assert preview["chat_info"]["name"] == "QCE Testing Group"
+    assert preview["group_id"] == "QCE Testing Group"
+    assert preview["counts"]["messages"] == 2
+    assert preview["counts"]["unique_senders"] == 1
+    assert preview["samples"]["messages"][0]["sender_id"] == "u_alice"
+    assert preview["samples"]["messages"][0]["sender_name"] == "Alice (PM)"
+    assert preview["samples"]["messages"][1]["message"] == "thanks team, fix incoming"
+    assert preview["samples"]["messages"][1]["reply_to"] == "m_1001"
+
+
+def test_qq_chat_history_importer_previews_qce_self_contained_html(tmp_path):
+    export_file = tmp_path / "qce.html"
+    export_file.write_text(
+        """<!doctype html>
+<html lang="zh-CN">
+<body>
+  <div class="chat-container">
+    <h1 class="chat-title">QCE Testing Group</h1>
+    <div class="messages-container" id="messagesContainer">
+      <div class="message" data-message-id="m_1">
+        <div class="message-header">
+          <span class="message-sender">Alice (PM)</span>
+          <span class="message-time">2024-01-01 00:01:40</span>
+        </div>
+        <div class="message-content">
+          Anyone seen the build break?
+        </div>
+      </div>
+      <div class="message" data-message-id="m_2">
+        <div class="message-header">
+          <span class="message-sender">Bob (Eng)</span>
+          <span class="message-time">2024-01-01 00:02:40</span>
+        </div>
+        <div class="message-content">
+          Looking now [[微笑]]
+        </div>
+      </div>
+      <div class="message" data-message-id="m_3">
+        <div class="message-header">
+          <span class="message-sender">Alice (PM)</span>
+          <span class="message-time">2024-01-01 00:04:00</span>
+        </div>
+        <div class="message-content">
+          <div class="reply-content">
+            <strong>Alice (PM):</strong>
+            Anyone seen the build break?
+          </div>
+          [回复 Alice (PM): Anyone seen the build break?]<br>thanks team, fix incoming
+        </div>
+      </div>
+      <div class="message" data-message-id="m_4">
+        <div class="message-header">
+          <span class="message-sender">Charlie</span>
+          <span class="message-time">2024-01-01 00:05:00</span>
+        </div>
+        <div class="message-content">
+          [语音: voice_msg.silk]
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>""",
+        encoding="utf-8",
+    )
+
+    preview = QQChatHistoryImporter().preview(source_path=export_file)
+
+    assert preview["source_format"] == "qq_html_text"
+    assert preview["group_id"] == "QCE Testing Group"
+    assert preview["counts"]["messages"] == 3
+    assert preview["counts"]["unique_senders"] == 2
+    assert preview["samples"]["messages"][0]["message"] == "Anyone seen the build break?"
+    assert preview["samples"]["messages"][1]["sender_name"] == "Bob"
+    assert preview["samples"]["messages"][2]["message"] == "thanks team, fix incoming"
+
+
 def test_qq_chat_history_importer_can_include_training_pairs(tmp_path):
     _write_qce_export(tmp_path)
 


### PR DESCRIPTION
## Summary
- support qq-chat-exporter single JSON exports that use qce type codes like `type_1`/`type_3`/`type_8`
- preserve top-level `chatInfo` for preview group metadata
- parse qq-chat-exporter self-contained HTML message DOM before falling back to plain text parsing
- preserve media-only placeholders such as images/files/audio instead of dropping them as empty content
- keep self-contained HTML reply targets from `.reply-content[data-reply-to]`
- add regression coverage for QCE JSON, chunked JSONL, self-contained HTML previews, raw-message import, and dedupe

## Upstream evidence
- `shuakami/qq-chat-exporter` JSON snapshot `plugins/qq-chat-exporter/__tests__/integration/__snapshots__/JsonExporter.groupMixedMedia.snap.json` uses top-level `metadata`, `chatInfo`, `statistics`, `messages`, plus message `sender`, `type`, `content.text/html/elements/resources` fields.
- `shuakami/qq-chat-exporter` HTML snapshot `plugins/qq-chat-exporter/__tests__/integration/__snapshots__/HtmlExporter.groupMixedMedia.snap.html` renders `.message[data-message-id]`, `.message-sender`, `.message-time`, `.message-content`, and reply blocks with `data-reply-to="msg-..."`.
- `plugins/qq-chat-exporter/lib/core/exporter/JsonExporter.ts` is the matching exporter implementation source for the JSON contract.

## Tests
- `python -m pytest tests\unit\test_qq_chat_history_importer.py tests\integration\test_qq_chat_history_integration_routes.py -q`
- `python -m py_compile services\integration\qq_chat_history_importer.py tests\unit\test_qq_chat_history_importer.py tests\integration\test_qq_chat_history_integration_routes.py`
- `python -m ruff check services\integration\qq_chat_history_importer.py tests\unit\test_qq_chat_history_importer.py tests\integration\test_qq_chat_history_integration_routes.py`
- `git diff --check`

Fixes #230