### PR TITLE
fix: accept extra after-message hook args

### DIFF
--- a/main.py
+++ b/main.py
@@ -440,7 +440,7 @@ class SelfLearningPlugin(star.Star):
 
     @filter.after_message_sent()
     @monitored
-    async def on_bot_message_sent(self, event: AstrMessageEvent):
+    async def on_bot_message_sent(self, event: AstrMessageEvent, *_args):
         """捕获 Bot 发送的消息并存入数据库，用于 fewshot 对话对提取。"""
         reset_trace_context()
         try:

--- a/tests/integration/test_package_imports.py
+++ b/tests/integration/test_package_imports.py
@@ -3,6 +3,7 @@ import asyncio
 import builtins
 import importlib
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -57,6 +58,24 @@ def test_webui_persona_review_service_imports_under_astrbot_package_path():
 
         assert module.UPDATE_TYPE_STYLE_LEARNING
         assert module.normalize_update_type("style_learning")
+    finally:
+        _cleanup_alias(alias)
+
+
+def test_after_message_sent_hook_accepts_framework_extra_args():
+    """AstrBot v4.26.5 can pass extra hook args after the event object."""
+    alias = "data.plugins.astrbot_plugin_self_learning_hook_signature_pkgtest"
+    _cleanup_alias(alias)
+
+    try:
+        _load_plugin_package(alias)
+        module = importlib.import_module(f"{alias}.main")
+        signature = inspect.signature(module.SelfLearningPlugin.on_bot_message_sent)
+
+        assert any(
+            param.kind is inspect.Parameter.VAR_POSITIONAL
+            for param in signature.parameters.values()
+        )
     finally:
         _cleanup_alias(alias)
 


### PR DESCRIPTION
## Summary

- Accept extra positional arguments in the selflearning `after_message_sent` hook.
- Add a package-path import regression test that verifies the hook signature remains compatible.

## Evidence

- `lxfight-s-Astrbot-Plugins/astrbot_plugin_livingmemory` PR #196 / merge `e2ac45d4bdb09a42def646be21cc6292a2b02736` fixed the same AstrBot v4.26.5 hook dispatcher issue.
- Related LivingMemory issue #195 shows AstrBot v4.26.5 calling `after_message_sent` as `event, *args, **kwargs`, producing `TypeError: ... takes 2 positional arguments but 3 were given` for single-argument plugin hooks.
- Local selflearning `main.py` had `SelfLearningPlugin.on_bot_message_sent(self, event)` under `@filter.after_message_sent()`.

## Validation

- `python -m pytest tests/integration/test_package_imports.py -q`
- `python -m py_compile main.py tests\integration\test_package_imports.py`
- `git diff --check`
- AstrBot local smoke test in `C:\Users\zacza\Desktop\x\AstrBot\data\plugins\astrbot_plugin_self_learning`: imported plugin and called `on_bot_message_sent(event, extra_arg)` successfully.

## Summary by Sourcery

Allow the self-learning plugin’s after-message hook to accept extra positional arguments while ensuring its signature remains compatible with AstrBot’s framework calls.

Bug Fixes:
- Prevent TypeError when AstrBot passes extra positional arguments to the self-learning plugin’s after_message_sent hook.

Enhancements:
- Add an integration test that validates the after_message_sent hook’s signature supports additional positional arguments.