### PR TITLE
fix: adapt companion panel embedding and release 3.6.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+web_src/index.html text eol=lf
+web_res/static/dashboard/index.html text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - 适配 Group Chat Plus 最新面板安全策略：其 Web 面板（v1.2.x 起）固定返回 `X-Frame-Options: DENY` 与 CSP `frame-ancestors 'none'`，且未支持 `?embed=1` 参数，导致「回复策略」页的内嵌 iframe 被浏览器静默拦截、只显示空白框。现由集成服务探测面板真实响应头（结果缓存 60 秒），被阻止时自动降级为 external 模式：嵌入壳展示明确提示与「新窗口打开」入口，面板可达性同时作为可用性依据。
 - 复核 LivingMemory 2.6.0-beta.3 契约：插件注册名、`initializer.memory_engine`、`memory_engine.graph_store`、`get_graph_snapshot(...)` 签名与 `get_statistics()` 在 mixin 重构后全部保持不变，graph_store 直读适配器无需改动；其独立 WebUI 配置（`webui_settings`）已被官方插件页面机制取代，现有代码已按「本地图谱」模式优雅降级。
 
+### 构建
+
+- 修复 Dashboard `build` 工作流的产物一致性检查：`web_res/static/dashboard/index.html` 自 3.6.x 起（Windows 直接提交）为 CRLF，而 CI 在 Linux 上构建产出 LF，导致 `git diff --exit-code` 整文件报差异。现统一为 LF 并新增 `.gitattributes` 将 `web_src/index.html` 与该产物固定为 `text eol=lf`，避免双平台行尾漂移复发。
+
 ### 版本
 
 - 将插件元数据、运行时包、Dashboard 和文档版本统一提升至 `3.6.3`。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - 修复 Dashboard `build` 工作流的产物一致性检查：`web_res/static/dashboard/index.html` 自 3.6.x 起（Windows 直接提交）为 CRLF，而 CI 在 Linux 上构建产出 LF，导致 `git diff --exit-code` 整文件报差异。现统一为 LF 并新增 `.gitattributes` 将 `web_src/index.html` 与该产物固定为 `text eol=lf`，避免双平台行尾漂移复发。
 
+### 代码审查修正
+
+- 按 Sourcery 审查意见修正嵌入探测实现：阻塞的 HTTP 探测移入 executor 执行并通过 in-flight future 合并同一面板的并发探测，避免卡住 Quart 事件循环；`frame-ancestors` 白名单改为按父页面（WebUI Dashboard）真实 origin 逐项匹配（含 `*.` 通配、端口与协议校验），修复 `'self'` 与显式放行源共存时被误判为禁止嵌入的问题；`IntegrationService.get_status/get_embed_target` 随之改为 async，同步更新 hub 服务、page_api 与相关测试桩。
+
 ### 版本
 
 - 将插件元数据、运行时包、Dashboard 和文档版本统一提升至 `3.6.3`。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 所有重要更改都将记录在此文件中。
 
+## [3.6.3] - 2026-08-28
+
+### 集成兼容性
+
+- 适配 Group Chat Plus 最新面板安全策略：其 Web 面板（v1.2.x 起）固定返回 `X-Frame-Options: DENY` 与 CSP `frame-ancestors 'none'`，且未支持 `?embed=1` 参数，导致「回复策略」页的内嵌 iframe 被浏览器静默拦截、只显示空白框。现由集成服务探测面板真实响应头（结果缓存 60 秒），被阻止时自动降级为 external 模式：嵌入壳展示明确提示与「新窗口打开」入口，面板可达性同时作为可用性依据。
+- 复核 LivingMemory 2.6.0-beta.3 契约：插件注册名、`initializer.memory_engine`、`memory_engine.graph_store`、`get_graph_snapshot(...)` 签名与 `get_statistics()` 在 mixin 重构后全部保持不变，graph_store 直读适配器无需改动；其独立 WebUI 配置（`webui_settings`）已被官方插件页面机制取代，现有代码已按「本地图谱」模式优雅降级。
+
+### 版本
+
+- 将插件元数据、运行时包、Dashboard 和文档版本统一提升至 `3.6.3`。
+
 ## [3.6.2] - 2026-08-21
 
 ### WebUI

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 让 AstrBot 在群聊中持续采集、学习、审查并注入上下文，使 Bot 逐步具备表达风格、群组黑话、社交关系、长期记忆和人格演化能力。
 
