### PR TITLE
fix: honor realtime setting for V2 learning

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -959,6 +959,12 @@
         "hint": "AstrBot 冷启动时 Provider 注册表可能尚未就绪。插件会按此间隔重试绑定 Embedding/Reranker Provider。",
         "default": 10.0
       },
+      "enable_realtime_v2_processing": {
+        "description": "启用 V2 实时逐消息处理",
+        "type": "bool",
+        "hint": "实时学习关闭时，是否仍按每条消息触发 V2 分层处理。V2 会按短冷却批量触发 LightRAG/Mem0/黑话推理等高成本模型调用；默认关闭以遵守实时学习开关和学习间隔。",
+        "default": false
+      },
       "knowledge_engine": {
         "description": "知识引擎",
         "type": "string",

--- a/config.py
+++ b/config.py
@@ -179,6 +179,7 @@ class PluginConfig(BaseModel):
     rerank_top_k: int = 5
     rerank_min_candidates: int = 3 # 候选文档数低于此阈值时跳过 rerank 以节省延迟
     provider_retry_interval_seconds: float = 10.0 # Provider 注册表未就绪时的重试间隔
+    enable_realtime_v2_processing: bool = False # 实时学习关闭时是否仍按消息触发V2处理
 
     # v2 Architecture: Knowledge engine
     knowledge_engine: str = "legacy" # "lightrag" | "legacy"
@@ -479,6 +480,9 @@ class PluginConfig(BaseModel):
             rerank_min_candidates=v2_settings.get('rerank_min_candidates', 3),
             provider_retry_interval_seconds=v2_settings.get(
                 'provider_retry_interval_seconds', 10.0
+            ),
+            enable_realtime_v2_processing=v2_settings.get(
+                'enable_realtime_v2_processing', False
             ),
             knowledge_engine=v2_settings.get('knowledge_engine', 'legacy'),
             lightrag_query_mode=v2_settings.get('lightrag_query_mode', 'local'),

--- a/services/learning/message_pipeline.py
+++ b/services/learning/message_pipeline.py
@@ -61,6 +61,13 @@ class MessagePipeline:
         )
         self._groups_seeded = self._jargon_learning.groups_seeded
 
+    def _should_process_v2_realtime(self) -> bool:
+        """Return whether V2 realtime, per-message processing is enabled."""
+        return bool(
+            getattr(self._config, "enable_realtime_learning", False)
+            or getattr(self._config, "enable_realtime_v2_processing", False)
+        )
+
     # 后台学习流水线（6 步）
 
     @monitored
@@ -141,7 +148,7 @@ class MessagePipeline:
                     self._spawn_jargon_task(group_id, raw_message_count)
 
             # 3.5 V2 per-message processing
-            if self._v2_integration:
+            if self._v2_integration and self._should_process_v2_realtime():
                 try:
                     msg_data = MessageData(
                         message=message_text,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,6 +37,7 @@ class TestPluginConfigDefaults:
         assert config.enable_auto_learning is True
         assert config.enable_realtime_learning is False
         assert config.enable_realtime_llm_filter is False
+        assert config.enable_realtime_v2_processing is False
         assert config.enable_realtime_expression_learning is False
         assert config.enable_llm_hooks is False
         assert config.enable_web_interface is True
@@ -276,6 +277,7 @@ class TestPluginConfigFromDict:
                 'embedding_provider_id': 'embed_provider',
                 'rerank_provider_id': 'rerank_provider',
                 'provider_retry_interval_seconds': 2.5,
+                'enable_realtime_v2_processing': True,
                 'knowledge_engine': 'lightrag',
                 'memory_engine': 'mem0',
             }
@@ -286,6 +288,7 @@ class TestPluginConfigFromDict:
         assert config.embedding_provider_id == 'embed_provider'
         assert config.rerank_provider_id == 'rerank_provider'
         assert config.provider_retry_interval_seconds == 2.5
+        assert config.enable_realtime_v2_processing is True
         assert config.knowledge_engine == 'lightrag'
         assert config.memory_engine == 'mem0'
 

