### PR TITLE
chore: bump version to 3.4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 让 AstrBot 在群聊中持续采集、学习、审查并注入上下文，使 Bot 逐步具备表达风格、群组黑话、社交关系、长期记忆和人格演化能力。
 
-[![Version](https://img.shields.io/badge/version-3.4.4-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
+[![Version](https://img.shields.io/badge/version-3.4.5-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE)
 [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-3.4.4-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+[![Version](https://img.shields.io/badge/version-3.4.5-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 
 [Features](#what-we-can-do) · [Quick Start](#quick-start) · [Web UI](#visual-management-interface) · [Community](#community) · [Contributing](CONTRIBUTING.md)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 # AstrBot 自学习插件
-__version__ = "3.4.4"
+__version__ = "3.4.5"
 
 # Ensure parent namespace packages ("data", "data.plugins") are
 # durably registered in sys.modules.  AstrBot loads plugins via

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: "astrbot_plugin_self_learning"
 author: "NickMo, EterUltimate"
 display_name: "self-learning"
 description: "SELF LEARNING 自主学习插件 — 让 AI 聊天机器人自主学习对话风格、理解群组黑话、管理社交关系与好感度、自适应人格演化，像真人一样自然对话。(使用前必须手动备份人格数据)"
-version: "3.4.4"
+version: "3.4.5"
 repo: "https://github.com/NickCharlie/astrbot_plugin_self_learning"
 tags:
   - "自学习"


### PR DESCRIPTION
## Summary
- bump plugin version from 3.4.4 to 3.4.5 after merging the QCE import fix in #231
- update metadata and README version badges

## Tests
- `python -m py_compile __init__.py`
- `python -m ruff check __init__.py`
- `git diff --check`
- `rg -n "3\.4\.4|3\.4\.5|version:" metadata.yaml __init__.py README.md README_EN.md`

## Summary by Sourcery

Bump the plugin to version 3.4.5 and align associated metadata and documentation.

Enhancements:
- Update the plugin package version metadata from 3.4.4 to 3.4.5.

Documentation:
- Refresh README version badges to reflect the 3.4.5 release.