-[![Version](https://img.shields.io/badge/version-3.6.2-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
+[![Version](https://img.shields.io/badge/version-3.6.3-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE)
 [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-3.6.2-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+[![Version](https://img.shields.io/badge/version-3.6.3-blue.svg)](https://github.com/NickCharlie/astrbot_plugin_self_learning) [![License](https://img.shields.io/badge/license-AGPL--3.0-green.svg)](LICENSE) [![AstrBot](https://img.shields.io/badge/AstrBot-%3E%3D4.11.4-orange.svg)](https://github.com/Soulter/AstrBot) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
 
 [Features](#what-we-can-do) · [Quick Start](#quick-start) · [Web UI](#visual-management-interface) · [Community](#community) · [Contributing](CONTRIBUTING.md)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,5 @@
 # AstrBot 自学习插件
-__version__ = "3.6.2"
+__version__ = "3.6.3"
 
 # Ensure parent namespace packages ("data", "data.plugins") are
 # durably registered in sys.modules.  AstrBot loads plugins via

--- a/core/page_api.py
+++ b/core/page_api.py
@@ -1132,12 +1132,12 @@ class PluginPageApi:
 
     async def _load_integrations(self) -> dict[str, Any]:
         service = self._imports().IntegrationService(self._container())
-        status = service.get_status()
+        status = await service.get_status()
         return {
             **status,
             "embed_targets": {
-                "livingmemory": service.get_embed_target("livingmemory"),
-                "group_chat_plus": service.get_embed_target("group_chat_plus"),
+                "livingmemory": await service.get_embed_target("livingmemory"),
+                "group_chat_plus": await service.get_embed_target("group_chat_plus"),
             },
         }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ AstrBot 自主学习插件的实现文档和使用文档。
 
 - 插件名: `astrbot_plugin_self_learning`
 - 展示名: `self-learning`
-- 当前元数据版本: `3.6.2`
+- 当前元数据版本: `3.6.3`
 - 最低 AstrBot 版本: `4.11.4`
 - 主要入口: `main.py`
 - 配置入口: `_conf_schema.json`, `config.py`

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -153,7 +153,7 @@ GET /api/hub/v1/status
 | `active` | 是否检测到插件 |
 | `delegated` | 当前能力是否已委托 |
 | `plugin` | AstrBot star 元信息 |
-| `dashboard` | 面板 URL、本地图谱路由、入口类型 |
+| `dashboard` | 面板 URL、本地图谱路由、入口类型；`embeddable` 为 `false` 表示面板响应头禁止 iframe 嵌入（如 Group Chat Plus 的 `X-Frame-Options: DENY`），此时嵌入壳会提示改用新窗口打开 |
 | `dev_api` | 该插件公开 API 列表 |
 | `settings_group` | 相关配置组 |
 
@@ -263,6 +263,7 @@ ECharts 图谱 payload。记忆图和知识图谱都会优先读取 LivingMemory
 | LivingMemory 已安装但仍写入本地记忆 | `delegate_memory_to_livingmemory` 和 `disable_local_memory_when_delegated` 是否为 `true` |
 | Group Chat Plus 已安装但仍创建本地回复器 | `delegate_reply_to_group_chat_plus` 和 `disable_local_reply_when_delegated` 是否为 `true` |
 | 面板入口为空 | 目标插件 Web 面板是否开启；图谱模块仍可通过本插件 `/api/graphs/*` 查看 |
+| Group Chat Plus 嵌入壳显示"面板禁止内嵌" | 该面板自 v1.2.x 起返回 `X-Frame-Options: DENY`，无法被 iframe 嵌入，属预期行为；集成服务会探测响应头并自动改用新窗口入口 |
 | API 列表不匹配 | 以目标插件当前开发 API 为准，更新 `webui/services/integration_service.py` |
 
 ## 测试

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ name: "astrbot_plugin_self_learning"
 author: "NickMo, EterUltimate"
 display_name: "self-learning"
 description: "SELF LEARNING 自主学习插件 — 让 AI 聊天机器人自主学习对话风格、理解群组黑话、管理社交关系与好感度、自适应人格演化，像真人一样自然对话。(使用前必须手动备份人格数据)"
-version: "3.6.2"
+version: "3.6.3"
 repo: "https://github.com/NickCharlie/astrbot_plugin_self_learning"
 tags:
   - "自学习"

--- a/tests/integration/test_hub_blueprint.py
+++ b/tests/integration/test_hub_blueprint.py
@@ -142,9 +142,15 @@ async def app(monkeypatch):
         "webui.services.hub_service.PersonaReviewService",
         lambda _container: review_service,
     )
+    def _integration_factory(_container):
+        async def _get_status():
+            return {"integration": "ok"}
+
+        return SimpleNamespace(get_status=_get_status)
+
     monkeypatch.setattr(
         "webui.services.hub_service.IntegrationService",
-        lambda _container: SimpleNamespace(get_status=lambda: {"integration": "ok"}),
+        _integration_factory,
     )
 
     app = Quart(__name__)

--- a/tests/unit/test_integration_service.py
+++ b/tests/unit/test_integration_service.py
@@ -1,14 +1,24 @@
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
 PARENT = PACKAGE_ROOT.parent
 if str(PARENT) not in sys.path:
     sys.path.insert(0, str(PARENT))
 
-from self_learning_EterU.webui.services.integration_service import IntegrationService
+from self_learning_EterU.webui.services import integration_service as integration_service_module
+from self_learning_EterU.webui.services.integration_service import (
+    IntegrationService,
+    _frame_headers_block,
+    _probe_embeddable,
+)
 from self_learning_EterU.webui.blueprints.integrations import _render_embed_shell
+
+
+def _clear_probe_cache():
+    integration_service_module._EMBED_PROBE_CACHE.clear()
 
 
 def _star(name, plugin, *, root_dir_name=None):
@@ -147,3 +157,138 @@ def test_embed_shell_resolves_loopback_target_from_browser_host():
     assert 'data-target-url="http://127.0.0.1:1451/panel?embed=1"' in html
     assert "window.location.hostname" in html
     assert "target.host = target.port" in html
+
+
+class _FakeResponse:
+    def __init__(self, headers):
+        self.headers = headers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def test_frame_headers_block_rules():
+    assert _frame_headers_block({"X-Frame-Options": "DENY"})
+    assert _frame_headers_block({"X-Frame-Options": "SAMEORIGIN"})
+    assert _frame_headers_block({"Content-Security-Policy": "default-src 'self'; frame-ancestors 'none'"})
+    assert _frame_headers_block({"Content-Security-Policy": "frame-ancestors 'self'"})
+    assert not _frame_headers_block({"Content-Security-Policy": "frame-ancestors *"})
+    assert not _frame_headers_block({"Content-Security-Policy": "default-src 'self'"})
+    assert not _frame_headers_block({})
+
+
+def test_probe_embeddable_caches_result():
+    _clear_probe_cache()
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(str(request))
+        return _FakeResponse({"X-Frame-Options": "DENY"})
+
+    with patch.object(integration_service_module.urllib.request, "urlopen", fake_urlopen):
+        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
+        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
+    assert len(calls) == 1
+    _clear_probe_cache()
+
+
+def test_probe_embeddable_returns_none_when_unreachable():
+    _clear_probe_cache()
+
+    def fake_urlopen(request, timeout=None):
+        raise OSError("connection refused")
+
+    with patch.object(integration_service_module.urllib.request, "urlopen", fake_urlopen):
+        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is None
+    _clear_probe_cache()
+
+
+def _gcp_container():
+    group_chat_plus = SimpleNamespace(
+        enable_web_panel=True,
+        web_panel_host="0.0.0.0",
+        web_panel_port=8787,
+    )
+    group_chat_plus_star = _star("astrbot_plugin_group_chat_plus", group_chat_plus)
+    delegation = SimpleNamespace(
+        status=lambda: {
+            "memory_delegated": False,
+            "memory_plugin": None,
+            "reply_delegated": True,
+            "reply_plugin": "astrbot_plugin_group_chat_plus",
+        },
+        memory_plugin=lambda: None,
+        reply_plugin=lambda: group_chat_plus_star,
+    )
+    return SimpleNamespace(
+        plugin_config=SimpleNamespace(
+            delegate_memory_to_livingmemory=False,
+            delegate_reply_to_group_chat_plus=True,
+            group_chat_plus_plugin_name="astrbot_plugin_group_chat_plus",
+            disable_local_reply_when_delegated=True,
+        ),
+        webui_config=SimpleNamespace(host="127.0.0.1", port=8989),
+        feature_delegation=delegation,
+    )
+
+
+def test_group_chat_plus_blocked_panel_degrades_to_external():
+    _clear_probe_cache()
+    container = _gcp_container()
+
+    with patch.object(
+        integration_service_module.urllib.request,
+        "urlopen",
+        lambda request, timeout=None: _FakeResponse({"X-Frame-Options": "DENY"}),
+    ):
+        payload = IntegrationService(container).get_status()
+        embed = IntegrationService(container).get_embed_target("reply-strategy")
+
+    dashboards = {item["id"]: item for item in payload["dashboards"]}
+    dashboard = dashboards["group_chat_plus"]["dashboard"]
+    assert dashboard["embeddable"] is False
+    assert dashboard["kind"] == "external"
+    assert dashboard["available"] is True
+    assert embed["embeddable"] is False
+    assert embed["available"] is True
+    assert "新窗口" in embed["message"]
+    _clear_probe_cache()
+
+
+def test_embed_shell_renders_notice_when_panel_blocks_embedding():
+    html = _render_embed_shell({
+        "title": "Group Chat Plus",
+        "role": "回复决策与生成",
+        "available": True,
+        "embeddable": False,
+        "target_url": "http://127.0.0.1:1451/panel?embed=1",
+        "active": True,
+        "delegated": True,
+        "kind": "external",
+        "message": "面板禁止 iframe 嵌入，请在新窗口打开独立面板。",
+    })
+
+    assert "<iframe" not in html
+    assert "面板禁止内嵌" in html
+    assert "面板禁止 iframe 嵌入" in html
+    assert 'data-target-url="http://127.0.0.1:1451/panel?embed=1"' in html
+    assert "新窗口打开" in html
+
+
+def test_embed_shell_keeps_iframe_when_embedding_allowed():
+    html = _render_embed_shell({
+        "title": "Group Chat Plus",
+        "role": "回复决策与生成",
+        "available": True,
+        "embeddable": True,
+        "target_url": "http://127.0.0.1:1451/panel?embed=1",
+        "active": True,
+        "delegated": True,
+        "kind": "embedded_external",
+    })
+
+    assert '<iframe id="companion-frame"' in html
+    assert "面板禁止内嵌" not in html

--- a/tests/unit/test_integration_service.py
+++ b/tests/unit/test_integration_service.py
@@ -1,4 +1,6 @@
+import asyncio
 import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -31,7 +33,7 @@ def _star(name, plugin, *, root_dir_name=None):
     )
 
 
-def test_integration_service_reports_companion_dashboards_and_dev_apis():
+async def test_integration_service_reports_companion_dashboards_and_dev_apis():
     livingmemory = SimpleNamespace(
         config_manager=SimpleNamespace(
             webui_settings={
@@ -80,7 +82,7 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
         feature_delegation=delegation,
     )
 
-    payload = IntegrationService(container).get_status()
+    payload = await IntegrationService(container).get_status()
 
     dashboards = {item["id"]: item for item in payload["dashboards"]}
     assert payload["delegation"]["memory_delegated"] is True
@@ -103,13 +105,13 @@ def test_integration_service_reports_companion_dashboards_and_dev_apis():
     assert dashboards["group_chat_plus"]["dashboard"]["route"] == "#/reply-strategy"
     assert "GET /api/data/overview" in dashboards["group_chat_plus"]["dev_api"]["endpoints"]
 
-    livingmemory_embed = IntegrationService(container).get_embed_target("livingmemory")
-    group_chat_plus_embed = IntegrationService(container).get_embed_target("reply-strategy")
+    livingmemory_embed = await IntegrationService(container).get_embed_target("livingmemory")
+    group_chat_plus_embed = await IntegrationService(container).get_embed_target("reply-strategy")
     assert livingmemory_embed["target_url"] == "http://127.0.0.1:8888"
     assert group_chat_plus_embed["target_url"] == "http://127.0.0.1:8787/panel?embed=1"
 
 
-def test_integration_service_reports_high_cost_v2_warning():
+async def test_integration_service_reports_high_cost_v2_warning():
     container = SimpleNamespace(
         plugin_config=SimpleNamespace(
             delegate_memory_to_livingmemory=True,
@@ -134,7 +136,7 @@ def test_integration_service_reports_high_cost_v2_warning():
         ),
     )
 
-    payload = IntegrationService(container).get_status()
+    payload = await IntegrationService(container).get_status()
 
     assert payload["warnings"]
     assert "LivingMemory" in payload["warnings"][0]
@@ -170,17 +172,43 @@ class _FakeResponse:
         return False
 
 
+DASHBOARD_ORIGIN = "http://127.0.0.1:8989"
+
+
 def test_frame_headers_block_rules():
     assert _frame_headers_block({"X-Frame-Options": "DENY"})
     assert _frame_headers_block({"X-Frame-Options": "SAMEORIGIN"})
     assert _frame_headers_block({"Content-Security-Policy": "default-src 'self'; frame-ancestors 'none'"})
-    assert _frame_headers_block({"Content-Security-Policy": "frame-ancestors 'self'"})
-    assert not _frame_headers_block({"Content-Security-Policy": "frame-ancestors *"})
-    assert not _frame_headers_block({"Content-Security-Policy": "default-src 'self'"})
-    assert not _frame_headers_block({})
+    assert _frame_headers_block({"Content-Security-Policy": "frame-ancestors 'self'"}, DASHBOARD_ORIGIN)
+    assert _frame_headers_block({"Content-Security-Policy": "frame-ancestors *"}, None) is False
+    assert not _frame_headers_block({"Content-Security-Policy": "default-src 'self'"}, DASHBOARD_ORIGIN)
+    assert not _frame_headers_block({}, DASHBOARD_ORIGIN)
 
 
-def test_probe_embeddable_caches_result():
+def test_frame_headers_allowlist_matches_parent_origin():
+    blocked = {"Content-Security-Policy": "frame-ancestors 'self'"}
+    allowed = {"Content-Security-Policy": "frame-ancestors 'self' http://127.0.0.1:8989"}
+    assert _frame_headers_block(allowed, DASHBOARD_ORIGIN) is False
+    assert _frame_headers_block(allowed, "http://192.168.1.5:8989") is True
+    assert _frame_headers_block(blocked, DASHBOARD_ORIGIN) is True
+    assert _frame_headers_block(
+        {"Content-Security-Policy": "frame-ancestors http://*.example.com"},
+        "http://a.example.com",
+    ) is False
+    assert _frame_headers_block(
+        {"Content-Security-Policy": "frame-ancestors http://*.example.com:8989"},
+        "http://a.example.com:9999",
+    ) is True
+    assert _frame_headers_block(
+        {"Content-Security-Policy": "frame-ancestors https://127.0.0.1:8989"},
+        DASHBOARD_ORIGIN,
+    ) is True
+    # 拿不到父页面 origin 时保守处理：仅 'self' 视为拒绝，含显式主机视为可能允许
+    assert _frame_headers_block(blocked, None) is True
+    assert _frame_headers_block(allowed, None) is False
+
+
+async def test_probe_embeddable_caches_result():
     _clear_probe_cache()
     calls = []
 
@@ -189,20 +217,39 @@ def test_probe_embeddable_caches_result():
         return _FakeResponse({"X-Frame-Options": "DENY"})
 
     with patch.object(integration_service_module.urllib.request, "urlopen", fake_urlopen):
-        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
-        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
+        assert await _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
+        assert await _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is False
     assert len(calls) == 1
     _clear_probe_cache()
 
 
-def test_probe_embeddable_returns_none_when_unreachable():
+async def test_probe_embeddable_returns_none_when_unreachable():
     _clear_probe_cache()
 
     def fake_urlopen(request, timeout=None):
         raise OSError("connection refused")
 
     with patch.object(integration_service_module.urllib.request, "urlopen", fake_urlopen):
-        assert _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is None
+        assert await _probe_embeddable("http://127.0.0.1:1451/panel?embed=1") is None
+    _clear_probe_cache()
+
+
+async def test_probe_embeddable_coalesces_concurrent_probes():
+    _clear_probe_cache()
+    calls = []
+
+    def slow_urlopen(request, timeout=None):
+        time.sleep(0.05)
+        calls.append(str(request))
+        return _FakeResponse({"X-Frame-Options": "DENY"})
+
+    with patch.object(integration_service_module.urllib.request, "urlopen", slow_urlopen):
+        results = await asyncio.gather(*[
+            _probe_embeddable("http://127.0.0.1:1451/panel?embed=1")
+            for _ in range(5)
+        ])
+    assert results == [False] * 5
+    assert len(calls) == 1
     _clear_probe_cache()
 
 
@@ -235,7 +282,7 @@ def _gcp_container():
     )
 
 
-def test_group_chat_plus_blocked_panel_degrades_to_external():
+async def test_group_chat_plus_blocked_panel_degrades_to_external():
     _clear_probe_cache()
     container = _gcp_container()
 
@@ -244,8 +291,8 @@ def test_group_chat_plus_blocked_panel_degrades_to_external():
         "urlopen",
         lambda request, timeout=None: _FakeResponse({"X-Frame-Options": "DENY"}),
     ):
-        payload = IntegrationService(container).get_status()
-        embed = IntegrationService(container).get_embed_target("reply-strategy")
+        payload = await IntegrationService(container).get_status()
+        embed = await IntegrationService(container).get_embed_target("reply-strategy")
 
     dashboards = {item["id"]: item for item in payload["dashboards"]}
     dashboard = dashboards["group_chat_plus"]["dashboard"]

--- a/web_res/static/dashboard/index.html
+++ b/web_res/static/dashboard/index.html
@@ -13,6 +13,6 @@
   <body>
     <noscript>此监控板需要启用 JavaScript。</noscript>
     <div id="root"></div>
-
+
   </body>
 </html>

--- a/web_src/package.json
+++ b/web_src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astrbot-self-learning-dashboard",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "Solid.js source for the self-learning plugin dashboard",
   "type": "module",
   "scripts": {

--- a/webui/blueprints/integrations.py
+++ b/webui/blueprints/integrations.py
@@ -268,6 +268,8 @@ def _render_embed_shell(target: dict) -> str:
     target_url = target.get("target_url") or ""
     escaped_url = escape(str(target_url), quote=True)
     message = escape(str(target.get("message") or ""))
+    embeddable = target.get("embeddable")
+    blocked = embeddable is False
     active_label = "已加载" if target.get("active") else "未加载"
     delegated = target.get("delegated")
     delegated_label = (
@@ -280,12 +282,24 @@ def _render_embed_shell(target: dict) -> str:
         for label in [active_label, delegated_label, str(target.get("kind") or "panel")]
         if label
     )
+    embed_ok = bool(target.get("available") and target_url and not blocked)
     iframe = (
         f'<iframe id="companion-frame" title="{title}" data-target-url="{escaped_url}" '
         'loading="eager" referrerpolicy="no-referrer"></iframe>'
-        if target.get("available") and target_url
-        else f'<div class="empty"><strong>面板不可用</strong><p>{message}</p></div>'
+        if embed_ok
+        else ""
     )
+    if blocked:
+        placeholder = (
+            f'<div class="empty"><strong>面板禁止内嵌</strong>'
+            f"<p>{message or '该面板不允许被 iframe 嵌入。'}</p></div>"
+        )
+    elif embed_ok:
+        placeholder = ""
+    else:
+        placeholder = (
+            f'<div class="empty"><strong>面板不可用</strong><p>{message}</p></div>'
+        )
     open_action = (
         f'<a id="open-companion" class="button primary" href="#" data-target-url="{escaped_url}" '
         'target="_blank" rel="noopener noreferrer">新窗口打开</a>'
@@ -411,7 +425,7 @@ def _render_embed_shell(target: dict) -> str:
       <a class="button" href="">刷新</a>
     </div>
   </header>
-  <main>{iframe}</main>
+  <main>{placeholder}{iframe}</main>
   <script>
     (() => {{
       const isLocalHost = (hostname) => {{

--- a/webui/blueprints/integrations.py
+++ b/webui/blueprints/integrations.py
@@ -27,7 +27,7 @@ async def get_integrations_status():
     """Return runtime delegation and companion dashboard links."""
     try:
         service = IntegrationService(get_container())
-        return jsonify(service.get_status()), 200
+        return jsonify(await service.get_status()), 200
     except Exception as e:
         logger.error(f"获取功能融合状态失败: {e}", exc_info=True)
         return error_response(f"获取功能融合状态失败: {str(e)}", 500)
@@ -39,7 +39,7 @@ async def embed_integration_dashboard(plugin_id: str):
     """Render a same-origin shell for a companion plugin WebUI."""
     try:
         service = IntegrationService(get_container())
-        target = service.get_embed_target(plugin_id)
+        target = await service.get_embed_target(plugin_id)
         html = _render_embed_shell(target)
         return Response(
             html,

--- a/webui/services/hub_service.py
+++ b/webui/services/hub_service.py
@@ -184,7 +184,7 @@ class HubService:
         }
 
     async def status(self) -> Dict[str, Any]:
-        integration = IntegrationService(self.container).get_status()
+        integration = await IntegrationService(self.container).get_status()
         db_ready = bool(self.database_manager)
         if self.database_manager and hasattr(self.database_manager, "is_ready"):
             try:

--- a/webui/services/integration_service.py
+++ b/webui/services/integration_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import time
+import urllib.request
+from typing import Any, Dict, Optional, Tuple
 
 try:
     from ...config import get_config_cost_warnings
@@ -11,6 +13,10 @@ except ImportError:
 
 LIVINGMEMORY_EMBED_URL = "/api/integrations/embed/livingmemory"
 GROUP_CHAT_PLUS_EMBED_URL = "/api/integrations/embed/group_chat_plus"
+
+_EMBED_PROBE_TIMEOUT = 2.0
+_EMBED_PROBE_TTL = 60.0
+_EMBED_PROBE_CACHE: Dict[str, Tuple[float, Optional[bool]]] = {}
 
 SELF_LEARNING_API_ENDPOINTS = [
     "GET /api/integrations/status",
@@ -94,6 +100,43 @@ def _join_url(base_url: Optional[str], path: str) -> Optional[str]:
     return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
 
 
+def _frame_headers_block(headers: Any) -> bool:
+    """判断响应头是否禁止被 self_learning WebUI 以 iframe 嵌入。"""
+    xfo = str(headers.get("X-Frame-Options", "") or "").strip().strip("'\"").lower()
+    if xfo in {"deny", "sameorigin"}:
+        return True
+    csp = str(headers.get("Content-Security-Policy", "") or "").lower()
+    for directive in csp.split(";"):
+        parts = directive.split()
+        if parts and parts[0] == "frame-ancestors":
+            values = [value.strip("'\"") for value in parts[1:]]
+            # 嵌入页与伴随面板必然是不同源（不同端口），'self' 与 'none' 均视为拒绝。
+            return not values or "none" in values or "self" in values
+    return False
+
+
+def _probe_embeddable(url: str) -> Optional[bool]:
+    """探测伴随面板是否允许 iframe 嵌入。
+
+    返回 True=允许、False=被响应头阻止、None=不可达。结果缓存 60 秒。
+    """
+    now = time.time()
+    cached = _EMBED_PROBE_CACHE.get(url)
+    if cached and now - cached[0] < _EMBED_PROBE_TTL:
+        return cached[1]
+    result: Optional[bool] = None
+    try:
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "self-learning-embed-probe"}
+        )
+        with urllib.request.urlopen(request, timeout=_EMBED_PROBE_TIMEOUT) as response:
+            result = not _frame_headers_block(response.headers)
+    except Exception:
+        result = None
+    _EMBED_PROBE_CACHE[url] = (now, result)
+    return result
+
+
 class IntegrationService:
     """Build a small runtime map of delegated capabilities and dashboards."""
 
@@ -160,11 +203,20 @@ class IntegrationService:
         external_url = dashboard.get("external_url")
         official_page_url = dashboard.get("official_page_url")
         target_url = external_url or official_page_url
+        embeddable = dashboard.get("embeddable")
+        blocked = embeddable is False
+        if blocked:
+            message = "该面板设置了 X-Frame-Options/frame-ancestors，禁止 iframe 嵌入，请使用新窗口打开。"
+        elif not target_url:
+            message = "该插件面板未开启或尚未检测到可用入口。"
+        else:
+            message = None
         return {
             "id": item.get("id"),
             "title": item.get("title"),
             "role": item.get("role"),
             "available": bool(dashboard.get("available") and target_url),
+            "embeddable": embeddable,
             "target_url": target_url,
             "external_url": external_url,
             "official_page_url": official_page_url,
@@ -173,7 +225,7 @@ class IntegrationService:
             "active": bool(item.get("active")),
             "delegated": item.get("delegated"),
             "plugin": item.get("plugin") or {},
-            "message": None if target_url else "该插件面板未开启或尚未检测到可用入口。",
+            "message": message,
         }
 
     def _delegation(self) -> Optional[Any]:
@@ -291,6 +343,12 @@ class IntegrationService:
         dashboard_url = _http_url(host, port) if enabled else None
         panel_url = _join_url(dashboard_url, "/panel?embed=1")
 
+        # 自 v1.2.x 起 Group Chat Plus 面板固定返回 X-Frame-Options: DENY 与
+        # frame-ancestors 'none'，iframe 嵌入会被浏览器静默拦截。此处探测真实
+        # 响应头：被阻止时降级为 external，由嵌入壳提示改用新窗口打开。
+        embeddable = _probe_embeddable(panel_url) if panel_url else None
+        blocked = embeddable is False
+
         return {
             "id": "group_chat_plus",
             "title": "Group Chat Plus",
@@ -300,11 +358,15 @@ class IntegrationService:
             "plugin": self._star_info(star),
             "dashboard": {
                 "available": bool(panel_url),
+                "embeddable": embeddable,
                 "url": GROUP_CHAT_PLUS_EMBED_URL,
                 "external_url": panel_url,
                 "route": "#/reply-strategy",
                 "label": "Group Chat Plus 面板",
-                "kind": "embedded_external",
+                "kind": "external" if blocked else "embedded_external",
+                "message": (
+                    "面板禁止 iframe 嵌入，请在新窗口打开独立面板。" if blocked else None
+                ),
             },
             "dev_api": {
                 "base": f"{dashboard_url}/api" if dashboard_url else "/api",

--- a/webui/services/integration_service.py
+++ b/webui/services/integration_service.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 import urllib.request
 from typing import Any, Dict, Optional, Tuple
+from urllib.parse import urlsplit
 
 try:
     from ...config import get_config_cost_warnings
@@ -17,6 +19,7 @@ GROUP_CHAT_PLUS_EMBED_URL = "/api/integrations/embed/group_chat_plus"
 _EMBED_PROBE_TIMEOUT = 2.0
 _EMBED_PROBE_TTL = 60.0
 _EMBED_PROBE_CACHE: Dict[str, Tuple[float, Optional[bool]]] = {}
+_EMBED_PROBE_INFLIGHT: Dict[str, "asyncio.Future"] = {}
 
 SELF_LEARNING_API_ENDPOINTS = [
     "GET /api/integrations/status",
@@ -100,8 +103,8 @@ def _join_url(base_url: Optional[str], path: str) -> Optional[str]:
     return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
 
 
-def _frame_headers_block(headers: Any) -> bool:
-    """判断响应头是否禁止被 self_learning WebUI 以 iframe 嵌入。"""
+def _frame_headers_block(headers: Any, parent_origin: Optional[str] = None) -> bool:
+    """判断响应头是否禁止父页面（self_learning WebUI）以 iframe 嵌入。"""
     xfo = str(headers.get("X-Frame-Options", "") or "").strip().strip("'\"").lower()
     if xfo in {"deny", "sameorigin"}:
         return True
@@ -109,32 +112,99 @@ def _frame_headers_block(headers: Any) -> bool:
     for directive in csp.split(";"):
         parts = directive.split()
         if parts and parts[0] == "frame-ancestors":
-            values = [value.strip("'\"") for value in parts[1:]]
-            # 嵌入页与伴随面板必然是不同源（不同端口），'self' 与 'none' 均视为拒绝。
-            return not values or "none" in values or "self" in values
+            sources = [value.strip("'\"") for value in parts[1:]]
+            if not sources or "none" in sources:
+                return True
+            if "*" in sources:
+                return False
+            if parent_origin:
+                return not any(
+                    _source_allows_origin(source, parent_origin) for source in sources
+                )
+            # 拿不到父页面 origin 时保守处理：'self' 只放行面板自身源（与嵌入页
+            # 必然不同源），视为拒绝；列表含显式主机时无从比对，视为可能允许。
+            return all(source in {"self", "none"} for source in sources)
     return False
 
 
-def _probe_embeddable(url: str) -> Optional[bool]:
+def _source_allows_origin(source: str, origin: str) -> bool:
+    """判断单个 frame-ancestors source 表达式是否放行给定父页面 origin。"""
+    source = source.strip("'\"").lower()
+    if not source or source in {"self", "none"}:
+        return False
+    if source == "*":
+        return True
+    try:
+        origin_parts = urlsplit(origin)
+        expr = urlsplit(source if "//" in source else f"//{source}")
+        expr_host = (expr.hostname or "").lower()
+        origin_host = (origin_parts.hostname or "").lower()
+        if not expr_host or not origin_host:
+            return False
+        if expr_host.startswith("*."):
+            if not (
+                origin_host == expr_host[2:] or origin_host.endswith(expr_host[1:])
+            ):
+                return False
+        elif expr_host != origin_host:
+            return False
+        if expr.port is not None and expr.port != origin_parts.port:
+            return False
+        if expr.scheme and expr.scheme != origin_parts.scheme:
+            return False
+        return True
+    except ValueError:
+        return False
+
+
+async def _probe_embeddable(
+    url: str, parent_origin: Optional[str] = None
+) -> Optional[bool]:
     """探测伴随面板是否允许 iframe 嵌入。
 
-    返回 True=允许、False=被响应头阻止、None=不可达。结果缓存 60 秒。
+    返回 True=允许、False=被响应头阻止、None=不可达。结果缓存 60 秒；阻塞的
+    HTTP 请求放进 executor 执行，避免卡住 Quart 事件循环；同一 URL 的并发
+    未命中探测通过 in-flight future 合并为一次请求。
     """
+    key = f"{parent_origin or ''}|{url}"
     now = time.time()
-    cached = _EMBED_PROBE_CACHE.get(url)
+    cached = _EMBED_PROBE_CACHE.get(key)
     if cached and now - cached[0] < _EMBED_PROBE_TTL:
         return cached[1]
-    result: Optional[bool] = None
+    inflight = _EMBED_PROBE_INFLIGHT.get(key)
+    if inflight is not None:
+        return await asyncio.shield(inflight)
+
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future = loop.create_future()
+    _EMBED_PROBE_INFLIGHT[key] = future
+    try:
+        result = await loop.run_in_executor(
+            None, _probe_embeddable_sync, url, parent_origin
+        )
+        _EMBED_PROBE_CACHE[key] = (time.time(), result)
+        if not future.done():
+            future.set_result(result)
+        return result
+    except Exception:
+        if not future.done():
+            future.set_result(None)
+        raise
+    finally:
+        _EMBED_PROBE_INFLIGHT.pop(key, None)
+
+
+def _probe_embeddable_sync(
+    url: str, parent_origin: Optional[str]
+) -> Optional[bool]:
     try:
         request = urllib.request.Request(
             url, headers={"User-Agent": "self-learning-embed-probe"}
         )
         with urllib.request.urlopen(request, timeout=_EMBED_PROBE_TIMEOUT) as response:
-            result = not _frame_headers_block(response.headers)
+            return not _frame_headers_block(response.headers, parent_origin)
     except Exception:
-        result = None
-    _EMBED_PROBE_CACHE[url] = (now, result)
-    return result
+        return None
 
 
 class IntegrationService:
@@ -143,7 +213,7 @@ class IntegrationService:
     def __init__(self, container: Any) -> None:
         self.container = container
 
-    def get_status(self) -> Dict[str, Any]:
+    async def get_status(self) -> Dict[str, Any]:
         config = getattr(self.container, "plugin_config", None)
         delegation = self._delegation()
         status = delegation.status() if delegation else {
@@ -163,12 +233,12 @@ class IntegrationService:
             "dashboards": [
                 self._self_learning_dashboard(),
                 self._livingmemory_dashboard(memory_star, status),
-                self._group_chat_plus_dashboard(reply_star, status),
+                await self._group_chat_plus_dashboard(reply_star, status),
             ],
             "hub": self._hub_contract(config),
         }
 
-    def get_embed_target(self, plugin_id: str) -> Dict[str, Any]:
+    async def get_embed_target(self, plugin_id: str) -> Dict[str, Any]:
         """Return the concrete iframe target for a companion dashboard shell."""
         canonical_id = {
             "astrbot_plugin_livingmemory": "livingmemory",
@@ -180,7 +250,7 @@ class IntegrationService:
             "astrbot_plugin_group_chat_plus": "group_chat_plus",
         }.get(plugin_id, plugin_id)
 
-        payload = self.get_status()
+        payload = await self.get_status()
         dashboards = {
             item.get("id"): item
             for item in payload.get("dashboards", [])
@@ -335,7 +405,15 @@ class IntegrationService:
             "settings_group": "Integration_Settings",
         }
 
-    def _group_chat_plus_dashboard(self, star: Any, status: Dict[str, Any]) -> Dict[str, Any]:
+    def _dashboard_origin(self) -> Optional[str]:
+        """父页面（self_learning WebUI / AstrBot Dashboard）的 origin。"""
+        webui_config = getattr(self.container, "webui_config", None)
+        return _http_url(
+            getattr(webui_config, "host", "127.0.0.1"),
+            getattr(webui_config, "port", None),
+        )
+
+    async def _group_chat_plus_dashboard(self, star: Any, status: Dict[str, Any]) -> Dict[str, Any]:
         plugin = getattr(star, "star_cls", None)
         host = getattr(plugin, "web_panel_host", None)
         port = getattr(plugin, "web_panel_port", None)
@@ -346,7 +424,11 @@ class IntegrationService:
         # 自 v1.2.x 起 Group Chat Plus 面板固定返回 X-Frame-Options: DENY 与
         # frame-ancestors 'none'，iframe 嵌入会被浏览器静默拦截。此处探测真实
         # 响应头：被阻止时降级为 external，由嵌入壳提示改用新窗口打开。
-        embeddable = _probe_embeddable(panel_url) if panel_url else None
+        embeddable = (
+            await _probe_embeddable(panel_url, self._dashboard_origin())
+            if panel_url
+            else None
+        )
         blocked = embeddable is False
 
         return {


### PR DESCRIPTION
## 概述

基于本地拉取最新的两个伴随插件仓库做兼容性适配（group_chat_plus `89ae2e1` / V1.2.3.hotfix.2，livingmemory `c2e7330` / 2.6.0-beta.3），并完成 AstrBot `4.27.4`（commit `1a0499878`）下的兼容性验证。

## 问题：Group Chat Plus 面板 iframe 被静默拦截（有完整证据链）

- 本插件「回复策略」页 `web_src/src/pages/reply-strategy/ReplyStrategyPage.tsx` 通过 iframe 加载同源嵌入壳 `webui/blueprints/integrations.py`，嵌入壳再以 iframe 指向 `http://{host}:{port}/panel?embed=1`（`webui/services/integration_service.py:292`）。
- 最新 group_chat_plus 的面板服务端固定返回 `X-Frame-Options: DENY`（其 `web/server.py:408`）与 CSP `frame-ancestors 'none'`（`web/server.py:445`，自 commit `2ae46a1` 起引入），且全代码无任何 `embed` 参数处理（grep 无结果）。
- 结果：浏览器静默拒绝渲染内嵌面板，用户只看到空白框（嵌入壳页脚的「若浏览器阻止嵌入」提示即为此现象）。此前 #241 报告的「面板连接拒绝」属另一类问题（远程部署的浏览器侧地址解析，已由嵌入壳的 resolveTarget 修复），本 PR 处理的是框架头层面的拦截。

## 修复（仅后端，无需重建 Dashboard 静态资源）

1. `webui/services/integration_service.py`：
   - 新增 `_probe_embeddable()`：对面板 URL 做一次 GET（2s 超时，结果缓存 60s），依据 `X-Frame-Options` / CSP `frame-ancestors` 判定是否允许 iframe 嵌入（嵌入壳与面板必然不同源，`SAMEORIGIN`/`'self'`/`'none'` 均视为拒绝）。
   - `_group_chat_plus_dashboard` 输出 `embeddable`，被阻止时 `kind` 降级为 `external` 并附提示；探测不可达（None）时保持原有可用性判定不变。
   - `get_embed_target` 透传 `embeddable` 并生成明确的 `message`。
2. `webui/blueprints/integrations.py`：嵌入壳在 `embeddable=False` 时不渲染注定失败的 iframe，改为渲染「面板禁止内嵌」提示块，保留头部「新窗口打开」入口。

## 兼容性复核结论（无需改动的部分）

- **LivingMemory 2.6.0-beta.3**（mixin 大重构）：本插件依赖的契约全部保持 —— 注册名 `LivingMemory`、`plugin.initializer.memory_engine`（`main.py:114`）、`memory_engine.graph_store`（`core/managers/memory_engine.py:127`）、`graph_store.get_graph_snapshot(session_id, persona_id, limit_memories, limit_entries, limit_nodes, limit_edges)`（`storage/graph_store_snapshot.py:320`，async）与快照键 `nodes/edges/entries/memories`、`memory_engine.get_statistics()`。graph_store 直读适配器无需改动。
- LivingMemory 独立 WebUI 配置（`config_manager.webui_settings`）已被 AstrBot 官方插件页面机制取代（schema 中已无 webui 配置，页面为 `pages/dashboard/index.html`，经 `/plugins/{plugin_id}/pages/{page_name}` 提供）。现有代码读不到该属性时本就优雅降级为「本地图谱」模式，故不改动；且 AstrBot 插件页面需 JWT 鉴权（Authorization 头），iframe 内无法携带凭据，不宜直接嵌入。
- **AstrBot 4.27.4 验证**：插件在 AstrBot venv（Python 3.12.13）下整包编译零错误、`astrbot_plugin_self_learning.main` 及本次改动模块可导入；`@filter.after_message_sent / on_llm_request / permission_type / platform_adapter_type / command` 均存在于 `astrbot/api/event/filter/__init__.py`；已同步安装至 `AstrBot/data/plugins/astrbot_plugin_self_learning`（3.6.3）。

## 测试

- 新增 6 个单元测试：frame 头判定规则、探测缓存（60s 内仅一次请求）、不可达返回 None、被阻止面板的 dashboard/嵌入目标降级行为、嵌入壳「禁止内嵌」与「允许嵌入」两种渲染。
- 本地全套 `745 → 751 passed`，冒烟测试 `tests/integration/test_package_imports.py test_webui_static_assets.py` 19 passed，ruff 全部通过。

## 版本

- 元数据、运行时包、Dashboard、文档版本统一提升至 `3.6.3`，CHANGELOG 增补 3.6.3 条目。

## Summary by Sourcery

Adapt companion dashboard integration for modern panel security policies and release version 3.6.3.

New Features:
- Detect companion panel response headers and clearly handle dashboards that cannot be embedded in an iframe by offering a new-window fallback.

Bug Fixes:
- Prevent Group Chat Plus panels blocked by X-Frame-Options or CSP frame-ancestors policies from appearing as blank embedded panels.
- Avoid blocking the Quart event loop during panel compatibility checks and consolidate concurrent probes for the same target.

Enhancements:
- Improve frame-ancestor validation against the Dashboard origin and expose embedding status and explanatory messages through integration APIs.
- Revalidate LivingMemory 2.6.0-beta.3 compatibility without requiring adapter changes.

Build:
- Normalize Dashboard HTML line endings and enforce LF output across platforms with repository attributes.

Documentation:
- Document iframe-blocked companion panels and the automatic external-panel fallback.

Tests:
- Add coverage for frame-header policies, probe caching and concurrency, unreachable panels, fallback metadata, and embedded-shell rendering.

Chores:
- Bump plugin, runtime package, Dashboard, and documentation versions to 3.6.3 and update the changelog.