--- a/tests/unit/test_learning_chain_regressions.py
+++ b/tests/unit/test_learning_chain_regressions.py
@@ -850,6 +850,122 @@ async def test_message_pipeline_can_run_expression_learning_when_explicitly_enab
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_message_pipeline_skips_v2_processing_when_realtime_disabled_by_default():
+    config = SimpleNamespace(
+        enable_jargon_learning=False,
+        enable_realtime_learning=False,
+        enable_style_learning=False,
+        enable_goal_driven_chat=False,
+    )
+    v2_integration = SimpleNamespace(process_message=AsyncMock())
+    pipeline = MessagePipeline(
+        plugin_config=config,
+        message_collector=SimpleNamespace(collect_message=AsyncMock(return_value=True)),
+        enhanced_interaction=SimpleNamespace(update_conversation_context=AsyncMock()),
+        jargon_miner_manager=None,
+        jargon_statistical_filter=None,
+        v2_integration=v2_integration,
+        realtime_processor=SimpleNamespace(
+            process_expression_learning_background=AsyncMock(),
+            process_realtime_background=AsyncMock(),
+        ),
+        group_orchestrator=SimpleNamespace(),
+        conversation_goal_manager=None,
+        affection_manager=SimpleNamespace(),
+        db_manager=SimpleNamespace(),
+    )
+    event = SimpleNamespace(
+        get_sender_name=lambda: "User A",
+        get_platform_name=lambda: "test",
+        get_self_id=lambda: "bot-a",
+    )
+
+    await pipeline.process_learning("group-a", "user-a", "实时关闭时的普通消息", event)
+
+    v2_integration.process_message.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_message_pipeline_runs_v2_processing_when_realtime_enabled():
+    config = SimpleNamespace(
+        enable_jargon_learning=False,
+        enable_realtime_learning=True,
+        enable_style_learning=False,
+        enable_goal_driven_chat=False,
+    )
+    v2_integration = SimpleNamespace(process_message=AsyncMock())
+    pipeline = MessagePipeline(
+        plugin_config=config,
+        message_collector=SimpleNamespace(collect_message=AsyncMock(return_value=True)),
+        enhanced_interaction=SimpleNamespace(update_conversation_context=AsyncMock()),
+        jargon_miner_manager=None,
+        jargon_statistical_filter=None,
+        v2_integration=v2_integration,
+        realtime_processor=SimpleNamespace(
+            process_expression_learning_background=AsyncMock(),
+            process_realtime_background=AsyncMock(),
+        ),
+        group_orchestrator=SimpleNamespace(),
+        conversation_goal_manager=None,
+        affection_manager=SimpleNamespace(),
+        db_manager=SimpleNamespace(),
+    )
+    event = SimpleNamespace(
+        get_sender_name=lambda: "User A",
+        get_platform_name=lambda: "test",
+        get_self_id=lambda: "bot-a",
+    )
+
+    await pipeline.process_learning("group-a", "user-a", "实时开启时的普通消息", event)
+
+    v2_integration.process_message.assert_awaited_once()
+    message_data, group_id = v2_integration.process_message.await_args.args
+    assert group_id == "group-a"
+    assert isinstance(message_data, MessageData)
+    assert message_data.message == "实时开启时的普通消息"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_message_pipeline_runs_v2_processing_when_explicitly_opted_in():
+    config = SimpleNamespace(
+        enable_jargon_learning=False,
+        enable_realtime_learning=False,
+        enable_realtime_v2_processing=True,
+        enable_style_learning=False,
+        enable_goal_driven_chat=False,
+    )
+    v2_integration = SimpleNamespace(process_message=AsyncMock())
+    pipeline = MessagePipeline(
+        plugin_config=config,
+        message_collector=SimpleNamespace(collect_message=AsyncMock(return_value=True)),
+        enhanced_interaction=SimpleNamespace(update_conversation_context=AsyncMock()),
+        jargon_miner_manager=None,
+        jargon_statistical_filter=None,
+        v2_integration=v2_integration,
+        realtime_processor=SimpleNamespace(
+            process_expression_learning_background=AsyncMock(),
+            process_realtime_background=AsyncMock(),
+        ),
+        group_orchestrator=SimpleNamespace(),
+        conversation_goal_manager=None,
+        affection_manager=SimpleNamespace(),
+        db_manager=SimpleNamespace(),
+    )
+    event = SimpleNamespace(
+        get_sender_name=lambda: "User A",
+        get_platform_name=lambda: "test",
+        get_self_id=lambda: "bot-a",
+    )
+
+    await pipeline.process_learning("group-a", "user-a", "显式开启 V2 实时消息", event)
+
+    v2_integration.process_message.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_message_pipeline_skips_plugin_log_events_before_collection():
     config = SimpleNamespace(
         enable_jargon_learning=False,

--- a/tests/unit/test_persona_review_service.py
+++ b/tests/unit/test_persona_review_service.py
@@ -8,6 +8,7 @@ Tests the persona review service including:
 """
 import pytest
 from unittest.mock import Mock, AsyncMock
+from webui.services import persona_review_service as persona_review_module
 from webui.services.persona_review_service import PersonaReviewService
 
 
@@ -51,6 +52,52 @@ class TestPersonaReviewService:
         assert result['total'] == 1
         assert len(result['updates']) == 1
         assert result['updates'][0]['review_source'] == 'traditional'
+
+    @pytest.mark.asyncio
+    async def test_get_pending_persona_updates_polling_logs_are_debug(
+        self, mock_container, monkeypatch
+    ):
+        """Dashboard polling should not emit routine persona-review reads at INFO."""
+        messages = {"info": [], "debug": []}
+
+        class FakeLogger:
+            def info(self, message, *args, **kwargs):
+                messages["info"].append(str(message))
+
+            def debug(self, message, *args, **kwargs):
+                messages["debug"].append(str(message))
+
+            def warning(self, *args, **kwargs):
+                pass
+
+            def error(self, *args, **kwargs):
+                pass
+
+        monkeypatch.setattr(persona_review_module, "logger", FakeLogger())
+        service = PersonaReviewService(mock_container)
+        mock_container.persona_updater.get_pending_persona_updates.return_value = []
+        mock_container.database_manager.get_pending_persona_learning_reviews.return_value = []
+        mock_container.database_manager.get_pending_style_reviews.return_value = []
+
+        result = await service.get_pending_persona_updates(limit=10)
+
+        assert result["success"] is True
+        routine_markers = (
+            "正在获取传统人格更新",
+            "获取到 0 个传统人格更新",
+            "正在获取人格学习审查",
+            "获取到 0 个人格学习审查",
+            "正在获取风格学习审查",
+            "获取到 0 个风格学习审查",
+            "共 0 条人格更新记录",
+            "分页返回",
+        )
+        assert not any(
+            marker in message
+            for marker in routine_markers
+            for message in messages["info"]
+        )
+        assert any("分页返回" in message for message in messages["debug"])
 
     @pytest.mark.asyncio
     async def test_get_pending_persona_updates_three_sources(

--- a/tests/unit/test_persona_review_service.py
+++ b/tests/unit/test_persona_review_service.py
@@ -55,49 +55,35 @@ class TestPersonaReviewService:
 
     @pytest.mark.asyncio
     async def test_get_pending_persona_updates_polling_logs_are_debug(
-        self, mock_container, monkeypatch
+        self, mock_container, caplog
     ):
         """Dashboard polling should not emit routine persona-review reads at INFO."""
-        messages = {"info": [], "debug": []}
-
-        class FakeLogger:
-            def info(self, message, *args, **kwargs):
-                messages["info"].append(str(message))
-
-            def debug(self, message, *args, **kwargs):
-                messages["debug"].append(str(message))
-
-            def warning(self, *args, **kwargs):
-                pass
-
-            def error(self, *args, **kwargs):
-                pass
-
-        monkeypatch.setattr(persona_review_module, "logger", FakeLogger())
         service = PersonaReviewService(mock_container)
         mock_container.persona_updater.get_pending_persona_updates.return_value = []
         mock_container.database_manager.get_pending_persona_learning_reviews.return_value = []
         mock_container.database_manager.get_pending_style_reviews.return_value = []
 
-        result = await service.get_pending_persona_updates(limit=10)
+        service_logger = persona_review_module.logger
+        logger_name = service_logger.name
+        service_logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level("DEBUG", logger=logger_name):
+                result = await service.get_pending_persona_updates(limit=10)
+        finally:
+            service_logger.removeHandler(caplog.handler)
 
         assert result["success"] is True
-        routine_markers = (
-            "正在获取传统人格更新",
-            "获取到 0 个传统人格更新",
-            "正在获取人格学习审查",
-            "获取到 0 个人格学习审查",
-            "正在获取风格学习审查",
-            "获取到 0 个风格学习审查",
-            "共 0 条人格更新记录",
-            "分页返回",
-        )
+        service_records = [
+            record for record in caplog.records if record.name == logger_name
+        ]
         assert not any(
-            marker in message
-            for marker in routine_markers
-            for message in messages["info"]
+            record.levelname == "INFO" for record in service_records
         )
-        assert any("分页返回" in message for message in messages["debug"])
+        assert any(
+            record.levelname == "DEBUG"
+            and "offset=0, limit=10" in record.getMessage()
+            for record in service_records
+        )
 
     @pytest.mark.asyncio
     async def test_get_pending_persona_updates_three_sources(

--- a/webui/services/persona_review_service.py
+++ b/webui/services/persona_review_service.py
@@ -516,9 +516,9 @@ class PersonaReviewService:
         # 1. 获取传统的人格更新审查
         if self.persona_updater:
             try:
-                logger.info("正在获取传统人格更新...")
+                logger.debug("正在获取传统人格更新...")
                 traditional_updates = await self.persona_updater.get_pending_persona_updates()
-                logger.info(f"获取到 {len(traditional_updates)} 个传统人格更新")
+                logger.debug(f"获取到 {len(traditional_updates)} 个传统人格更新")
 
                 # 将PersonaUpdateRecord对象转换为字典格式
                 for record in traditional_updates:
@@ -564,9 +564,9 @@ class PersonaReviewService:
         # 2. 获取人格学习审查（包括渐进式学习、表达学习等）
         if self.database_manager:
             try:
-                logger.info("正在获取人格学习审查...")
+                logger.debug("正在获取人格学习审查...")
                 persona_learning_reviews = await self.database_manager.get_pending_persona_learning_reviews()
-                logger.info(f"获取到 {len(persona_learning_reviews)} 个人格学习审查")
+                logger.debug(f"获取到 {len(persona_learning_reviews)} 个人格学习审查")
 
                 for review in persona_learning_reviews:
                     # 使用常量进行类型标准化和分类
@@ -660,9 +660,9 @@ class PersonaReviewService:
         # 3. 获取风格学习审查（Few-shot样本学习）
         if self.database_manager:
             try:
-                logger.info("正在获取风格学习审查...")
+                logger.debug("正在获取风格学习审查...")
                 style_reviews = await self.database_manager.get_pending_style_reviews()
-                logger.info(f"获取到 {len(style_reviews)} 个风格学习审查")
+                logger.debug(f"获取到 {len(style_reviews)} 个风格学习审查")
 
                 for review in style_reviews:
                     group_id = review['group_id']
@@ -741,14 +741,14 @@ class PersonaReviewService:
 
         total = len(all_updates)
 
-        logger.info(f"共 {total} 条人格更新记录 (传统: {len([u for u in all_updates if u['review_source'] == 'traditional'])}, "
-                    f"人格学习: {len([u for u in all_updates if u['review_source'] == 'persona_learning'])}, "
-                    f"风格学习: {len([u for u in all_updates if u['review_source'] == 'style_learning'])})")
+        logger.debug(f"共 {total} 条人格更新记录 (传统: {len([u for u in all_updates if u['review_source'] == 'traditional'])}, "
+                     f"人格学习: {len([u for u in all_updates if u['review_source'] == 'persona_learning'])}, "
+                     f"风格学习: {len([u for u in all_updates if u['review_source'] == 'style_learning'])})")
 
         # 应用分页
         if limit > 0:
             paged_updates = all_updates[offset:offset + limit]
-            logger.info(f"分页返回: offset={offset}, limit={limit}, 本页 {len(paged_updates)} 条")
+            logger.debug(f"分页返回: offset={offset}, limit={limit}, 本页 {len(paged_updates)} 条")
         else:
             paged_updates = all_updates
 


### PR DESCRIPTION
## Summary
- honor `enable_realtime_learning` before V2 per-message processing so realtime-off setups do not keep triggering V2 tiered learning on every message
- add default-off `enable_realtime_v2_processing` in config/schema as an explicit opt-in for users who still want V2 realtime ingestion while realtime learning is off
- keep the earlier `/api/persona_updates` polling logs at DEBUG so dashboard refreshes no longer look like learning jobs

## Evidence
- Issue #232 now reports real model calls: realtime learning off, learning interval set to 6h, but about 59 model calls in 30 minutes and 1000+ calls total.
- `services/learning/message_pipeline.py` previously called `self._v2_integration.process_message(...)` for every inbound message whenever V2 integration existed, independent of `enable_realtime_learning`.
- `services/core_learning/v2_learning_integration.py` registers Tier 2 LLM-heavy operations including LightRAG/Mem0 ingestion flush every 5 messages or 60 seconds and jargon inference every 20 messages or 180 seconds using `llm.generate_response`.
- `services/learning/group_orchestrator.py` still respects `learning_interval_hours`, so the high-frequency path is the V2 realtime/tiered trigger, not the 6-hour scheduler.
- The original #232 WebUI logs also map to routine `/api/persona_updates` polling; those diagnostics remain downgraded from INFO to DEBUG.

## Tests
- `python -m pytest tests\unit\test_learning_chain_regressions.py tests\unit\test_config.py tests\unit\test_config_service.py tests\unit\test_persona_review_service.py -q` (159 passed)
- `python -m py_compile services\learning\message_pipeline.py config.py tests\unit\test_learning_chain_regressions.py tests\unit\test_config.py webui\services\persona_review_service.py tests\unit\test_persona_review_service.py`
- `python -m ruff check services\learning\message_pipeline.py config.py tests\unit\test_learning_chain_regressions.py tests\unit\test_config.py webui\services\persona_review_service.py tests\unit\test_persona_review_service.py`
- `git diff --check`

## Install validation
- Attempted earlier to copy into `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning`, run py_compile, import smoke, and pre-review.
- Blocked by Windows ACL `Access denied` reading/writing the installed plugin directory; no permission changes attempted.

Refs #232