### PR TITLE
fix: unify plugin config source

### DIFF
--- a/config.py
+++ b/config.py
@@ -638,59 +638,6 @@ class PluginConfig(BaseModel):
         )
 
     @classmethod
-    def _flatten_config_payload(cls, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Flatten grouped config with direct fields taking precedence."""
-        grouped: Dict[str, Any] = {}
-        direct: Dict[str, Any] = {}
-        for key, value in payload.items():
-            if isinstance(value, dict) and key not in cls.model_fields:
-                nested = cls._flatten_config_payload(value)
-                duplicated = sorted(set(grouped) & set(nested))
-                if duplicated:
-                    logger.info(
-                        "持久化配置分组字段覆盖较早分组字段: "
-                        f"{', '.join(duplicated)}"
-                    )
-                grouped.update(nested)
-            else:
-                direct[key] = value
-
-        duplicated = sorted(set(grouped) & set(direct))
-        if duplicated:
-            logger.info(
-                "持久化配置顶层字段覆盖分组字段: "
-                f"{', '.join(duplicated)}"
-            )
-
-        return {**grouped, **direct}
-
-    @staticmethod
-    def _file_mtime(path: Optional[str]) -> Optional[float]:
-        if not path:
-            return None
-        try:
-            return os.path.getmtime(os.fspath(path))
-        except (OSError, TypeError, ValueError):
-            return None
-
-    @classmethod
-    def _should_load_persisted_config(
-        cls,
-        config_file: Optional[str],
-        astrbot_config_file: Optional[str] = None,
-    ) -> bool:
-        """Return whether the WebUI compatibility cache should override AstrBot config."""
-        persisted_mtime = cls._file_mtime(config_file)
-        if persisted_mtime is None:
-            return False
-
-        astrbot_mtime = cls._file_mtime(astrbot_config_file)
-        if astrbot_mtime is None:
-            return True
-
-        return persisted_mtime > astrbot_mtime
-
-    @classmethod
     def create_from_runtime_sources(
         cls,
         config: dict,
@@ -698,59 +645,13 @@ class PluginConfig(BaseModel):
         config_file: Optional[str] = None,
         astrbot_config_file: Optional[str] = None,
     ) -> 'PluginConfig':
-        """Create config from AstrBot settings and optional persisted WebUI config."""
-        runtime_config = cls.create_from_config(config or {}, data_dir=data_dir)
-        if astrbot_config_file is None:
-            astrbot_config_file = getattr(config, "config_path", None)
-
-        if not cls._should_load_persisted_config(config_file, astrbot_config_file):
-            if cls._file_mtime(config_file) is not None and cls._file_mtime(astrbot_config_file) is not None:
-                logger.info(
-                    "AstrBot 配置不旧于 WebUI 兼容配置，跳过旧副本覆盖: "
-                    f"{config_file}"
-                )
-            return runtime_config
-
-        try:
-            with open(config_file, 'r', encoding='utf-8') as f:
-                persisted_data = json.load(f)
-        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as e:
-            logger.warning(f"读取持久化配置失败，继续使用AstrBot配置: {e}")
-            return runtime_config
-
-        if not isinstance(persisted_data, dict):
-            logger.warning("持久化配置格式无效，继续使用AstrBot配置")
-            return runtime_config
-
-        merged = runtime_config.to_dict()
-        persisted_config = cls._flatten_config_payload(persisted_data)
-        for provider_field in ROLE_PROVIDER_ID_FIELDS:
-            if (
-                getattr(runtime_config, provider_field, None)
-                and not persisted_config.get(provider_field)
-            ):
-                persisted_config.pop(provider_field, None)
-
-        overridden = sorted(
-            key
-            for key, value in persisted_config.items()
-            if key in merged and merged[key] != value
-        )
-        if overridden:
+        """Create config from the single AstrBot plugin settings source."""
+        if config_file and os.path.exists(os.fspath(config_file)):
             logger.info(
-                "持久化配置覆盖AstrBot运行时字段: "
-                f"{', '.join(overridden)}"
+                "检测到旧版 WebUI 配置副本，运行时已忽略该文件，"
+                f"统一使用 AstrBot 插件配置: {config_file}"
             )
-        merged.update(persisted_config)
-
-        try:
-            loaded_config = cls.model_validate(merged)
-        except ValidationError as e:
-            logger.warning(f"持久化配置校验失败，继续使用AstrBot配置: {e}")
-            return runtime_config
-
-        logger.info(f"已加载持久化插件配置: {config_file}")
-        return loaded_config
+        return cls.create_from_config(config or {}, data_dir=data_dir)
 
     @classmethod
     def create_default(cls) -> 'PluginConfig':

--- a/core/plugin_lifecycle.py
+++ b/core/plugin_lifecycle.py
@@ -1,6 +1,4 @@
 """插件全生命周期编排 — 服务初始化 → 异步启动 → 有序关停"""
-import os
-import json
 import asyncio
 from typing import Any, Dict, TYPE_CHECKING
 
@@ -569,15 +567,6 @@ class PluginLifecycle:
                     "停止 WebUI",
                     self._webui_manager.stop(),
                 )
-
-            # 9. 保存配置
-            try:
-                config_path = os.path.join(p.plugin_config.data_dir, "config.json")
-                with open(config_path, "w", encoding="utf-8") as f:
-                    json.dump(p.plugin_config.to_dict(), f, ensure_ascii=False, indent=2)
-                logger.info(LogMessages.PLUGIN_CONFIG_SAVED)
-            except Exception as e:
-                logger.error(f"保存配置失败: {e}")
 
             logger.info(LogMessages.PLUGIN_UNLOAD_SUCCESS)
 

--- a/main.py
+++ b/main.py
@@ -440,7 +440,7 @@ class SelfLearningPlugin(star.Star):
 
     @filter.after_message_sent()
     @monitored
-    async def on_bot_message_sent(self, event: AstrMessageEvent):
+    async def on_bot_message_sent(self, event: AstrMessageEvent, *_args):
         """捕获 Bot 发送的消息并存入数据库，用于 fewshot 对话对提取。"""
         reset_trace_context()
         try:

--- a/main.py
+++ b/main.py
@@ -66,6 +66,22 @@ def _migrate_legacy_data_dir(astrbot_data_path: str, plugin_data_dir: str) -> No
             logger.warning(f"迁移旧版自学习数据目录失败 ({legacy} -> {target}): {exc}")
 
 
+def _archive_legacy_config_copy(config_file: str) -> None:
+    """Move the old WebUI config copy aside so it cannot be mistaken as active."""
+    if not os.path.isfile(config_file):
+        return
+
+    archive_path = f"{config_file}.legacy"
+    if os.path.exists(archive_path):
+        archive_path = f"{config_file}.{int(time.time())}.legacy"
+
+    try:
+        os.replace(config_file, archive_path)
+        logger.info(f"已归档旧版 WebUI 配置副本: {archive_path}")
+    except OSError as exc:
+        logger.warning(f"归档旧版 WebUI 配置副本失败，将继续忽略该文件: {exc}")
+
+
 def _default_plugin_data_dir(astrbot_data_path: str) -> str:
     try:
         data_dir = StarTools.get_data_dir()
@@ -148,6 +164,7 @@ class SelfLearningPlugin(star.Star):
                 config_file=config_file,
                 astrbot_config_file=getattr(self.config, "config_path", None),
             )
+            _archive_legacy_config_copy(config_file)
 
             logger.info(f"[插件初始化] Provider配置已加载：")
             logger.info(f" - filter_provider_id: {self.plugin_config.filter_provider_id}")
@@ -165,6 +182,7 @@ class SelfLearningPlugin(star.Star):
                 config_file=config_file,
                 astrbot_config_file=getattr(self.config, "config_path", None),
             )
+            _archive_legacy_config_copy(config_file)
 
         os.makedirs(self.plugin_config.data_dir, exist_ok=True)
 

--- a/tests/integration/test_config_blueprint.py
+++ b/tests/integration/test_config_blueprint.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import UserDict
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -18,6 +20,29 @@ def assert_no_store_headers(response):
     assert response.headers["Cache-Control"] == "no-store"
     assert response.headers["Pragma"] == "no-cache"
     assert response.headers["Expires"] == "0"
+
+
+class SaveableConfig(UserDict):
+    def __init__(self, *args, **kwargs):
+        self.config_path = kwargs.pop("config_path", None)
+        super().__init__(*args, **kwargs)
+        self.save_calls = 0
+        self.saved_payloads = []
+
+    def save_config(self, replace_config=None):
+        self.save_calls += 1
+        if replace_config is not None:
+            self.data.clear()
+            self.data.update(replace_config)
+            self.saved_payloads.append(replace_config)
+        else:
+            self.saved_payloads.append(dict(self.data))
+        if self.config_path:
+            Path(self.config_path).parent.mkdir(parents=True, exist_ok=True)
+            Path(self.config_path).write_text(
+                json.dumps(self.data),
+                encoding="utf-8",
+            )
 
 
 def build_container(tmp_path: Path):
@@ -70,6 +95,25 @@ def build_container(tmp_path: Path):
     container.plugin_config = plugin_config
     container.factory_manager = factory_manager
     container.llm_adapter = Mock()
+    container.astrbot_config = SaveableConfig(
+        {
+            "Target_Settings": {
+                "target_qq_list": [],
+                "target_blacklist": [],
+            },
+            "Learning_Parameters": {
+                "learning_interval_hours": plugin_config.learning_interval_hours,
+                "max_messages_per_batch": plugin_config.max_messages_per_batch,
+            },
+            "Style_Analysis": {
+                "style_update_threshold": plugin_config.style_update_threshold,
+            },
+            "Filter_Parameters": {
+                "relevance_threshold": plugin_config.relevance_threshold,
+            },
+        },
+        config_path=tmp_path / "astrbot_plugin_self_learning_config.json",
+    )
     return container
 
 

--- a/tests/integration/test_package_imports.py
+++ b/tests/integration/test_package_imports.py
@@ -3,6 +3,7 @@ import asyncio
 import builtins
 import importlib
 import importlib.util
+import inspect
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -57,6 +58,24 @@ def test_webui_persona_review_service_imports_under_astrbot_package_path():
 
         assert module.UPDATE_TYPE_STYLE_LEARNING
         assert module.normalize_update_type("style_learning")
+    finally:
+        _cleanup_alias(alias)
+
+
+def test_after_message_sent_hook_accepts_framework_extra_args():
+    """AstrBot v4.26.5 can pass extra hook args after the event object."""
+    alias = "data.plugins.astrbot_plugin_self_learning_hook_signature_pkgtest"
+    _cleanup_alias(alias)
+
+    try:
+        _load_plugin_package(alias)
+        module = importlib.import_module(f"{alias}.main")
+        signature = inspect.signature(module.SelfLearningPlugin.on_bot_message_sent)
+
+        assert any(
+            param.kind is inspect.Parameter.VAR_POSITIONAL
+            for param in signature.parameters.values()
+        )
     finally:
         _cleanup_alias(alias)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -708,71 +708,39 @@ class TestPluginConfigSerialization:
         finally:
             os.unlink(filepath)
 
-    def test_create_from_runtime_sources_loads_persisted_flat_config(self, tmp_path):
-        """Persisted WebUI config should override AstrBot startup defaults."""
+    def test_create_from_runtime_sources_ignores_legacy_webui_config_copy(self, tmp_path):
+        """Legacy plugin_data/config.json must not override AstrBot plugin settings."""
         config_file = tmp_path / "config.json"
         config_file.write_text(
             json.dumps(
                 {
                     "db_type": "postgresql",
-                    "postgresql_host": "pg",
-                    "postgresql_database": "learning_db",
+                    "postgresql_host": "stale-webui-host",
+                    "postgresql_password": "stale-secret",
                 }
             ),
             encoding="utf-8",
         )
 
         config = PluginConfig.create_from_runtime_sources(
-            {},
+            {
+                "Database_Settings": {
+                    "db_type": "sqlite",
+                    "postgresql_host": "plugin-page-host",
+                    "postgresql_password": "plugin-page-secret",
+                }
+            },
             data_dir=str(tmp_path),
             config_file=str(config_file),
         )
 
         assert config.data_dir == str(tmp_path)
-        assert config.db_type == "postgresql"
-        assert config.postgresql_host == "pg"
-        assert config.postgresql_database == "learning_db"
+        assert config.db_type == "sqlite"
+        assert config.postgresql_host == "plugin-page-host"
+        assert config.postgresql_password == "plugin-page-secret"
 
-    def test_create_from_runtime_sources_prefers_newer_astrbot_config_file(self, tmp_path):
-        """A newer AstrBot settings file should not be overwritten by stale plugin_data."""
-        config_file = tmp_path / "plugin_data" / "config.json"
-        config_file.parent.mkdir(parents=True)
-        config_file.write_text(
-            json.dumps(
-                {
-                    "db_type": "postgresql",
-                    "postgresql_host": "localhost",
-                    "postgresql_password": "",
-                }
-            ),
-            encoding="utf-8",
-        )
-
-        astrbot_config_file = tmp_path / "config" / "astrbot_plugin_self_learning_config.json"
-        astrbot_config_file.parent.mkdir(parents=True)
-        astrbot_config_file.write_text("{}", encoding="utf-8")
-        os.utime(config_file, (1_700_000_000, 1_700_000_000))
-        os.utime(astrbot_config_file, (1_700_000_010, 1_700_000_010))
-
-        config = PluginConfig.create_from_runtime_sources(
-            {
-                "Database_Settings": {
-                    "db_type": "postgresql",
-                    "postgresql_host": "127.0.0.1",
-                    "postgresql_password": "new-secret",
-                }
-            },
-            data_dir=str(config_file.parent),
-            config_file=str(config_file),
-            astrbot_config_file=str(astrbot_config_file),
-        )
-
-        assert config.db_type == "postgresql"
-        assert config.postgresql_host == "127.0.0.1"
-        assert config.postgresql_password == "new-secret"
-
-    def test_create_from_runtime_sources_uses_newer_persisted_config_file(self, tmp_path):
-        """A newer WebUI compatibility file remains usable for legacy/full WebUI writes."""
+    def test_create_from_runtime_sources_ignores_newer_legacy_config_file(self, tmp_path):
+        """File mtimes must not make the legacy WebUI copy authoritative again."""
         config_file = tmp_path / "plugin_data" / "config.json"
         config_file.parent.mkdir(parents=True)
         config_file.write_text(
@@ -806,11 +774,11 @@ class TestPluginConfigSerialization:
         )
 
         assert config.db_type == "postgresql"
-        assert config.postgresql_host == "webui-host"
-        assert config.postgresql_password == "webui-secret"
+        assert config.postgresql_host == "astrbot-host"
+        assert config.postgresql_password == "astrbot-secret"
 
-    def test_create_from_runtime_sources_loads_persisted_grouped_config(self, tmp_path):
-        """Grouped persisted config should use the same fields as AstrBot config."""
+    def test_create_from_runtime_sources_reads_grouped_astrbot_config(self, tmp_path):
+        """Grouped AstrBot config remains the single runtime source."""
         config_file = tmp_path / "config.json"
         config_file.write_text(
             json.dumps(
@@ -828,16 +796,24 @@ class TestPluginConfigSerialization:
         )
 
         config = PluginConfig.create_from_runtime_sources(
-            {"Database_Settings": {"db_type": "postgresql"}},
+            {
+                "Database_Settings": {
+                    "db_type": "postgresql",
+                    "postgresql_host": "astrbot-pg",
+                },
+                "Self_Learning_Basic": {
+                    "enable_message_capture": False,
+                },
+            },
             data_dir=str(tmp_path),
             config_file=str(config_file),
         )
 
-        assert config.db_type == "sqlite"
-        assert config.postgresql_host == "pg"
+        assert config.db_type == "postgresql"
+        assert config.postgresql_host == "astrbot-pg"
         assert config.enable_message_capture is False
 
-    def test_create_from_runtime_sources_keeps_runtime_role_providers_over_stale_empty_persisted_values(self, tmp_path):
+    def test_create_from_runtime_sources_keeps_astrbot_role_providers_over_legacy_empty_values(self, tmp_path):
         """Old WebUI snapshots with empty provider IDs must not erase plugin-page choices."""
         config_file = tmp_path / "config.json"
         config_file.write_text(
@@ -869,8 +845,8 @@ class TestPluginConfigSerialization:
         assert config.refine_provider_id == "deepseek/deepseek-v4-flash"
         assert config.reinforce_provider_id == "deepseek/deepseek-v4-pro"
 
-    def test_create_from_runtime_sources_top_level_overrides_grouped_config(self, tmp_path):
-        """Top-level persisted fields should win over grouped persisted fields."""
+    def test_create_from_runtime_sources_uses_astrbot_grouped_fields_over_legacy_top_level(self, tmp_path):
+        """Legacy top-level fields must not override grouped AstrBot settings."""
         config_file = tmp_path / "config.json"
         config_file.write_text(
             json.dumps(
@@ -887,16 +863,21 @@ class TestPluginConfigSerialization:
         )
 
         config = PluginConfig.create_from_runtime_sources(
-            {},
+            {
+                "Database_Settings": {
+                    "db_type": "postgresql",
+                    "postgresql_host": "astrbot-grouped-host",
+                }
+            },
             data_dir=str(tmp_path),
             config_file=str(config_file),
         )
 
-        assert config.db_type == "sqlite"
-        assert config.postgresql_host == "top-level-host"
+        assert config.db_type == "postgresql"
+        assert config.postgresql_host == "astrbot-grouped-host"
 
     def test_create_from_runtime_sources_invalid_json_keeps_runtime_config(self, tmp_path):
-        """Malformed persisted JSON should fall back to AstrBot runtime config."""
+        """Malformed legacy JSON should be ignored."""
         config_file = tmp_path / "config.json"
         config_file.write_text("{not valid json", encoding="utf-8")
 

--- a/tests/unit/test_config_service.py
+++ b/tests/unit/test_config_service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections import UserDict
 import json
-import os
 from pathlib import Path
 import time
 from types import SimpleNamespace
@@ -585,13 +584,8 @@ class TestConfigServiceSchema:
         assert set(PluginConfig.model_fields) <= covered_fields
 
     @pytest.mark.asyncio
-    async def test_config_schema_refresh_imports_newer_plugin_page_config(self, tmp_path):
+    async def test_config_schema_refresh_imports_plugin_page_config(self, tmp_path):
         container = build_container(tmp_path)
-        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
-        container.plugin_config.save_to_file(str(config_file))
-        old_time = config_file.stat().st_mtime - 10
-        config_file.touch()
-        os.utime(config_file, (old_time, old_time))
 
         astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
         container.astrbot_config = SaveableConfig(
@@ -623,16 +617,10 @@ class TestConfigServiceSchema:
         assert fields["target_qq_list"]["value"] == ["plugin-page"]
         assert fields["learning_interval_hours"]["value"] == 3
 
-        saved = json.loads(config_file.read_text(encoding="utf-8"))
-        assert saved["target_qq_list"] == ["plugin-page"]
-        assert saved["learning_interval_hours"] == 3
-
     @pytest.mark.asyncio
-    async def test_config_schema_refresh_imports_plugin_page_payload_change_without_newer_file(self, tmp_path):
+    async def test_config_schema_refresh_imports_live_plugin_page_payload_change(self, tmp_path):
         container = build_container(tmp_path)
-        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
         container.plugin_config.target_qq_list = ["webui-before"]
-        container.plugin_config.save_to_file(str(config_file))
 
         astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
         container.astrbot_config.config_path = str(astrbot_path)
@@ -652,14 +640,33 @@ class TestConfigServiceSchema:
         assert container.plugin_config.target_qq_list == ["plugin-page-live"]
 
     @pytest.mark.asyncio
+    async def test_config_schema_refresh_applies_plugin_page_log_level(self, tmp_path, monkeypatch):
+        container = build_container(tmp_path)
+        calls = []
+
+        def fake_apply_log_level(level, *, debug_mode=False, fallback="info"):
+            calls.append((level, debug_mode, fallback))
+            return level
+
+        monkeypatch.setattr(
+            "webui.services.config_service.apply_astrbot_log_level",
+            fake_apply_log_level,
+        )
+        container.astrbot_config["Advanced_Settings"] = {
+            "log_level": "debug",
+            "debug_mode": False,
+        }
+
+        schema = await ConfigService(container).get_config_schema()
+
+        assert schema["config"]["log_level"] == "debug"
+        assert container.plugin_config.log_level == "debug"
+        assert calls[-1] == ("debug", False, "info")
+
+    @pytest.mark.asyncio
     async def test_config_schema_refresh_rebinds_llm_after_plugin_page_provider_change(self, tmp_path):
         container = build_container(tmp_path)
-        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
         container.plugin_config.filter_provider_id = "old-chat"
-        container.plugin_config.save_to_file(str(config_file))
-        old_time = config_file.stat().st_mtime - 10
-        config_file.touch()
-        os.utime(config_file, (old_time, old_time))
 
         plugin_adapter = Mock()
         plugin_adapter.initialize_providers = Mock()
@@ -692,11 +699,6 @@ class TestConfigServiceSchema:
     @pytest.mark.asyncio
     async def test_config_schema_refresh_prefers_grouped_realtime_plugin_page_values(self, tmp_path):
         container = build_container(tmp_path)
-        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
-        container.plugin_config.save_to_file(str(config_file))
-        old_time = config_file.stat().st_mtime - 10
-        config_file.touch()
-        os.utime(config_file, (old_time, old_time))
 
         astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
         container.astrbot_config = SaveableConfig(
@@ -729,10 +731,6 @@ class TestConfigServiceSchema:
         assert fields["enable_realtime_llm_filter"]["value"] is True
         assert fields["webui_initial_password"]["value"] == ""
 
-        saved = json.loads(config_file.read_text(encoding="utf-8"))
-        assert saved["enable_realtime_learning"] is True
-        assert saved["enable_realtime_llm_filter"] is True
-        assert saved["webui_initial_password"] == ""
         assert container.astrbot_config["Self_Learning_Basic"]["webui_initial_password"] == ""
 
         password_config = json.loads(
@@ -744,36 +742,30 @@ class TestConfigServiceSchema:
         assert "password" not in password_config
 
     @pytest.mark.asyncio
-    async def test_config_schema_refresh_pushes_newer_webui_config_to_plugin_page(self, tmp_path):
+    async def test_config_schema_refresh_does_not_push_runtime_cache_to_plugin_page(self, tmp_path):
         container = build_container(tmp_path)
         container.plugin_config.target_qq_list = ["webui-saved"]
         container.plugin_config.learning_interval_hours = 4
 
-        config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
-        container.plugin_config.save_to_file(str(config_file))
-
         astrbot_path = tmp_path / "astrbot_plugin_self_learning_config.json"
         container.astrbot_config.config_path = str(astrbot_path)
         container.astrbot_config.save_config(dict(container.astrbot_config))
-        old_time = config_file.stat().st_mtime - 10
-        os.utime(astrbot_path, (old_time, old_time))
 
         schema = await ConfigService(container).get_config_schema()
 
-        assert schema["config"]["target_qq_list"] == ["webui-saved"]
-        assert schema["config"]["learning_interval_hours"] == 4
-        assert container.astrbot_config["Target_Settings"]["target_qq_list"] == [
-            "webui-saved",
-        ]
-        assert container.astrbot_config["Learning_Parameters"]["learning_interval_hours"] == 4
-        assert container.astrbot_config.save_calls == 2
-        assert container.astrbot_config.saved_payloads[-1]["Target_Settings"]["target_qq_list"] == [
-            "webui-saved",
-        ]
+        assert schema["config"]["target_qq_list"] == []
+        assert schema["config"]["learning_interval_hours"] == container.astrbot_config[
+            "Learning_Parameters"
+        ]["learning_interval_hours"]
+        assert container.plugin_config.target_qq_list == []
+        assert container.plugin_config.learning_interval_hours == container.astrbot_config[
+            "Learning_Parameters"
+        ]["learning_interval_hours"]
+        assert container.astrbot_config.save_calls == 1
 
         await ConfigService(container).get_config_schema()
 
-        assert container.astrbot_config.save_calls == 2
+        assert container.astrbot_config.save_calls == 1
 
 
 @pytest.mark.unit
@@ -798,7 +790,7 @@ class TestConfigServiceUpdate:
         assert not (Path(container.plugin_config.data_dir) / "password.json").exists()
 
     @pytest.mark.asyncio
-    async def test_update_config_persists_and_syncs_paths(self, tmp_path):
+    async def test_update_config_persists_to_astrbot_config_and_syncs_paths(self, tmp_path):
         container = build_container(tmp_path)
         service = ConfigService(container)
 
@@ -832,13 +824,33 @@ class TestConfigServiceUpdate:
         container.llm_adapter.initialize_providers.assert_called_once_with(container.plugin_config)
 
         config_file = Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE
-        assert config_file.exists()
+        assert not config_file.exists()
+        assert container.astrbot_config["Storage_Settings"]["data_dir"] == str(new_data_dir)
+        assert container.astrbot_config["Database_Settings"]["db_type"] == "postgresql"
+        assert container.astrbot_config["Database_Settings"]["postgresql_schema"] == "bot_space"
+        assert container.astrbot_config["Filter_Parameters"]["relevance_threshold"] == 0.75
+        assert container.astrbot_config["Advanced_Settings"]["log_level"] == "debug"
 
-        saved = json.loads(config_file.read_text(encoding="utf-8"))
-        assert saved["db_type"] == "postgresql"
-        assert saved["postgresql_schema"] == "bot_space"
-        assert saved["relevance_threshold"] == 0.75
-        assert saved["log_level"] == "debug"
+    @pytest.mark.asyncio
+    async def test_update_config_accepts_empty_astrbot_config_source(self, tmp_path):
+        container = build_container(tmp_path)
+        container.astrbot_config = SaveableConfig({})
+
+        success, message, updated = await ConfigService(container).update_config(
+            {
+                "Target_Settings": {
+                    "target_qq_list": ["group_20002"],
+                },
+            }
+        )
+
+        assert success is True
+        assert "已同步到插件设置页" in message
+        assert updated["target_qq_list"] == ["group_20002"]
+        assert container.astrbot_config["Target_Settings"]["target_qq_list"] == [
+            "group_20002",
+        ]
+        assert not (Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE).exists()
 
     @pytest.mark.asyncio
     async def test_update_config_returns_cost_warning_for_high_cost_combo(self, tmp_path):
@@ -899,14 +911,10 @@ class TestConfigServiceUpdate:
         assert schema["config"]["mysql_password"] == ""
         assert schema["config"]["postgresql_password"] == ""
 
-        saved = json.loads(
-            (Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE).read_text(
-                encoding="utf-8",
-            )
-        )
-        assert saved["api_key"] == "hub-secret"
-        assert saved["mysql_password"] == "mysql-secret"
-        assert saved["postgresql_password"] == "postgres-secret"
+        assert not (Path(container.plugin_config.data_dir) / FileNames.CONFIG_FILE).exists()
+        assert container.astrbot_config["API_Settings"]["api_key"] == "hub-secret"
+        assert container.astrbot_config["Database_Settings"]["mysql_password"] == "mysql-secret"
+        assert container.astrbot_config["Database_Settings"]["postgresql_password"] == "postgres-secret"
 
     @pytest.mark.asyncio
     async def test_update_config_syncs_webui_changes_to_plugin_page_config_and_runtime(self, tmp_path):

--- a/webui/services/config_service.py
+++ b/webui/services/config_service.py
@@ -355,16 +355,6 @@ class ConfigService:
         except (AttributeError, TypeError):
             logger.debug(f"写入容器属性失败: {name}", exc_info=True)
 
-    def _get_config_file_path(self) -> str:
-        data_dir = getattr(self.plugin_config, "data_dir", None) if self.plugin_config else None
-        if isinstance(data_dir, (str, os.PathLike)) and os.fspath(data_dir):
-            return os.path.join(os.fspath(data_dir), FileNames.CONFIG_FILE)
-        try:
-            from ...config import DEFAULT_DATA_DIR
-        except ImportError:
-            from config import DEFAULT_DATA_DIR
-        return os.path.join(DEFAULT_DATA_DIR, FileNames.CONFIG_FILE)
-
     def _get_astrbot_config(self) -> Optional[MutableMapping[str, Any]]:
         astrbot_config = self._get_container_attr("astrbot_config")
         plugin = self._get_container_attr("plugin_instance")
@@ -403,28 +393,6 @@ class ConfigService:
                 payload[key] = value
         return payload
 
-    def _astrbot_config_is_newer(self, astrbot_config: MutableMapping[str, Any]) -> bool:
-        astrbot_path = getattr(astrbot_config, "config_path", None)
-        if not astrbot_path:
-            return False
-
-        config_file = self._get_config_file_path()
-        if not os.path.exists(os.fspath(astrbot_path)):
-            return False
-        if not os.path.exists(config_file):
-            return True
-
-        return os.path.getmtime(os.fspath(astrbot_path)) > os.path.getmtime(config_file)
-
-    @staticmethod
-    def _file_mtime_signature(path: Any) -> Optional[float]:
-        if not path:
-            return None
-        try:
-            return os.path.getmtime(os.fspath(path))
-        except OSError:
-            return None
-
     @staticmethod
     def _payload_signature(payload: Dict[str, Any]) -> str:
         return json.dumps(
@@ -446,13 +414,8 @@ class ConfigService:
     def _config_source_signature(
         self,
         astrbot_config: MutableMapping[str, Any],
-    ) -> Tuple[Optional[float], Optional[float], str, str]:
-        return (
-            self._file_mtime_signature(getattr(astrbot_config, "config_path", None)),
-            self._file_mtime_signature(self._get_config_file_path()),
-            self._payload_signature(self._plain_mapping(astrbot_config)),
-            self._payload_signature(self.plugin_config.to_dict()),
-        )
+    ) -> str:
+        return self._payload_signature(self._plain_mapping(astrbot_config))
 
     def _remember_config_sync_state(
         self,
@@ -468,14 +431,9 @@ class ConfigService:
 
     def _last_config_source_signature(
         self,
-    ) -> Optional[Tuple[Optional[float], Optional[float], str, str]]:
+    ) -> Optional[str]:
         signature = self._get_container_attr("_config_source_sync_signature")
-        if (
-            isinstance(signature, tuple)
-            and len(signature) == 4
-            and isinstance(signature[2], str)
-            and isinstance(signature[3], str)
-        ):
+        if isinstance(signature, str):
             return signature
         return None
 
@@ -530,6 +488,9 @@ class ConfigService:
                 self.plugin_config.data_dir, FileNames.LEARNING_LOG_FILE
             )
 
+        if "log_level" in changed_keys or "debug_mode" in changed_keys:
+            self._apply_runtime_log_settings()
+
         if (
             initial_webui_password
             and getattr(self.plugin_config, "enable_webui_password", False) is True
@@ -542,27 +503,24 @@ class ConfigService:
                 )
                 if not password_success:
                     logger.warning(f"AstrBot 插件页 WebUI 初始密码保存失败: {password_message}")
+                else:
+                    self._clear_astrbot_initial_password(astrbot_config)
             else:
                 issues = "、".join(strength_result["issues"]) if strength_result["issues"] else "密码强度不足"
                 logger.warning(f"AstrBot 插件页 WebUI 初始密码无效: {issues}")
 
         self._sync_runtime_components(changed_keys)
         self._refresh_llm_provider_bindings()
-        config_file = self._get_config_file_path()
-        if not self.plugin_config.save_to_file(config_file):
-            logger.warning("AstrBot 插件页配置已同步到内存，但写入 WebUI 配置文件失败")
-        self._sync_astrbot_group_config(self.plugin_config, list(known_config))
-
         logger.info(
-            "AstrBot 插件页配置已同步到 WebUI: "
+            "AstrBot 插件页配置已应用到运行时: "
             f"{', '.join(sorted(changed_keys))}"
         )
         return True
 
     def _sync_config_sources(self, *, force: bool = False) -> None:
-        """Keep AstrBot plugin-page config and WebUI config on the same values."""
+        """Refresh runtime config from the single AstrBot plugin-page source."""
         astrbot_config = self._get_astrbot_config()
-        if not astrbot_config or not self.plugin_config:
+        if astrbot_config is None or not self.plugin_config:
             return
 
         signature = self._config_source_signature(astrbot_config)
@@ -570,30 +528,59 @@ class ConfigService:
         if not force and last_signature == signature:
             return
 
-        astrbot_payload_changed = (
-            last_signature is not None and signature[2] != last_signature[2]
-        )
-        plugin_payload_changed = (
-            last_signature is not None and signature[3] != last_signature[3]
-        )
-        should_pull_from_astrbot = False
-        if astrbot_payload_changed and not plugin_payload_changed:
-            should_pull_from_astrbot = True
-        elif astrbot_payload_changed and plugin_payload_changed:
-            should_pull_from_astrbot = self._astrbot_config_is_newer(astrbot_config)
-        elif last_signature is None:
-            should_pull_from_astrbot = self._astrbot_config_is_newer(astrbot_config)
+        self._apply_astrbot_config_to_plugin(astrbot_config)
+        self._remember_config_sync_state(astrbot_config)
 
-        if should_pull_from_astrbot:
-            self._apply_astrbot_config_to_plugin(astrbot_config)
-            self._remember_config_sync_state(astrbot_config)
+    def _clear_astrbot_initial_password(
+        self,
+        astrbot_config: MutableMapping[str, Any],
+    ) -> None:
+        changed = False
+        group = astrbot_config.get("Self_Learning_Basic")
+        if isinstance(group, MutableMapping) and group.get("webui_initial_password"):
+            group["webui_initial_password"] = ""
+            changed = True
+        if astrbot_config.get("webui_initial_password"):
+            astrbot_config["webui_initial_password"] = ""
+            changed = True
+        if not changed:
             return
 
-        self._sync_astrbot_group_config(
-            self.plugin_config,
-            list(self.plugin_config.to_dict()),
+        save_config = getattr(astrbot_config, "save_config", None)
+        if callable(save_config):
+            try:
+                save_config()
+            except Exception as e:
+                logger.warning(f"清空 AstrBot 插件页 WebUI 初始密码失败: {e}", exc_info=True)
+
+    def _apply_runtime_log_settings(self) -> None:
+        applied_level = apply_astrbot_log_level(
+            getattr(self.plugin_config, "log_level", "info"),
+            debug_mode=getattr(self.plugin_config, "debug_mode", False),
+            fallback="info",
         )
-        self._remember_config_sync_state(astrbot_config)
+        self.plugin_config.log_level = applied_level
+        set_debug_mode = None
+        set_trace_enabled = None
+        for module_name in (
+            "self_learning_EterU.services.monitoring.instrumentation",
+            f"{__package__.split('.')[0]}.services.monitoring.instrumentation"
+            if __package__
+            else "",
+        ):
+            if not module_name:
+                continue
+            try:
+                instrumentation = importlib.import_module(module_name)
+                set_debug_mode = getattr(instrumentation, "set_debug_mode")
+                set_trace_enabled = getattr(instrumentation, "set_trace_enabled")
+                break
+            except Exception as exc:
+                logger.debug(f"同步函数级监控配置失败 ({module_name}): {exc}")
+        if set_debug_mode and set_trace_enabled:
+            set_debug_mode(getattr(self.plugin_config, "debug_mode", False))
+            set_trace_enabled(applied_level == "trace")
+        logger.info(f"AstrBot 日志等级已更新为: {applied_level}")
 
     @staticmethod
     def _field_group_index(schema_definition: Dict[str, Any]) -> Dict[str, str]:
@@ -615,7 +602,7 @@ class ConfigService:
     ) -> bool:
         """Pass the full WebUI config through to AstrBot's grouped plugin-page config."""
         astrbot_config = self._get_astrbot_config()
-        if not astrbot_config:
+        if astrbot_config is None:
             return False
 
         schema_definition = self._merged_schema_definition()
@@ -1866,6 +1853,9 @@ class ConfigService:
         if provider_error in "；".join(blocking_errors):
             warnings.append("至少需要配置一个模型提供商ID，系统将继续依赖 AstrBot 的自动兜底 Provider 选择")
 
+        if self._get_astrbot_config() is None:
+            return False, "AstrBot 插件配置不可用，无法持久化到统一配置", safe_original_config
+
         auth_service = AuthService(self.container)
         password_enabled = getattr(validated_config, "enable_webui_password", False) is True
         if initial_webui_password and not password_enabled:
@@ -1893,33 +1883,7 @@ class ConfigService:
                 setattr(self.plugin_config, field_name, value)
 
         if "log_level" in changed_keys or "debug_mode" in changed_keys:
-            applied_level = apply_astrbot_log_level(
-                getattr(self.plugin_config, "log_level", "info"),
-                debug_mode=getattr(self.plugin_config, "debug_mode", False),
-                fallback="info",
-            )
-            self.plugin_config.log_level = applied_level
-            set_debug_mode = None
-            set_trace_enabled = None
-            for module_name in (
-                "self_learning_EterU.services.monitoring.instrumentation",
-                f"{__package__.split('.')[0]}.services.monitoring.instrumentation"
-                if __package__
-                else "",
-            ):
-                if not module_name:
-                    continue
-                try:
-                    instrumentation = importlib.import_module(module_name)
-                    set_debug_mode = getattr(instrumentation, "set_debug_mode")
-                    set_trace_enabled = getattr(instrumentation, "set_trace_enabled")
-                    break
-                except Exception as exc:
-                    logger.debug(f"同步函数级监控配置失败 ({module_name}): {exc}")
-            if set_debug_mode and set_trace_enabled:
-                set_debug_mode(getattr(self.plugin_config, "debug_mode", False))
-                set_trace_enabled(applied_level == "trace")
-            logger.info(f"AstrBot 日志等级已更新为: {applied_level}")
+            self._apply_runtime_log_settings()
 
         if getattr(self.plugin_config, "data_dir", None):
             self.plugin_config.messages_db_path = os.path.join(
@@ -1945,13 +1909,6 @@ class ConfigService:
 
         self._refresh_llm_provider_bindings()
 
-        config_file = self._get_config_file_path()
-        if not self.plugin_config.save_to_file(config_file):
-            return (
-                False,
-                "配置已更新到内存，但持久化到文件失败",
-                self._redact_config_for_response(self.plugin_config.to_dict()),
-            )
         astrbot_config = self._get_astrbot_config()
         if astrbot_config:
             self._remember_config_sync_state(astrbot_config)


### PR DESCRIPTION
## Summary
- make AstrBot plugin settings the single authoritative runtime config source
- stop reading/writing the legacy WebUI plugin_data/config.json copy and archive it on startup
- persist WebUI edits back into AstrBot grouped plugin config, including runtime log-level application

## Tests
- python -m pytest tests\\unit\\test_config.py tests\\unit\\test_config_service.py tests\\integration\\test_config_blueprint.py tests\\integration\\test_package_imports.py -q
- python -m py_compile config.py main.py webui\\services\\config_service.py core\\plugin_lifecycle.py tests\\unit\\test_config.py tests\\unit\\test_config_service.py tests\\integration\\test_config_blueprint.py
- git diff --check
- local smoke: legacy config ignored and archived

## Summary by Sourcery

Unify runtime configuration to use AstrBot’s plugin settings as the single authoritative source and retire the legacy WebUI config file.

Enhancements:
- Simplify config source synchronization so runtime settings are always refreshed from AstrBot plugin-page configuration.
- Apply log-level and debug-mode changes via a shared helper when either source (WebUI or AstrBot) updates logging-related settings.
- Clear one-time WebUI initial passwords from AstrBot grouped config after successful application to avoid stale secrets.
- Archive any existing legacy WebUI plugin_data/config.json on startup so it cannot be treated as active configuration.
- Remove shutdown-time saving of plugin_config to the legacy WebUI config file, relying solely on AstrBot configuration persistence.

Tests:
- Update unit and integration tests around config loading, synchronization, and logging to reflect AstrBot as the sole runtime config source and the archival of the legacy WebUI config copy.